### PR TITLE
replace slashbox with new diagbox

### DIFF
--- a/latex/data/chap01.tex
+++ b/latex/data/chap01.tex
@@ -114,7 +114,7 @@
   \begin{minipage}[t]{0.8\textwidth} 
     \begin{tabularx}{\linewidth}{|l|X|X|X|X|}
       \hline
- \multirow{2}*{\backslashbox{x}{y}}  & \multicolumn{2}{c|}{First Half} & \multicolumn{2}{c|}{Second Half}\\\cline{2-5}
+ \multirow{2}*{\diagbox[width=5em]{x}{y}}  & \multicolumn{2}{c|}{First Half} & \multicolumn{2}{c|}{Second Half}\\\cline{2-5}
       & 1st Qtr &2nd Qtr&3rd Qtr&4th Qtr \\ \hline
       East$^{*}$ &   20.4&   27.4&   90&     20.4 \\
       West$^{**}$ &   30.6 &   38.6 &   34.6 &  31.6 \\ \hline
@@ -126,7 +126,7 @@
 \end{table}
 
 此外，表~\ref{tab:tabexamp1} 同时还演示了另外两个功能：1）通过 \textsf{tabularx} 的
- \texttt{|X|} 扩展实现表格自动放大；2）通过命令 \verb|\backslashbox| 在表头部分
+ \texttt{|X|} 扩展实现表格自动放大；2）通过命令 \verb|\diagbox| 在表头部分
 插入反斜线。
 
 为了使我们的例子更接近实际情况，我会在必要的时候插入一些“无关”文字，以免太多图

--- a/latex/thutils.sty
+++ b/latex/thutils.sty
@@ -17,7 +17,7 @@
 \RequirePackage{tabularx}
 
 % 表格中的反斜线
-\RequirePackage{slashbox}
+\RequirePackage{diagbox}
 
 % 确定浮动对象的位置，可以使用~H，强制将浮动对象放到这里（可能效果很差）
 \RequirePackage{float}


### PR DESCRIPTION
slashbox has been removed from TeX Live in lack of free license.
diagbox by leoliu is a good replacement.

see also: http://www.newsmth.net/nForum/article/TeX/310232
