### PR TITLE
修改英文关键词为 Key Words

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -2898,7 +2898,7 @@
 %    \begin{macrocode}
   \ifthu@doctor\vfill\else\vskip12bp\fi
   \thu@put@keywords{%
-    \textbf{\ifthu@bachelor Keywords:\else Key words:\fi\enskip}}{\thu@ekeywords}}
+    \textbf{\ifthu@bachelor Keywords:\else Key Words:\fi\enskip}}{\thu@ekeywords}}
 %</cls>
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
《研究生学位论文写作指南》2011版第6页给出的说明为：“Key Words”与中文摘要部分的
关键词对应，每个关键词之间用分号间隔。