### PR TITLE
Zhfonts refine

### DIFF
--- a/latex/zhfonts.py
+++ b/latex/zhfonts.py
@@ -7,6 +7,9 @@
 # The script prefers the font name in ASCII to the one containing Unicode
 # character, thus trying to avoid the problem with 'Adobe 宋体 Std L'.
 
+# The script should work with Python 2.6, 2.7 and Python 3.2, providing
+# that your locale is utf-8. Please report issues if you find.
+
 try:
     from subprocess import check_output
 except ImportError: # python 2.6 has no check_output
@@ -14,14 +17,29 @@ except ImportError: # python 2.6 has no check_output
     def check_output(cmdline):
         return Popen(cmdline, stdout=PIPE).communicate()[0]
 
-from string import split
+# Py3K renames raw_input to input.
+try:
+    input = raw_input
+except:
+    pass
+
 import re
 
+# The return value is of type byte string (in py3k).
 fontliststr = check_output(["fc-list", ":lang=zh"])
 allfontliststr = check_output(["fc-list", ""])
 if not fontliststr:
     print("No Chinese font exists! Leaving...")
     exit(1)
+
+# strip out ':style=BLABLA' stuff
+fontnamelist = sorted([x.split(b":")[0] for x in fontliststr.splitlines()])
+allfontnamelist = sorted([x.split(b":")[0] for x in allfontliststr.splitlines()])
+
+# Convert to unicode string, assuming utf-8 encoding of byte string.
+# Thus following variables are all unicode string.
+fontnamelist = [x.decode("utf-8") for x in fontnamelist]
+allfontnamelist = [x.decode("utf-8") for x in allfontnamelist]
 
 songtilist = []
 kaitilist = []
@@ -29,10 +47,6 @@ heitilist = []
 fangsonglist = []
 lishulist = []
 youyuanlist = []
-
-# strip out ':style=BLABLA' stuff
-fontnamelist = sorted(set([x.split(":")[0] for x in fontliststr.split("\n")[:-1]]))
-allfontnamelist = sorted(set([x.split(":")[0] for x in allfontliststr.split("\n")[:-1]]))
 
 for x in fontnamelist:
     if re.search("仿宋|Fang", x, re.IGNORECASE):
@@ -61,9 +75,10 @@ def selectfont(fontlist):
             return selectfont(fontnamelist)
     
     for i, v in enumerate(fontlist):
-        print i, v
+        # Ugly, since python 2 has no real print function.
+        print(str(i) + ' ' + v)
     while True:
-        n_str = raw_input("选择一个：(输入数字[0-" + str(len(fontlist)-1) + "]，默认0。按z在所有中文字体中选择，按a在所有字体中选择)")
+        n_str = input("选择一个：(输入数字[0-" + str(len(fontlist)-1) + "]，默认0。按z在所有中文字体中选择，按a在所有字体中选择)")
         if not n_str:
             n = 0
         else:
@@ -81,8 +96,8 @@ def selectfont(fontlist):
     asciifontname = ''
     for x in fontlist[n].split(","):
         try:
-            x.decode('ascii')
-        except UnicodeDecodeError:
+            x.encode('ascii')
+        except UnicodeEncodeError:
             pass
         else:
             asciifontname = x
@@ -90,8 +105,8 @@ def selectfont(fontlist):
     if asciifontname:
         return asciifontname
     else:
-        print "ASCII font name not found!"
-        print "You might encounter error using this font with XeLaTeX..."
+        print("ASCII font name not found!")
+        print("You might encounter error using this font with XeLaTeX...")
         return fontlist[n].split(",")[-1]
 
 print("宋体：")
@@ -108,10 +123,10 @@ print("幼圆：")
 youyuan = selectfont(youyuanlist)
 
 if not songti or not heiti or not kaiti:
-    print "错误：缺少宋体、黑体或楷体字体"
+    print("错误：缺少宋体、黑体或楷体字体")
     exit(2)
 
-print "生成字体文件fontname.def"
+print("生成字体文件fontname.def")
 with open('fontname.def', 'w') as f:
     f.write("\\ProvidesFile{fontname.def}\n")
     f.write("\\newcommand{\\fontsong}{" + songti + "}\n")
@@ -120,16 +135,16 @@ with open('fontname.def', 'w') as f:
     if fangsong:
         f.write("\\newcommand{\\fontfs}{" + fangsong + "}\n")
     else:
-        print "缺少仿宋，宋体代替"
+        print("缺少仿宋，宋体代替")
         f.write("\\newcommand{\\fontfs}{" + songti + "}\n")
     if lishu:
         f.write("\\newcommand{\\fontli}{" + lishu + "}\n")
     else:
-        print "缺少隶书，宋体代替"
+        print("缺少隶书，宋体代替")
         f.write("\\newcommand{\\fontli}{" + songti + "}\n")
     if youyuan:
         f.write("\\newcommand{\\fontyou}{" + youyuan + "}\n")
     else:
-        print "缺少幼圆，宋体代替"
+        print("缺少幼圆，宋体代替")
         f.write("\\newcommand{\\fontyou}{" + songti + "}\n")
 


### PR DESCRIPTION
zhfonts.py 应该兼容 python 3 了。

我在一个 Arch 上做了一定测试。不过它是个服务器，字体并不多~~
希望有更多的人帮忙测试，找出可能的bug。

另外 python 2.6/2.7 的兼容性也做了测试，应该没问题。
