### PR TITLE
add space between "professional" and "degree"

### DIFF
--- a/latex/thuthesis.dtx
+++ b/latex/thuthesis.dtx
@@ -2683,7 +2683,7 @@
         Submitted to\\
         {\bfseries Tsinghua University}\\
         in partial fulfillment of the requirement\\
-        for the \ifthu@professional professional\fi
+        for the \ifthu@professional professional \fi
         degree of\\
         {\bfseries\sffamily\thu@edegree}
         \ifthu@professional\relax\else


### PR DESCRIPTION
用XeLaTeX排版的时候，硕士论文的英文封面出现"for the professionaldegree of"，应该改为"for the professional degree of"。
