### PR TITLE
接管 ctex 的 fontset

### DIFF
--- a/testfiles/01-cover/bachelor-english.tlg
+++ b/testfiles/01-cover/bachelor-english.tlg
@@ -150,17 +150,17 @@ Completed box being shipped out [1]
 ...\hbox(27.89621+5.9984)x417.11752, glue set 54.98506fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/b/n/36.135 综
+....\TU/FandolHei(0)/b/n/36.135 综
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 合
+....\TU/FandolHei(0)/b/n/36.135 合
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 论
+....\TU/FandolHei(0)/b/n/36.135 论
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 文
+....\TU/FandolHei(0)/b/n/36.135 文
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 训
+....\TU/FandolHei(0)/b/n/36.135 训
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 练
+....\TU/FandolHei(0)/b/n/36.135 练
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -176,11 +176,11 @@ Completed box being shipped out [1]
 .....\hbox(20.22556+4.61925)x417.11752, glue set 0.3108
 ......\hbox(0.0+0.0)x36.13498
 ......\hbox(12.88213+2.90884)x54.20247
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 题
+.......\TU/FandolHei(0)/m/n/18.06749 题
 .......\glue 0.0 plus 0.93489
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 目
+.......\TU/FandolHei(0)/m/n/18.06749 目
 .......\penalty 10000
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 ：
+.......\TU/FandolHei(0)/m/n/18.06749 ：
 .......\rule(0.0+0.0)x-12.79178
 .......\kern 0.00078
 .......\kern -0.00078
@@ -202,7 +202,7 @@ Completed box being shipped out [1]
 ......\hbox(20.22556+4.43655)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 中
+.......\TU/FandolHei(0)/m/n/26.09749 中
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -225,7 +225,7 @@ Completed box being shipped out [1]
 ......\hbox(18.81628+4.41046)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 国
+.......\TU/FandolHei(0)/m/n/26.09749 国
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ......\hbox(20.04288+4.17558)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 计
+.......\TU/FandolHei(0)/m/n/26.09749 计
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -271,7 +271,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.61925)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 算
+.......\TU/FandolHei(0)/m/n/26.09749 算
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -294,7 +294,7 @@ Completed box being shipped out [1]
 ......\hbox(19.52092+4.0712)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 机
+.......\TU/FandolHei(0)/m/n/26.09749 机
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -317,7 +317,7 @@ Completed box being shipped out [1]
 ......\hbox(19.96458+4.27997)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 科
+.......\TU/FandolHei(0)/m/n/26.09749 科
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -340,7 +340,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.61925)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 学
+.......\TU/FandolHei(0)/m/n/26.09749 学
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -363,7 +363,7 @@ Completed box being shipped out [1]
 ......\hbox(18.6336+3.9407)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 研
+.......\TU/FandolHei(0)/m/n/26.09749 研
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -386,7 +386,7 @@ Completed box being shipped out [1]
 ......\hbox(19.7036+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 究
+.......\TU/FandolHei(0)/m/n/26.09749 究
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -409,7 +409,7 @@ Completed box being shipped out [1]
 ......\hbox(19.93848+3.26218)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 生
+.......\TU/FandolHei(0)/m/n/26.09749 生
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -432,7 +432,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.61925)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 学
+.......\TU/FandolHei(0)/m/n/26.09749 学
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -455,7 +455,7 @@ Completed box being shipped out [1]
 ......\hbox(19.86018+4.48875)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 术
+.......\TU/FandolHei(0)/m/n/26.09749 术
 ......\glue(\rightskip) 0.0
 .....\penalty 300
 .....\glue(\baselineskip) 15.63232
@@ -474,7 +474,7 @@ Completed box being shipped out [1]
 ......\hbox(20.40823+3.78412)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 论
+.......\TU/FandolHei(0)/m/n/26.09749 论
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -497,7 +497,7 @@ Completed box being shipped out [1]
 ......\hbox(19.49483+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 文
+.......\TU/FandolHei(0)/m/n/26.09749 文
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -520,7 +520,7 @@ Completed box being shipped out [1]
 ......\hbox(18.81628+4.27997)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 写
+.......\TU/FandolHei(0)/m/n/26.09749 写
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -543,7 +543,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+3.8885)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 作
+.......\TU/FandolHei(0)/m/n/26.09749 作
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -566,7 +566,7 @@ Completed box being shipped out [1]
 ......\hbox(20.22556+4.43655)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 中
+.......\TU/FandolHei(0)/m/n/26.09749 中
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -589,7 +589,7 @@ Completed box being shipped out [1]
 ......\hbox(19.54703+4.41046)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 引
+.......\TU/FandolHei(0)/m/n/26.09749 引
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -612,7 +612,7 @@ Completed box being shipped out [1]
 ......\hbox(19.07727+4.25388)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 用
+.......\TU/FandolHei(0)/m/n/26.09749 用
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -635,7 +635,7 @@ Completed box being shipped out [1]
 ......\hbox(20.04288+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 行
+.......\TU/FandolHei(0)/m/n/26.09749 行
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -658,7 +658,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.09729)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 为
+.......\TU/FandolHei(0)/m/n/26.09749 为
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -681,7 +681,7 @@ Completed box being shipped out [1]
 ......\hbox(20.46043+4.22778)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 的
+.......\TU/FandolHei(0)/m/n/26.09749 的
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -704,7 +704,7 @@ Completed box being shipped out [1]
 ......\hbox(18.6336+3.9407)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 研
+.......\TU/FandolHei(0)/m/n/26.09749 研
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -727,7 +727,7 @@ Completed box being shipped out [1]
 ......\hbox(19.7036+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 究
+.......\TU/FandolHei(0)/m/n/26.09749 究
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -744,30 +744,30 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.41438+2.50534)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 系
+.....\TU/FandolFang(0)/m/n/16.06 系
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 别
+.....\TU/FandolFang(0)/m/n/16.06 别
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\glue 11.19382 minus 8.03
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 外
+....\TU/FandolFang(0)/m/n/16.06 外
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 国
+....\TU/FandolFang(0)/m/n/16.06 国
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 语
+....\TU/FandolFang(0)/m/n/16.06 语
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 言
+....\TU/FandolFang(0)/m/n/16.06 言
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 文
+....\TU/FandolFang(0)/m/n/16.06 文
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 学
+....\TU/FandolFang(0)/m/n/16.06 学
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 系
+....\TU/FandolFang(0)/m/n/16.06 系
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -780,28 +780,28 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.79982+2.64989)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 专
+.....\TU/FandolFang(0)/m/n/16.06 专
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 业
+.....\TU/FandolFang(0)/m/n/16.06 业
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\glue 11.19382 minus 8.03
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 英
+....\TU/FandolFang(0)/m/n/16.06 英
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 语
+....\TU/FandolFang(0)/m/n/16.06 语
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 语
+....\TU/FandolFang(0)/m/n/16.06 语
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 言
+....\TU/FandolFang(0)/m/n/16.06 言
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 文
+....\TU/FandolFang(0)/m/n/16.06 文
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 学
+....\TU/FandolFang(0)/m/n/16.06 学
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -814,14 +814,14 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.75163+2.40898)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 姓
+.....\TU/FandolFang(0)/m/n/16.06 姓
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 名
+.....\TU/FandolFang(0)/m/n/16.06 名
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\kern 0.00069
 ....\kern -0.00069
@@ -830,11 +830,11 @@ Completed box being shipped out [1]
 ....\glue 11.19382 minus 8.03
 ....\hbox(12.75163+2.89078)x48.18
 .....\special{color push gray 0}
-.....\TU/FandolFang-Regular(0)/m/n/16.06 姚
+.....\TU/FandolFang(0)/m/n/16.06 姚
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 沛
+.....\TU/FandolFang(0)/m/n/16.06 沛
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 然
+.....\TU/FandolFang(0)/m/n/16.06 然
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{color pop}
@@ -848,18 +848,18 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.81587+3.05139)x64.23999
-.....\TU/FandolFang-Regular(0)/m/n/16.06 指
+.....\TU/FandolFang(0)/m/n/16.06 指
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 导
+.....\TU/FandolFang(0)/m/n/16.06 导
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 教
+.....\TU/FandolFang(0)/m/n/16.06 教
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 师
+.....\TU/FandolFang(0)/m/n/16.06 师
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\kern 0.00069
 ....\kern -0.00069
@@ -867,18 +867,18 @@ Completed box being shipped out [1]
 ....\kern 0.99649
 ....\glue 11.19382 minus 8.03
 ....\hbox(12.67134+2.9229)x48.18, glue set 8.03filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 颜
+.....\TU/FandolFang(0)/m/n/16.06 颜
 .....\glue 0.0 plus 2.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 奕
+.....\TU/FandolFang(0)/m/n/16.06 奕
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 16.06
-....\TU/FandolFang-Regular(0)/m/n/16.06 副
+....\TU/FandolFang(0)/m/n/16.06 副
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 教
+....\TU/FandolFang(0)/m/n/16.06 教
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 授
+....\TU/FandolFang(0)/m/n/16.06 授
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -891,19 +891,19 @@ Completed box being shipped out [1]
 ...\hbox(9.29874+2.04764)x417.11752, glue set 162.3963fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 2019
+....\TU/FandolSong(0)/m/n/12.045 2019
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 7
+....\TU/FandolSong(0)/m/n/12.045 7
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 1
+....\TU/FandolSong(0)/m/n/12.045 1
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000

--- a/testfiles/01-cover/bachelor-secret.tlg
+++ b/testfiles/01-cover/bachelor-secret.tlg
@@ -115,18 +115,18 @@ Completed box being shipped out [1]
 .....\hbox(9.3951+2.09581)x417.11752, glue set 344.84753fill
 ......\hbox(0.0+0.0)x0.0
 ......\glue 0.0 plus 1.0fill
-......\TU/FandolHei-Regular(0)/m/n/12.045 秘
+......\TU/FandolHei(0)/m/n/12.045 秘
 ......\glue 0.0 plus 0.61353
-......\TU/FandolHei-Regular(0)/m/n/12.045 密
+......\TU/FandolHei(0)/m/n/12.045 密
 ......\kern -0.00017
 ......\kern 0.00017
 ......\hbox(8.1665+0.26497)x36.135, glue set 12.045fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-.......\TU/FandolHei-Regular(0)/m/n/12.045 10
+.......\TU/FandolHei(0)/m/n/12.045 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-......\TU/FandolHei-Regular(0)/m/n/12.045 年
+......\TU/FandolHei(0)/m/n/12.045 年
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -163,17 +163,17 @@ Completed box being shipped out [1]
 ...\hbox(27.89621+5.9984)x417.11752, glue set 54.98506fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/b/n/36.135 综
+....\TU/FandolHei(0)/b/n/36.135 综
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 合
+....\TU/FandolHei(0)/b/n/36.135 合
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 论
+....\TU/FandolHei(0)/b/n/36.135 论
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 文
+....\TU/FandolHei(0)/b/n/36.135 文
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 训
+....\TU/FandolHei(0)/b/n/36.135 训
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 练
+....\TU/FandolHei(0)/b/n/36.135 练
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -189,11 +189,11 @@ Completed box being shipped out [1]
 .....\hbox(20.38214+4.61925)x417.11752, glue set 0.3108
 ......\hbox(0.0+0.0)x36.13498
 ......\hbox(12.88213+2.90884)x54.20247
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 题
+.......\TU/FandolHei(0)/m/n/18.06749 题
 .......\glue 0.0 plus 0.93489
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 目
+.......\TU/FandolHei(0)/m/n/18.06749 目
 .......\penalty 10000
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 ：
+.......\TU/FandolHei(0)/m/n/18.06749 ：
 .......\rule(0.0+0.0)x-12.79178
 .......\kern 0.00078
 .......\kern -0.00078
@@ -215,7 +215,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.51485)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 气
+.......\TU/FandolHei(0)/m/n/26.09749 气
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -238,7 +238,7 @@ Completed box being shipped out [1]
 ......\hbox(20.25165+4.43655)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 候
+.......\TU/FandolHei(0)/m/n/26.09749 候
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -261,7 +261,7 @@ Completed box being shipped out [1]
 ......\hbox(19.31215+4.17558)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 变
+.......\TU/FandolHei(0)/m/n/26.09749 变
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -284,7 +284,7 @@ Completed box being shipped out [1]
 ......\hbox(19.6775+4.41046)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 化
+.......\TU/FandolHei(0)/m/n/26.09749 化
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -307,7 +307,7 @@ Completed box being shipped out [1]
 ......\hbox(19.65141+4.33217)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 对
+.......\TU/FandolHei(0)/m/n/26.09749 对
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -330,7 +330,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.61925)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 冬
+.......\TU/FandolHei(0)/m/n/26.09749 冬
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -353,7 +353,7 @@ Completed box being shipped out [1]
 ......\hbox(19.57312+3.9668)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 小
+.......\TU/FandolHei(0)/m/n/26.09749 小
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -376,7 +376,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.48875)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 麦
+.......\TU/FandolHei(0)/m/n/26.09749 麦
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -399,7 +399,7 @@ Completed box being shipped out [1]
 ......\hbox(20.38214+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 产
+.......\TU/FandolHei(0)/m/n/26.09749 产
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -422,7 +422,7 @@ Completed box being shipped out [1]
 ......\hbox(18.6858+3.54924)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 量
+.......\TU/FandolHei(0)/m/n/26.09749 量
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -445,7 +445,7 @@ Completed box being shipped out [1]
 ......\hbox(19.25995+4.48875)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 影
+.......\TU/FandolHei(0)/m/n/26.09749 影
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -468,7 +468,7 @@ Completed box being shipped out [1]
 ......\hbox(20.17336+4.12338)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 响
+.......\TU/FandolHei(0)/m/n/26.09749 响
 ......\glue(\rightskip) 0.0
 .....\penalty 300
 .....\glue(\baselineskip) 15.63232
@@ -487,7 +487,7 @@ Completed box being shipped out [1]
 ......\hbox(20.46043+4.22778)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 的
+.......\TU/FandolHei(0)/m/n/26.09749 的
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -510,7 +510,7 @@ Completed box being shipped out [1]
 ......\hbox(20.01677+4.38437)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 数
+.......\TU/FandolHei(0)/m/n/26.09749 数
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -533,7 +533,7 @@ Completed box being shipped out [1]
 ......\hbox(20.30385+4.51485)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 值
+.......\TU/FandolHei(0)/m/n/26.09749 值
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -556,7 +556,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.35826)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 模
+.......\TU/FandolHei(0)/m/n/26.09749 模
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -579,7 +579,7 @@ Completed box being shipped out [1]
 ......\hbox(19.33824+4.35826)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 拟
+.......\TU/FandolHei(0)/m/n/26.09749 拟
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -602,7 +602,7 @@ Completed box being shipped out [1]
 ......\hbox(18.6336+3.9407)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 研
+.......\TU/FandolHei(0)/m/n/26.09749 研
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -625,7 +625,7 @@ Completed box being shipped out [1]
 ......\hbox(19.7036+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 究
+.......\TU/FandolHei(0)/m/n/26.09749 究
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -642,30 +642,30 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.41438+2.50534)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 系
+.....\TU/FandolFang(0)/m/n/16.06 系
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 别
+.....\TU/FandolFang(0)/m/n/16.06 别
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\glue 11.19382 minus 8.03
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 利
+....\TU/FandolFang(0)/m/n/16.06 利
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 电
+....\TU/FandolFang(0)/m/n/16.06 电
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 工
+....\TU/FandolFang(0)/m/n/16.06 工
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 程
+....\TU/FandolFang(0)/m/n/16.06 程
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 系
+....\TU/FandolFang(0)/m/n/16.06 系
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -678,28 +678,28 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.79982+2.64989)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 专
+.....\TU/FandolFang(0)/m/n/16.06 专
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 业
+.....\TU/FandolFang(0)/m/n/16.06 业
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\glue 11.19382 minus 8.03
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 利
+....\TU/FandolFang(0)/m/n/16.06 利
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 电
+....\TU/FandolFang(0)/m/n/16.06 电
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 工
+....\TU/FandolFang(0)/m/n/16.06 工
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 程
+....\TU/FandolFang(0)/m/n/16.06 程
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -712,14 +712,14 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.75163+2.40898)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 姓
+.....\TU/FandolFang(0)/m/n/16.06 姓
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 名
+.....\TU/FandolFang(0)/m/n/16.06 名
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\kern 0.00069
 ....\kern -0.00069
@@ -728,11 +728,11 @@ Completed box being shipped out [1]
 ....\glue 11.19382 minus 8.03
 ....\hbox(12.67134+2.82654)x48.18
 .....\special{color push gray 0}
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{color pop}
@@ -746,18 +746,18 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.81587+3.05139)x64.23999
-.....\TU/FandolFang-Regular(0)/m/n/16.06 指
+.....\TU/FandolFang(0)/m/n/16.06 指
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 导
+.....\TU/FandolFang(0)/m/n/16.06 导
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 教
+.....\TU/FandolFang(0)/m/n/16.06 教
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 师
+.....\TU/FandolFang(0)/m/n/16.06 师
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\kern 0.00069
 ....\kern -0.00069
@@ -766,18 +766,18 @@ Completed box being shipped out [1]
 ....\glue 11.19382 minus 8.03
 ....\hbox(12.67134+2.82654)x48.18
 .....\special{color push gray 0}
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{color pop}
 ....\glue 16.06
-....\TU/FandolFang-Regular(0)/m/n/16.06 教
+....\TU/FandolFang(0)/m/n/16.06 教
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 授
+....\TU/FandolFang(0)/m/n/16.06 授
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -790,19 +790,19 @@ Completed box being shipped out [1]
 ...\hbox(9.29874+2.04764)x417.11752, glue set 162.3963fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 2019
+....\TU/FandolSong(0)/m/n/12.045 2019
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 7
+....\TU/FandolSong(0)/m/n/12.045 7
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 1
+....\TU/FandolSong(0)/m/n/12.045 1
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000

--- a/testfiles/01-cover/bachelor.tlg
+++ b/testfiles/01-cover/bachelor.tlg
@@ -150,17 +150,17 @@ Completed box being shipped out [1]
 ...\hbox(27.89621+5.9984)x417.11752, glue set 54.98506fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/b/n/36.135 综
+....\TU/FandolHei(0)/b/n/36.135 综
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 合
+....\TU/FandolHei(0)/b/n/36.135 合
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 论
+....\TU/FandolHei(0)/b/n/36.135 论
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 文
+....\TU/FandolHei(0)/b/n/36.135 文
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 训
+....\TU/FandolHei(0)/b/n/36.135 训
 ....\glue 18.06749 plus 0.22359 minus 6.57967
-....\TU/FandolHei-Regular(0)/b/n/36.135 练
+....\TU/FandolHei(0)/b/n/36.135 练
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -176,11 +176,11 @@ Completed box being shipped out [1]
 .....\hbox(20.38214+4.61925)x417.11752, glue set 0.3108
 ......\hbox(0.0+0.0)x36.13498
 ......\hbox(12.88213+2.90884)x54.20247
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 题
+.......\TU/FandolHei(0)/m/n/18.06749 题
 .......\glue 0.0 plus 0.93489
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 目
+.......\TU/FandolHei(0)/m/n/18.06749 目
 .......\penalty 10000
-.......\TU/FandolHei-Regular(0)/m/n/18.06749 ：
+.......\TU/FandolHei(0)/m/n/18.06749 ：
 .......\rule(0.0+0.0)x-12.79178
 .......\kern 0.00078
 .......\kern -0.00078
@@ -202,7 +202,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.51485)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 气
+.......\TU/FandolHei(0)/m/n/26.09749 气
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -225,7 +225,7 @@ Completed box being shipped out [1]
 ......\hbox(20.25165+4.43655)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 候
+.......\TU/FandolHei(0)/m/n/26.09749 候
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ......\hbox(19.31215+4.17558)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 变
+.......\TU/FandolHei(0)/m/n/26.09749 变
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -271,7 +271,7 @@ Completed box being shipped out [1]
 ......\hbox(19.6775+4.41046)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 化
+.......\TU/FandolHei(0)/m/n/26.09749 化
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -294,7 +294,7 @@ Completed box being shipped out [1]
 ......\hbox(19.65141+4.33217)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 对
+.......\TU/FandolHei(0)/m/n/26.09749 对
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -317,7 +317,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.61925)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 冬
+.......\TU/FandolHei(0)/m/n/26.09749 冬
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -340,7 +340,7 @@ Completed box being shipped out [1]
 ......\hbox(19.57312+3.9668)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 小
+.......\TU/FandolHei(0)/m/n/26.09749 小
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -363,7 +363,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.48875)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 麦
+.......\TU/FandolHei(0)/m/n/26.09749 麦
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -386,7 +386,7 @@ Completed box being shipped out [1]
 ......\hbox(20.38214+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 产
+.......\TU/FandolHei(0)/m/n/26.09749 产
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -409,7 +409,7 @@ Completed box being shipped out [1]
 ......\hbox(18.6858+3.54924)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 量
+.......\TU/FandolHei(0)/m/n/26.09749 量
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -432,7 +432,7 @@ Completed box being shipped out [1]
 ......\hbox(19.25995+4.48875)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 影
+.......\TU/FandolHei(0)/m/n/26.09749 影
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -455,7 +455,7 @@ Completed box being shipped out [1]
 ......\hbox(20.17336+4.12338)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 响
+.......\TU/FandolHei(0)/m/n/26.09749 响
 ......\glue(\rightskip) 0.0
 .....\penalty 300
 .....\glue(\baselineskip) 15.63232
@@ -474,7 +474,7 @@ Completed box being shipped out [1]
 ......\hbox(20.46043+4.22778)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 的
+.......\TU/FandolHei(0)/m/n/26.09749 的
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -497,7 +497,7 @@ Completed box being shipped out [1]
 ......\hbox(20.01677+4.38437)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 数
+.......\TU/FandolHei(0)/m/n/26.09749 数
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -520,7 +520,7 @@ Completed box being shipped out [1]
 ......\hbox(20.30385+4.51485)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 值
+.......\TU/FandolHei(0)/m/n/26.09749 值
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -543,7 +543,7 @@ Completed box being shipped out [1]
 ......\hbox(20.12117+4.35826)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 模
+.......\TU/FandolHei(0)/m/n/26.09749 模
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -566,7 +566,7 @@ Completed box being shipped out [1]
 ......\hbox(19.33824+4.35826)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 拟
+.......\TU/FandolHei(0)/m/n/26.09749 拟
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -589,7 +589,7 @@ Completed box being shipped out [1]
 ......\hbox(18.6336+3.9407)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 研
+.......\TU/FandolHei(0)/m/n/26.09749 研
 ......\glue -2.6097
 ......\leaders 5.21939 plus 3.98097
 .......\hbox(0.0+4.43651)x5.2194
@@ -612,7 +612,7 @@ Completed box being shipped out [1]
 ......\hbox(19.7036+4.30608)x26.09749
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolHei-Regular(0)/m/n/26.09749 究
+.......\TU/FandolHei(0)/m/n/26.09749 究
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -629,30 +629,30 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.41438+2.50534)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 系
+.....\TU/FandolFang(0)/m/n/16.06 系
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 别
+.....\TU/FandolFang(0)/m/n/16.06 别
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\glue 11.19382 minus 8.03
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 利
+....\TU/FandolFang(0)/m/n/16.06 利
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 电
+....\TU/FandolFang(0)/m/n/16.06 电
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 工
+....\TU/FandolFang(0)/m/n/16.06 工
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 程
+....\TU/FandolFang(0)/m/n/16.06 程
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 系
+....\TU/FandolFang(0)/m/n/16.06 系
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -665,28 +665,28 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.79982+2.64989)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 专
+.....\TU/FandolFang(0)/m/n/16.06 专
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 业
+.....\TU/FandolFang(0)/m/n/16.06 业
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\glue 11.19382 minus 8.03
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 利
+....\TU/FandolFang(0)/m/n/16.06 利
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 水
+....\TU/FandolFang(0)/m/n/16.06 水
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 电
+....\TU/FandolFang(0)/m/n/16.06 电
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 工
+....\TU/FandolFang(0)/m/n/16.06 工
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 程
+....\TU/FandolFang(0)/m/n/16.06 程
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -699,14 +699,14 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.75163+2.40898)x64.23999, glue set 16.06filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 姓
+.....\TU/FandolFang(0)/m/n/16.06 姓
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 名
+.....\TU/FandolFang(0)/m/n/16.06 名
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\kern 0.00069
 ....\kern -0.00069
@@ -715,11 +715,11 @@ Completed box being shipped out [1]
 ....\glue 11.19382 minus 8.03
 ....\hbox(12.67134+2.82654)x48.18
 .....\special{color push gray 0}
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{color pop}
@@ -733,18 +733,18 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 71.13188
 ....\hbox(0.0+0.0)x0.0
 ....\hbox(12.81587+3.05139)x64.23999
-.....\TU/FandolFang-Regular(0)/m/n/16.06 指
+.....\TU/FandolFang(0)/m/n/16.06 指
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 导
+.....\TU/FandolFang(0)/m/n/16.06 导
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 教
+.....\TU/FandolFang(0)/m/n/16.06 教
 .....\glue 0.0 plus 2.0filll minus 1.0filll
-.....\TU/FandolFang-Regular(0)/m/n/16.06 师
+.....\TU/FandolFang(0)/m/n/16.06 师
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
-....\TU/FandolFang-Regular(0)/m/n/16.06 ：
+....\TU/FandolFang(0)/m/n/16.06 ：
 ....\rule(0.0+0.0)x-11.19382
 ....\kern 0.00069
 ....\kern -0.00069
@@ -753,18 +753,18 @@ Completed box being shipped out [1]
 ....\glue 11.19382 minus 8.03
 ....\hbox(12.67134+2.82654)x48.18
 .....\special{color push gray 0}
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\glue 0.0 plus 1.37729
-.....\TU/FandolFang-Regular(0)/m/n/16.06 某
+.....\TU/FandolFang(0)/m/n/16.06 某
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{color pop}
 ....\glue 16.06
-....\TU/FandolFang-Regular(0)/m/n/16.06 教
+....\TU/FandolFang(0)/m/n/16.06 教
 ....\glue 0.0 plus 1.37729
-....\TU/FandolFang-Regular(0)/m/n/16.06 授
+....\TU/FandolFang(0)/m/n/16.06 授
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -777,19 +777,19 @@ Completed box being shipped out [1]
 ...\hbox(9.29874+2.04764)x417.11752, glue set 162.3963fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 2019
+....\TU/FandolSong(0)/m/n/12.045 2019
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 7
+....\TU/FandolSong(0)/m/n/12.045 7
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 1
+....\TU/FandolSong(0)/m/n/12.045 1
 ....\glue 4.01099 plus 2.0055 minus 1.33699
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000

--- a/testfiles/01-cover/doctor-1-1.tlg
+++ b/testfiles/01-cover/doctor-1-1.tlg
@@ -139,31 +139,31 @@ Completed box being shipped out [1]
 ...\hbox(20.46043+4.74973)x398.3386, glue set 29.53563fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 单
+....\TU/FandolHei(0)/m/n/26.09749 单
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 位
+....\TU/FandolHei(0)/m/n/26.09749 位
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 根
+....\TU/FandolHei(0)/m/n/26.09749 根
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 和
+....\TU/FandolHei(0)/m/n/26.09749 和
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 协
+....\TU/FandolHei(0)/m/n/26.09749 协
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 整
+....\TU/FandolHei(0)/m/n/26.09749 整
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 及
+....\TU/FandolHei(0)/m/n/26.09749 及
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 其
+....\TU/FandolHei(0)/m/n/26.09749 其
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 结
+....\TU/FandolHei(0)/m/n/26.09749 结
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 构
+....\TU/FandolHei(0)/m/n/26.09749 构
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 突
+....\TU/FandolHei(0)/m/n/26.09749 突
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 变
+....\TU/FandolHei(0)/m/n/26.09749 变
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 的
+....\TU/FandolHei(0)/m/n/26.09749 的
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -175,19 +175,19 @@ Completed box being shipped out [1]
 ...\hbox(20.40823+4.77582)x398.3386, glue set 107.8281fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 理
+....\TU/FandolHei(0)/m/n/26.09749 理
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 论
+....\TU/FandolHei(0)/m/n/26.09749 论
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 与
+....\TU/FandolHei(0)/m/n/26.09749 与
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 应
+....\TU/FandolHei(0)/m/n/26.09749 应
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 用
+....\TU/FandolHei(0)/m/n/26.09749 用
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -199,35 +199,35 @@ Completed box being shipped out [1]
 ...\hbox(14.1107+4.51686)x398.3386, glue set 56.65294fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 经
+....\TU/FandolSong(0)/m/n/18.06749 经
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 济
+....\TU/FandolSong(0)/m/n/18.06749 济
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -255,13 +255,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -270,7 +270,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -279,17 +279,17 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 经
+..........\TU/FandolFang(0)/m/n/16.06 经
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 济
+..........\TU/FandolFang(0)/m/n/16.06 济
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 管
+..........\TU/FandolFang(0)/m/n/16.06 管
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 院
+..........\TU/FandolFang(0)/m/n/16.06 院
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -305,9 +305,9 @@ Completed box being shipped out [1]
 ..........\hbox(12.59103+2.82654)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.59103+2.82654)x79.6678, glue set 23.77391filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 学
+............\TU/FandolFang(0)/m/n/16.06 学
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 科
+............\TU/FandolFang(0)/m/n/16.06 科
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -316,7 +316,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -325,15 +325,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 应
+..........\TU/FandolFang(0)/m/n/16.06 应
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 用
+..........\TU/FandolFang(0)/m/n/16.06 用
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 经
+..........\TU/FandolFang(0)/m/n/16.06 经
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 济
+..........\TU/FandolFang(0)/m/n/16.06 济
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -349,11 +349,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.9229)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.9229)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 研
+............\TU/FandolFang(0)/m/n/16.06 研
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 究
+............\TU/FandolFang(0)/m/n/16.06 究
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 生
+............\TU/FandolFang(0)/m/n/16.06 生
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -362,7 +362,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -375,11 +375,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.89618+2.6017)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.89618+2.6017)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 王
+.............\TU/FandolFang(0)/m/n/16.06 王
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 少
+.............\TU/FandolFang(0)/m/n/16.06 少
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 平
+.............\TU/FandolFang(0)/m/n/16.06 平
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -400,13 +400,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -415,7 +415,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -428,20 +428,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.88011+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.88011+2.9229)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 子
+.............\TU/FandolFang(0)/m/n/16.06 子
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 奈
+.............\TU/FandolFang(0)/m/n/16.06 奈
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -465,19 +465,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/doctor-1-2.tlg
+++ b/testfiles/01-cover/doctor-1-2.tlg
@@ -141,53 +141,53 @@ Completed box being shipped out [1]
 ....\hbox(0.0+0.0)x0.0
 ....\TU/texgyreheros(0)/m/n/26.09749 N-
 ....\discretionary
-....\TU/FandolHei-Regular(0)/m/n/26.09749 磷
+....\TU/FandolHei(0)/m/n/26.09749 磷
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 酰
+....\TU/FandolHei(0)/m/n/26.09749 酰
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 化
+....\TU/FandolHei(0)/m/n/26.09749 化
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 氨
+....\TU/FandolHei(0)/m/n/26.09749 氨
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 基
+....\TU/FandolHei(0)/m/n/26.09749 基
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 酸
+....\TU/FandolHei(0)/m/n/26.09749 酸
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 成
+....\TU/FandolHei(0)/m/n/26.09749 成
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 态
+....\TU/FandolHei(0)/m/n/26.09749 态
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 及
+....\TU/FandolHei(0)/m/n/26.09749 及
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 多
+....\TU/FandolHei(0)/m/n/26.09749 多
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 肽
+....\TU/FandolHei(0)/m/n/26.09749 肽
 ....\glue 7.2551 plus 3.62392 minus 2.42078
 ....\TU/texgyreheros(0)/m/n/26.09749 C
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 7.2551 plus 3.62392 minus 2.42078
-....\TU/FandolHei-Regular(0)/m/n/26.09749 端
+....\TU/FandolHei(0)/m/n/26.09749 端
 ....\glue(\rightskip) 0.0 plus 1.0fil
 ...\penalty 300
 ...\glue(\baselineskip) 21.92198
 ...\hbox(20.46043+4.67143)x398.3386, glue set 94.77934fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/26.09749 保
+....\TU/FandolHei(0)/m/n/26.09749 保
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 护
+....\TU/FandolHei(0)/m/n/26.09749 护
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 基
+....\TU/FandolHei(0)/m/n/26.09749 基
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 的
+....\TU/FandolHei(0)/m/n/26.09749 的
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 酶
+....\TU/FandolHei(0)/m/n/26.09749 酶
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 促
+....\TU/FandolHei(0)/m/n/26.09749 促
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 脱
+....\TU/FandolHei(0)/m/n/26.09749 脱
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 除
+....\TU/FandolHei(0)/m/n/26.09749 除
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -199,33 +199,33 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 65.68668fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 理
+....\TU/FandolSong(0)/m/n/18.06749 理
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -253,13 +253,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -268,7 +268,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -277,11 +277,11 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 化
+..........\TU/FandolFang(0)/m/n/16.06 化
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 系
+..........\TU/FandolFang(0)/m/n/16.06 系
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -297,9 +297,9 @@ Completed box being shipped out [1]
 ..........\hbox(12.59103+2.82654)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.59103+2.82654)x79.6678, glue set 23.77391filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 学
+............\TU/FandolFang(0)/m/n/16.06 学
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 科
+............\TU/FandolFang(0)/m/n/16.06 科
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -308,7 +308,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -317,9 +317,9 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 化
+..........\TU/FandolFang(0)/m/n/16.06 化
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -335,11 +335,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.9229)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.9229)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 研
+............\TU/FandolFang(0)/m/n/16.06 研
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 究
+............\TU/FandolFang(0)/m/n/16.06 究
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 生
+............\TU/FandolFang(0)/m/n/16.06 生
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -348,7 +348,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -361,11 +361,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.6874+2.69806)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.6874+2.69806)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 陈
+.............\TU/FandolFang(0)/m/n/16.06 陈
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 忠
+.............\TU/FandolFang(0)/m/n/16.06 忠
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 周
+.............\TU/FandolFang(0)/m/n/16.06 周
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -386,13 +386,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -401,7 +401,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -414,20 +414,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.65527+2.79442)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.65527+2.79442)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 赵
+.............\TU/FandolFang(0)/m/n/16.06 赵
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 玉
+.............\TU/FandolFang(0)/m/n/16.06 玉
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 芬
+.............\TU/FandolFang(0)/m/n/16.06 芬
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -444,15 +444,15 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set - 0.15805filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 副
+............\TU/FandolFang(0)/m/n/16.06 副
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -461,7 +461,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -474,20 +474,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 艳
+.............\TU/FandolFang(0)/m/n/16.06 艳
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 梅
+.............\TU/FandolFang(0)/m/n/16.06 梅
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -511,19 +511,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 五
+......\TU/FandolSong(0)/m/n/16.06 五
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/doctor-1-3.tlg
+++ b/testfiles/01-cover/doctor-1-3.tlg
@@ -139,31 +139,31 @@ Completed box being shipped out [1]
 ...\hbox(20.46043+4.69754)x398.3386, glue set 29.53563fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 碳
+....\TU/FandolHei(0)/m/n/26.09749 碳
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 纳
+....\TU/FandolHei(0)/m/n/26.09749 纳
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 米
+....\TU/FandolHei(0)/m/n/26.09749 米
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 管
+....\TU/FandolHei(0)/m/n/26.09749 管
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 若
+....\TU/FandolHei(0)/m/n/26.09749 若
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 干
+....\TU/FandolHei(0)/m/n/26.09749 干
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 力
+....\TU/FandolHei(0)/m/n/26.09749 力
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 学
+....\TU/FandolHei(0)/m/n/26.09749 学
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 问
+....\TU/FandolHei(0)/m/n/26.09749 问
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 题
+....\TU/FandolHei(0)/m/n/26.09749 题
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 的
+....\TU/FandolHei(0)/m/n/26.09749 的
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -175,33 +175,33 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 65.68668fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 工
+....\TU/FandolSong(0)/m/n/18.06749 工
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -229,13 +229,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -244,7 +244,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -253,17 +253,17 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 航
+..........\TU/FandolFang(0)/m/n/16.06 航
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 空
+..........\TU/FandolFang(0)/m/n/16.06 空
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 航
+..........\TU/FandolFang(0)/m/n/16.06 航
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 天
+..........\TU/FandolFang(0)/m/n/16.06 天
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 院
+..........\TU/FandolFang(0)/m/n/16.06 院
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -279,9 +279,9 @@ Completed box being shipped out [1]
 ..........\hbox(12.59103+2.82654)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.59103+2.82654)x79.6678, glue set 23.77391filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 学
+............\TU/FandolFang(0)/m/n/16.06 学
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 科
+............\TU/FandolFang(0)/m/n/16.06 科
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -290,7 +290,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -299,9 +299,9 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 力
+..........\TU/FandolFang(0)/m/n/16.06 力
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -317,11 +317,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.9229)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.9229)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 研
+............\TU/FandolFang(0)/m/n/16.06 研
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 究
+............\TU/FandolFang(0)/m/n/16.06 究
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 生
+............\TU/FandolFang(0)/m/n/16.06 生
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -330,7 +330,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -343,9 +343,9 @@ Completed box being shipped out [1]
 ...........\hbox(12.57498+2.81049)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.57498+2.81049)x64.23999, glue set 16.06filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 刘
+.............\TU/FandolFang(0)/m/n/16.06 刘
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 哲
+.............\TU/FandolFang(0)/m/n/16.06 哲
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -366,13 +366,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -381,7 +381,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -394,20 +394,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.91223+2.77837)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.91223+2.77837)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 郑
+.............\TU/FandolFang(0)/m/n/16.06 郑
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 泉
+.............\TU/FandolFang(0)/m/n/16.06 泉
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 水
+.............\TU/FandolFang(0)/m/n/16.06 水
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -431,19 +431,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 四
+......\TU/FandolSong(0)/m/n/16.06 四
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/doctor-1-4.tlg
+++ b/testfiles/01-cover/doctor-1-4.tlg
@@ -139,25 +139,25 @@ Completed box being shipped out [1]
 ...\hbox(20.12117+4.77582)x398.3386, glue set 68.68185fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 电
+....\TU/FandolHei(0)/m/n/26.09749 电
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 流
+....\TU/FandolHei(0)/m/n/26.09749 流
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 变
+....\TU/FandolHei(0)/m/n/26.09749 变
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 机
+....\TU/FandolHei(0)/m/n/26.09749 机
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 理
+....\TU/FandolHei(0)/m/n/26.09749 理
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 及
+....\TU/FandolHei(0)/m/n/26.09749 及
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 应
+....\TU/FandolHei(0)/m/n/26.09749 应
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 用
+....\TU/FandolHei(0)/m/n/26.09749 用
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -169,33 +169,33 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 65.68668fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 工
+....\TU/FandolSong(0)/m/n/18.06749 工
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -223,13 +223,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -238,7 +238,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -247,23 +247,23 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 精
+..........\TU/FandolFang(0)/m/n/16.06 精
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 密
+..........\TU/FandolFang(0)/m/n/16.06 密
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 仪
+..........\TU/FandolFang(0)/m/n/16.06 仪
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 器
+..........\TU/FandolFang(0)/m/n/16.06 器
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 与
+..........\TU/FandolFang(0)/m/n/16.06 与
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 机
+..........\TU/FandolFang(0)/m/n/16.06 机
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 械
+..........\TU/FandolFang(0)/m/n/16.06 械
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 系
+..........\TU/FandolFang(0)/m/n/16.06 系
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -279,9 +279,9 @@ Completed box being shipped out [1]
 ..........\hbox(12.59103+2.82654)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.59103+2.82654)x79.6678, glue set 23.77391filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 学
+............\TU/FandolFang(0)/m/n/16.06 学
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 科
+............\TU/FandolFang(0)/m/n/16.06 科
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -290,7 +290,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -299,13 +299,13 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 机
+..........\TU/FandolFang(0)/m/n/16.06 机
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 械
+..........\TU/FandolFang(0)/m/n/16.06 械
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -321,11 +321,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.9229)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.9229)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 研
+............\TU/FandolFang(0)/m/n/16.06 研
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 究
+............\TU/FandolFang(0)/m/n/16.06 究
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 生
+............\TU/FandolFang(0)/m/n/16.06 生
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -334,7 +334,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -347,9 +347,9 @@ Completed box being shipped out [1]
 ...........\hbox(12.06107+2.39293)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.06107+2.39293)x64.23999, glue set 16.06filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 田
+.............\TU/FandolFang(0)/m/n/16.06 田
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 煜
+.............\TU/FandolFang(0)/m/n/16.06 煜
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -370,13 +370,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -385,7 +385,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -398,20 +398,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.70346+2.97108)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.70346+2.97108)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 温
+.............\TU/FandolFang(0)/m/n/16.06 温
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 诗
+.............\TU/FandolFang(0)/m/n/16.06 诗
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 铸
+.............\TU/FandolFang(0)/m/n/16.06 铸
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -428,15 +428,15 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set - 0.15805filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 副
+............\TU/FandolFang(0)/m/n/16.06 副
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -445,7 +445,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -458,11 +458,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.81049)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.81049)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 孟
+.............\TU/FandolFang(0)/m/n/16.06 孟
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 永
+.............\TU/FandolFang(0)/m/n/16.06 永
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 钢
+.............\TU/FandolFang(0)/m/n/16.06 钢
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -470,11 +470,11 @@ Completed box being shipped out [1]
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.51074+2.9229)x48.18
 ...........\special{color push gray 0}
-...........\TU/FandolFang-Regular(0)/m/n/16.06 研
+...........\TU/FandolFang(0)/m/n/16.06 研
 ...........\glue 0.0 plus 1.3163
-...........\TU/FandolFang-Regular(0)/m/n/16.06 究
+...........\TU/FandolFang(0)/m/n/16.06 究
 ...........\glue 0.0 plus 1.3163
-...........\TU/FandolFang-Regular(0)/m/n/16.06 员
+...........\TU/FandolFang(0)/m/n/16.06 员
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\special{color pop}
@@ -498,19 +498,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 十
+......\TU/FandolSong(0)/m/n/16.06 十
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/doctor-1-5.tlg
+++ b/testfiles/01-cover/doctor-1-5.tlg
@@ -125,20 +125,20 @@ Completed box being shipped out [1]
 .....\hbox(12.5268+2.79442)x398.3386, glue set 300.2031fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -19.63246
-......\TU/FandolHei-Regular(0)/m/n/16.06 秘
+......\TU/FandolHei(0)/m/n/16.06 秘
 ......\glue 0.0 plus 1.3163
-......\TU/FandolHei-Regular(0)/m/n/16.06 密
+......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 5.34798 plus 2.67398 minus 1.78265
-......\TU/FandolHei-Regular(0)/m/n/16.06 ★
+......\TU/FandolHei(0)/m/n/16.06 ★
 ......\kern -0.0002
 ......\kern 0.0002
 ......\hbox(10.88867+0.3533)x48.18, glue set 16.06fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-.......\TU/FandolHei-Regular(0)/m/n/16.06 10
+.......\TU/FandolHei(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-......\TU/FandolHei-Regular(0)/m/n/16.06 年
+......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -154,31 +154,31 @@ Completed box being shipped out [1]
 ...\hbox(20.46043+4.74973)x398.3386, glue set 29.53563fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 单
+....\TU/FandolHei(0)/m/n/26.09749 单
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 位
+....\TU/FandolHei(0)/m/n/26.09749 位
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 根
+....\TU/FandolHei(0)/m/n/26.09749 根
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 和
+....\TU/FandolHei(0)/m/n/26.09749 和
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 协
+....\TU/FandolHei(0)/m/n/26.09749 协
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 整
+....\TU/FandolHei(0)/m/n/26.09749 整
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 及
+....\TU/FandolHei(0)/m/n/26.09749 及
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 其
+....\TU/FandolHei(0)/m/n/26.09749 其
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 结
+....\TU/FandolHei(0)/m/n/26.09749 结
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 构
+....\TU/FandolHei(0)/m/n/26.09749 构
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 突
+....\TU/FandolHei(0)/m/n/26.09749 突
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 变
+....\TU/FandolHei(0)/m/n/26.09749 变
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 的
+....\TU/FandolHei(0)/m/n/26.09749 的
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -190,19 +190,19 @@ Completed box being shipped out [1]
 ...\hbox(20.40823+4.77582)x398.3386, glue set 107.8281fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 理
+....\TU/FandolHei(0)/m/n/26.09749 理
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 论
+....\TU/FandolHei(0)/m/n/26.09749 论
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 与
+....\TU/FandolHei(0)/m/n/26.09749 与
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 应
+....\TU/FandolHei(0)/m/n/26.09749 应
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 用
+....\TU/FandolHei(0)/m/n/26.09749 用
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -214,35 +214,35 @@ Completed box being shipped out [1]
 ...\hbox(14.1107+4.51686)x398.3386, glue set 56.65294fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 经
+....\TU/FandolSong(0)/m/n/18.06749 经
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 济
+....\TU/FandolSong(0)/m/n/18.06749 济
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -270,13 +270,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -285,7 +285,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -294,17 +294,17 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 经
+..........\TU/FandolFang(0)/m/n/16.06 经
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 济
+..........\TU/FandolFang(0)/m/n/16.06 济
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 管
+..........\TU/FandolFang(0)/m/n/16.06 管
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 院
+..........\TU/FandolFang(0)/m/n/16.06 院
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -320,9 +320,9 @@ Completed box being shipped out [1]
 ..........\hbox(12.59103+2.82654)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.59103+2.82654)x79.6678, glue set 23.77391filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 学
+............\TU/FandolFang(0)/m/n/16.06 学
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 科
+............\TU/FandolFang(0)/m/n/16.06 科
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -331,7 +331,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -340,15 +340,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 应
+..........\TU/FandolFang(0)/m/n/16.06 应
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 用
+..........\TU/FandolFang(0)/m/n/16.06 用
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 经
+..........\TU/FandolFang(0)/m/n/16.06 经
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 济
+..........\TU/FandolFang(0)/m/n/16.06 济
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -364,11 +364,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.9229)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.9229)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 研
+............\TU/FandolFang(0)/m/n/16.06 研
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 究
+............\TU/FandolFang(0)/m/n/16.06 究
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 生
+............\TU/FandolFang(0)/m/n/16.06 生
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -377,7 +377,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -390,11 +390,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 王
+.............\TU/FandolFang(0)/m/n/16.06 王
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -415,13 +415,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -430,7 +430,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -443,20 +443,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -480,19 +480,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/doctor-1-6.tlg
+++ b/testfiles/01-cover/doctor-1-6.tlg
@@ -139,35 +139,35 @@ Completed box being shipped out [1]
 ...\hbox(20.46043+4.54095)x398.3386, glue set 3.43814fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 若
+....\TU/FandolHei(0)/m/n/26.09749 若
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 干
+....\TU/FandolHei(0)/m/n/26.09749 干
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 低
+....\TU/FandolHei(0)/m/n/26.09749 低
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 维
+....\TU/FandolHei(0)/m/n/26.09749 维
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 小
+....\TU/FandolHei(0)/m/n/26.09749 小
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 体
+....\TU/FandolHei(0)/m/n/26.09749 体
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 系
+....\TU/FandolHei(0)/m/n/26.09749 系
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 中
+....\TU/FandolHei(0)/m/n/26.09749 中
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 的
+....\TU/FandolHei(0)/m/n/26.09749 的
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 量
+....\TU/FandolHei(0)/m/n/26.09749 量
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 子
+....\TU/FandolHei(0)/m/n/26.09749 子
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 特
+....\TU/FandolHei(0)/m/n/26.09749 特
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 性
+....\TU/FandolHei(0)/m/n/26.09749 性
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -179,33 +179,33 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 65.68668fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 理
+....\TU/FandolSong(0)/m/n/18.06749 理
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -233,13 +233,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -257,11 +257,11 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 物
+..........\TU/FandolFang(0)/m/n/16.06 物
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 系
+..........\TU/FandolFang(0)/m/n/16.06 系
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -277,9 +277,9 @@ Completed box being shipped out [1]
 ..........\hbox(12.59103+2.82654)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.59103+2.82654)x79.6678, glue set 23.77391filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 学
+............\TU/FandolFang(0)/m/n/16.06 学
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 科
+............\TU/FandolFang(0)/m/n/16.06 科
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -288,7 +288,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -297,11 +297,11 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 物
+..........\TU/FandolFang(0)/m/n/16.06 物
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -317,11 +317,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.9229)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.9229)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 研
+............\TU/FandolFang(0)/m/n/16.06 研
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 究
+............\TU/FandolFang(0)/m/n/16.06 究
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 生
+............\TU/FandolFang(0)/m/n/16.06 生
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -330,7 +330,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -343,9 +343,9 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.73018)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.73018)x64.23999, glue set 16.06filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 胡
+.............\TU/FandolFang(0)/m/n/16.06 胡
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 辉
+.............\TU/FandolFang(0)/m/n/16.06 辉
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -366,13 +366,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -381,7 +381,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -394,20 +394,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.89618+2.74625)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.89618+2.74625)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 熊
+.............\TU/FandolFang(0)/m/n/16.06 熊
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 家
+.............\TU/FandolFang(0)/m/n/16.06 家
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 炯
+.............\TU/FandolFang(0)/m/n/16.06 炯
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -424,13 +424,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 联
+............\TU/FandolFang(0)/m/n/16.06 联
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 合
+............\TU/FandolFang(0)/m/n/16.06 合
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -439,7 +439,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -452,20 +452,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.88011+2.8426)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.88011+2.8426)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 朱
+.............\TU/FandolFang(0)/m/n/16.06 朱
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 嘉
+.............\TU/FandolFang(0)/m/n/16.06 嘉
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 麟
+.............\TU/FandolFang(0)/m/n/16.06 麟
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -489,19 +489,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 四
+......\TU/FandolSong(0)/m/n/16.06 四
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/doctor-1-7.tlg
+++ b/testfiles/01-cover/doctor-1-7.tlg
@@ -139,21 +139,21 @@ Completed box being shipped out [1]
 ...\hbox(20.22556+4.48875)x398.3386, glue set 94.77934fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 行
+....\TU/FandolHei(0)/m/n/26.09749 行
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 政
+....\TU/FandolHei(0)/m/n/26.09749 政
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 审
+....\TU/FandolHei(0)/m/n/26.09749 审
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 批
+....\TU/FandolHei(0)/m/n/26.09749 批
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 制
+....\TU/FandolHei(0)/m/n/26.09749 制
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 度
+....\TU/FandolHei(0)/m/n/26.09749 度
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -168,24 +168,24 @@ Completed box being shipped out [1]
 ....\penalty 0
 ....\glue 0.0
 ....\rule(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\rule(0.0+0.0)x0.0
 ....\glue 0.0
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 以
+....\TU/FandolHei(0)/m/n/26.09749 以
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 深
+....\TU/FandolHei(0)/m/n/26.09749 深
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 圳
+....\TU/FandolHei(0)/m/n/26.09749 圳
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 市
+....\TU/FandolHei(0)/m/n/26.09749 市
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 为
+....\TU/FandolHei(0)/m/n/26.09749 为
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 例
+....\TU/FandolHei(0)/m/n/26.09749 例
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -197,37 +197,37 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 47.61919fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 教
+....\TU/FandolSong(0)/m/n/18.06749 教
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 育
+....\TU/FandolSong(0)/m/n/18.06749 育
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 专
+....\TU/FandolSong(0)/m/n/18.06749 专
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 业
+....\TU/FandolSong(0)/m/n/18.06749 业
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -256,13 +256,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.87473)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.87473)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 培
+.............\TU/FandolFang(0)/m/n/16.06 培
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 养
+.............\TU/FandolFang(0)/m/n/16.06 养
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 单
+.............\TU/FandolFang(0)/m/n/16.06 单
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 位
+.............\TU/FandolFang(0)/m/n/16.06 位
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -272,7 +272,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -281,15 +281,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 教
+..........\TU/FandolFang(0)/m/n/16.06 教
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 育
+..........\TU/FandolFang(0)/m/n/16.06 育
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 研
+..........\TU/FandolFang(0)/m/n/16.06 研
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 究
+..........\TU/FandolFang(0)/m/n/16.06 究
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 院
+..........\TU/FandolFang(0)/m/n/16.06 院
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -306,11 +306,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.70346+2.95502)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.70346+2.95502)x80.29999, glue set 8.03filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 申
+.............\TU/FandolFang(0)/m/n/16.06 申
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 请
+.............\TU/FandolFang(0)/m/n/16.06 请
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 人
+.............\TU/FandolFang(0)/m/n/16.06 人
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -320,7 +320,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -333,11 +333,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -359,13 +359,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -375,7 +375,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -388,20 +388,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -425,19 +425,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/doctor-1-8.tlg
+++ b/testfiles/01-cover/doctor-1-8.tlg
@@ -125,20 +125,20 @@ Completed box being shipped out [1]
 .....\hbox(12.5268+2.79442)x398.3386, glue set 300.2031fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -19.63246
-......\TU/FandolHei-Regular(0)/m/n/16.06 秘
+......\TU/FandolHei(0)/m/n/16.06 秘
 ......\glue 0.0 plus 1.3163
-......\TU/FandolHei-Regular(0)/m/n/16.06 密
+......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 5.34798 plus 2.67398 minus 1.78265
-......\TU/FandolHei-Regular(0)/m/n/16.06 ★
+......\TU/FandolHei(0)/m/n/16.06 ★
 ......\kern -0.0002
 ......\kern 0.0002
 ......\hbox(10.88867+0.3533)x48.18, glue set 16.06fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-.......\TU/FandolHei-Regular(0)/m/n/16.06 10
+.......\TU/FandolHei(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-......\TU/FandolHei-Regular(0)/m/n/16.06 年
+......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -154,21 +154,21 @@ Completed box being shipped out [1]
 ...\hbox(20.22556+4.48875)x398.3386, glue set 94.77934fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 行
+....\TU/FandolHei(0)/m/n/26.09749 行
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 政
+....\TU/FandolHei(0)/m/n/26.09749 政
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 审
+....\TU/FandolHei(0)/m/n/26.09749 审
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 批
+....\TU/FandolHei(0)/m/n/26.09749 批
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 制
+....\TU/FandolHei(0)/m/n/26.09749 制
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 度
+....\TU/FandolHei(0)/m/n/26.09749 度
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -183,24 +183,24 @@ Completed box being shipped out [1]
 ....\penalty 0
 ....\glue 0.0
 ....\rule(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\rule(0.0+0.0)x0.0
 ....\glue 0.0
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 以
+....\TU/FandolHei(0)/m/n/26.09749 以
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 深
+....\TU/FandolHei(0)/m/n/26.09749 深
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 圳
+....\TU/FandolHei(0)/m/n/26.09749 圳
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 市
+....\TU/FandolHei(0)/m/n/26.09749 市
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 为
+....\TU/FandolHei(0)/m/n/26.09749 为
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 例
+....\TU/FandolHei(0)/m/n/26.09749 例
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -212,37 +212,37 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 47.61919fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 教
+....\TU/FandolSong(0)/m/n/18.06749 教
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 育
+....\TU/FandolSong(0)/m/n/18.06749 育
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 博
+....\TU/FandolSong(0)/m/n/18.06749 博
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 专
+....\TU/FandolSong(0)/m/n/18.06749 专
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 业
+....\TU/FandolSong(0)/m/n/18.06749 业
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -271,13 +271,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.87473)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.87473)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 培
+.............\TU/FandolFang(0)/m/n/16.06 培
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 养
+.............\TU/FandolFang(0)/m/n/16.06 养
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 单
+.............\TU/FandolFang(0)/m/n/16.06 单
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 位
+.............\TU/FandolFang(0)/m/n/16.06 位
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -287,7 +287,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -296,15 +296,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 教
+..........\TU/FandolFang(0)/m/n/16.06 教
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 育
+..........\TU/FandolFang(0)/m/n/16.06 育
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 研
+..........\TU/FandolFang(0)/m/n/16.06 研
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 究
+..........\TU/FandolFang(0)/m/n/16.06 究
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 院
+..........\TU/FandolFang(0)/m/n/16.06 院
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -321,11 +321,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.70346+2.95502)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.70346+2.95502)x80.29999, glue set 8.03filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 申
+.............\TU/FandolFang(0)/m/n/16.06 申
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 请
+.............\TU/FandolFang(0)/m/n/16.06 请
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 人
+.............\TU/FandolFang(0)/m/n/16.06 人
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -335,7 +335,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -348,11 +348,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -374,13 +374,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -390,7 +390,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -403,20 +403,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -440,19 +440,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/master-1-1.tlg
+++ b/testfiles/01-cover/master-1-1.tlg
@@ -139,27 +139,27 @@ Completed box being shipped out [1]
 ...\hbox(20.35605+4.56705)x398.3386, glue set 55.63312fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 两
+....\TU/FandolHei(0)/m/n/26.09749 两
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 层
+....\TU/FandolHei(0)/m/n/26.09749 层
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 次
+....\TU/FandolHei(0)/m/n/26.09749 次
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 物
+....\TU/FandolHei(0)/m/n/26.09749 物
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 流
+....\TU/FandolHei(0)/m/n/26.09749 流
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 中
+....\TU/FandolHei(0)/m/n/26.09749 中
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 心
+....\TU/FandolHei(0)/m/n/26.09749 心
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 规
+....\TU/FandolHei(0)/m/n/26.09749 规
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 划
+....\TU/FandolHei(0)/m/n/26.09749 划
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 模
+....\TU/FandolHei(0)/m/n/26.09749 模
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 型
+....\TU/FandolHei(0)/m/n/26.09749 型
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -171,23 +171,23 @@ Completed box being shipped out [1]
 ...\hbox(20.40823+4.61925)x398.3386, glue set 81.7306fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 理
+....\TU/FandolHei(0)/m/n/26.09749 理
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 论
+....\TU/FandolHei(0)/m/n/26.09749 论
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 分
+....\TU/FandolHei(0)/m/n/26.09749 分
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 析
+....\TU/FandolHei(0)/m/n/26.09749 析
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 和
+....\TU/FandolHei(0)/m/n/26.09749 和
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 算
+....\TU/FandolHei(0)/m/n/26.09749 算
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 法
+....\TU/FandolHei(0)/m/n/26.09749 法
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -199,33 +199,33 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 65.68668fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 工
+....\TU/FandolSong(0)/m/n/18.06749 工
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 硕
+....\TU/FandolSong(0)/m/n/18.06749 硕
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -254,13 +254,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.87473)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.87473)x88.32999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 培
+.............\TU/FandolFang(0)/m/n/16.06 培
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 养
+.............\TU/FandolFang(0)/m/n/16.06 养
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 单
+.............\TU/FandolFang(0)/m/n/16.06 单
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 位
+.............\TU/FandolFang(0)/m/n/16.06 位
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -270,7 +270,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -279,15 +279,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 业
+..........\TU/FandolFang(0)/m/n/16.06 业
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 系
+..........\TU/FandolFang(0)/m/n/16.06 系
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -304,9 +304,9 @@ Completed box being shipped out [1]
 ...........\hbox(12.59103+2.82654)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.59103+2.82654)x88.32999, glue set 28.105filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 学
+.............\TU/FandolFang(0)/m/n/16.06 学
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 科
+.............\TU/FandolFang(0)/m/n/16.06 科
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -316,7 +316,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -325,19 +325,19 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 管
+..........\TU/FandolFang(0)/m/n/16.06 管
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 科
+..........\TU/FandolFang(0)/m/n/16.06 科
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 与
+..........\TU/FandolFang(0)/m/n/16.06 与
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -354,11 +354,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.51074+2.9229)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.51074+2.9229)x88.32999, glue set 10.0375filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 研
+.............\TU/FandolFang(0)/m/n/16.06 研
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 究
+.............\TU/FandolFang(0)/m/n/16.06 究
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 生
+.............\TU/FandolFang(0)/m/n/16.06 生
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -368,7 +368,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -381,11 +381,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 吕
+.............\TU/FandolFang(0)/m/n/16.06 吕
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -407,13 +407,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x88.32999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -423,7 +423,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -436,20 +436,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -467,17 +467,17 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x88.32999, glue set - 1.606filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 联
+.............\TU/FandolFang(0)/m/n/16.06 联
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 合
+.............\TU/FandolFang(0)/m/n/16.06 合
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -487,7 +487,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -500,20 +500,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -537,19 +537,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 五
+......\TU/FandolSong(0)/m/n/16.06 五
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/master-1-2.tlg
+++ b/testfiles/01-cover/master-1-2.tlg
@@ -139,31 +139,31 @@ Completed box being shipped out [1]
 ...\hbox(20.46043+4.48875)x398.3386, glue set 29.53563fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 透
+....\TU/FandolHei(0)/m/n/26.09749 透
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 水
+....\TU/FandolHei(0)/m/n/26.09749 水
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 性
+....\TU/FandolHei(0)/m/n/26.09749 性
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 混
+....\TU/FandolHei(0)/m/n/26.09749 混
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 凝
+....\TU/FandolHei(0)/m/n/26.09749 凝
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 土
+....\TU/FandolHei(0)/m/n/26.09749 土
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 路
+....\TU/FandolHei(0)/m/n/26.09749 路
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 面
+....\TU/FandolHei(0)/m/n/26.09749 面
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 材
+....\TU/FandolHei(0)/m/n/26.09749 材
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 料
+....\TU/FandolHei(0)/m/n/26.09749 料
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 的
+....\TU/FandolHei(0)/m/n/26.09749 的
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -175,37 +175,37 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 47.61919fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 工
+....\TU/FandolSong(0)/m/n/18.06749 工
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 程
+....\TU/FandolSong(0)/m/n/18.06749 程
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 硕
+....\TU/FandolSong(0)/m/n/18.06749 硕
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 专
+....\TU/FandolSong(0)/m/n/18.06749 专
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 业
+....\TU/FandolSong(0)/m/n/18.06749 业
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -233,13 +233,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -257,15 +257,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 土
+..........\TU/FandolFang(0)/m/n/16.06 土
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 木
+..........\TU/FandolFang(0)/m/n/16.06 木
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 系
+..........\TU/FandolFang(0)/m/n/16.06 系
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -281,13 +281,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.8426)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.8426)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 工
+............\TU/FandolFang(0)/m/n/16.06 工
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 程
+............\TU/FandolFang(0)/m/n/16.06 程
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 领
+............\TU/FandolFang(0)/m/n/16.06 领
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 域
+............\TU/FandolFang(0)/m/n/16.06 域
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -296,7 +296,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -305,19 +305,19 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 建
+..........\TU/FandolFang(0)/m/n/16.06 建
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 筑
+..........\TU/FandolFang(0)/m/n/16.06 筑
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 与
+..........\TU/FandolFang(0)/m/n/16.06 与
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 土
+..........\TU/FandolFang(0)/m/n/16.06 土
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 木
+..........\TU/FandolFang(0)/m/n/16.06 木
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -333,11 +333,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.70346+2.95502)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.70346+2.95502)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 申
+............\TU/FandolFang(0)/m/n/16.06 申
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 请
+............\TU/FandolFang(0)/m/n/16.06 请
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 人
+............\TU/FandolFang(0)/m/n/16.06 人
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -346,7 +346,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -359,9 +359,9 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 16.06filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -382,13 +382,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -397,7 +397,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -410,20 +410,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -440,17 +440,17 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set - 3.33844filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 联
+............\TU/FandolFang(0)/m/n/16.06 联
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 合
+............\TU/FandolFang(0)/m/n/16.06 合
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -459,7 +459,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -472,20 +472,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -509,19 +509,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/master-1-3.tlg
+++ b/testfiles/01-cover/master-1-3.tlg
@@ -139,21 +139,21 @@ Completed box being shipped out [1]
 ...\hbox(20.22556+4.48875)x398.3386, glue set 94.77934fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 行
+....\TU/FandolHei(0)/m/n/26.09749 行
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 政
+....\TU/FandolHei(0)/m/n/26.09749 政
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 审
+....\TU/FandolHei(0)/m/n/26.09749 审
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 批
+....\TU/FandolHei(0)/m/n/26.09749 批
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 制
+....\TU/FandolHei(0)/m/n/26.09749 制
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 度
+....\TU/FandolHei(0)/m/n/26.09749 度
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -168,24 +168,24 @@ Completed box being shipped out [1]
 ....\penalty 0
 ....\glue 0.0
 ....\rule(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\rule(0.0+0.0)x0.0
 ....\glue 0.0
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 以
+....\TU/FandolHei(0)/m/n/26.09749 以
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 深
+....\TU/FandolHei(0)/m/n/26.09749 深
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 圳
+....\TU/FandolHei(0)/m/n/26.09749 圳
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 市
+....\TU/FandolHei(0)/m/n/26.09749 市
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 为
+....\TU/FandolHei(0)/m/n/26.09749 为
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 例
+....\TU/FandolHei(0)/m/n/26.09749 例
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -197,41 +197,41 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 29.5517fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 公
+....\TU/FandolSong(0)/m/n/18.06749 公
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 共
+....\TU/FandolSong(0)/m/n/18.06749 共
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 管
+....\TU/FandolSong(0)/m/n/18.06749 管
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 理
+....\TU/FandolSong(0)/m/n/18.06749 理
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 硕
+....\TU/FandolSong(0)/m/n/18.06749 硕
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 专
+....\TU/FandolSong(0)/m/n/18.06749 专
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 业
+....\TU/FandolSong(0)/m/n/18.06749 业
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -260,13 +260,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.87473)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.87473)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 培
+.............\TU/FandolFang(0)/m/n/16.06 培
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 养
+.............\TU/FandolFang(0)/m/n/16.06 养
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 单
+.............\TU/FandolFang(0)/m/n/16.06 单
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 位
+.............\TU/FandolFang(0)/m/n/16.06 位
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -276,7 +276,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -285,17 +285,17 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 公
+..........\TU/FandolFang(0)/m/n/16.06 公
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 共
+..........\TU/FandolFang(0)/m/n/16.06 共
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 管
+..........\TU/FandolFang(0)/m/n/16.06 管
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 院
+..........\TU/FandolFang(0)/m/n/16.06 院
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -312,11 +312,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.70346+2.95502)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.70346+2.95502)x80.29999, glue set 8.03filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 申
+.............\TU/FandolFang(0)/m/n/16.06 申
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 请
+.............\TU/FandolFang(0)/m/n/16.06 请
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 人
+.............\TU/FandolFang(0)/m/n/16.06 人
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -326,7 +326,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -339,11 +339,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -365,13 +365,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -381,7 +381,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -394,20 +394,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -425,17 +425,17 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x80.29999, glue set - 3.212filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 联
+.............\TU/FandolFang(0)/m/n/16.06 联
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 合
+.............\TU/FandolFang(0)/m/n/16.06 合
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -445,7 +445,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -458,20 +458,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -495,19 +495,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/master-1-4.tlg
+++ b/testfiles/01-cover/master-1-4.tlg
@@ -125,20 +125,20 @@ Completed box being shipped out [1]
 .....\hbox(12.5268+2.79442)x398.3386, glue set 300.2031fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -19.63246
-......\TU/FandolHei-Regular(0)/m/n/16.06 秘
+......\TU/FandolHei(0)/m/n/16.06 秘
 ......\glue 0.0 plus 1.3163
-......\TU/FandolHei-Regular(0)/m/n/16.06 密
+......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 5.34798 plus 2.67398 minus 1.78265
-......\TU/FandolHei-Regular(0)/m/n/16.06 ★
+......\TU/FandolHei(0)/m/n/16.06 ★
 ......\kern -0.0002
 ......\kern 0.0002
 ......\hbox(10.88867+0.3533)x48.18, glue set 16.06fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-.......\TU/FandolHei-Regular(0)/m/n/16.06 10
+.......\TU/FandolHei(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-......\TU/FandolHei-Regular(0)/m/n/16.06 年
+......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -154,27 +154,27 @@ Completed box being shipped out [1]
 ...\hbox(20.35605+4.56705)x398.3386, glue set 55.63312fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 两
+....\TU/FandolHei(0)/m/n/26.09749 两
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 层
+....\TU/FandolHei(0)/m/n/26.09749 层
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 次
+....\TU/FandolHei(0)/m/n/26.09749 次
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 物
+....\TU/FandolHei(0)/m/n/26.09749 物
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 流
+....\TU/FandolHei(0)/m/n/26.09749 流
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 中
+....\TU/FandolHei(0)/m/n/26.09749 中
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 心
+....\TU/FandolHei(0)/m/n/26.09749 心
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 规
+....\TU/FandolHei(0)/m/n/26.09749 规
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 划
+....\TU/FandolHei(0)/m/n/26.09749 划
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 模
+....\TU/FandolHei(0)/m/n/26.09749 模
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 型
+....\TU/FandolHei(0)/m/n/26.09749 型
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -186,23 +186,23 @@ Completed box being shipped out [1]
 ...\hbox(20.40823+4.61925)x398.3386, glue set 81.7306fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 理
+....\TU/FandolHei(0)/m/n/26.09749 理
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 论
+....\TU/FandolHei(0)/m/n/26.09749 论
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 分
+....\TU/FandolHei(0)/m/n/26.09749 分
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 析
+....\TU/FandolHei(0)/m/n/26.09749 析
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 和
+....\TU/FandolHei(0)/m/n/26.09749 和
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 算
+....\TU/FandolHei(0)/m/n/26.09749 算
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 法
+....\TU/FandolHei(0)/m/n/26.09749 法
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -214,33 +214,33 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 65.68668fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 工
+....\TU/FandolSong(0)/m/n/18.06749 工
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 硕
+....\TU/FandolSong(0)/m/n/18.06749 硕
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -269,13 +269,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.87473)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.87473)x88.32999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 培
+.............\TU/FandolFang(0)/m/n/16.06 培
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 养
+.............\TU/FandolFang(0)/m/n/16.06 养
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 单
+.............\TU/FandolFang(0)/m/n/16.06 单
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 位
+.............\TU/FandolFang(0)/m/n/16.06 位
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -285,7 +285,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -294,15 +294,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 业
+..........\TU/FandolFang(0)/m/n/16.06 业
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 系
+..........\TU/FandolFang(0)/m/n/16.06 系
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -319,9 +319,9 @@ Completed box being shipped out [1]
 ...........\hbox(12.59103+2.82654)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.59103+2.82654)x88.32999, glue set 28.105filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 学
+.............\TU/FandolFang(0)/m/n/16.06 学
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 科
+.............\TU/FandolFang(0)/m/n/16.06 科
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -331,7 +331,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -340,19 +340,19 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 管
+..........\TU/FandolFang(0)/m/n/16.06 管
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 科
+..........\TU/FandolFang(0)/m/n/16.06 科
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 与
+..........\TU/FandolFang(0)/m/n/16.06 与
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -369,11 +369,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.51074+2.9229)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.51074+2.9229)x88.32999, glue set 10.0375filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 研
+.............\TU/FandolFang(0)/m/n/16.06 研
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 究
+.............\TU/FandolFang(0)/m/n/16.06 究
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 生
+.............\TU/FandolFang(0)/m/n/16.06 生
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -383,7 +383,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -396,11 +396,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 吕
+.............\TU/FandolFang(0)/m/n/16.06 吕
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -422,13 +422,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x88.32999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -438,7 +438,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -451,20 +451,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -482,17 +482,17 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x88.32999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x88.32999, glue set - 1.606filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 联
+.............\TU/FandolFang(0)/m/n/16.06 联
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 合
+.............\TU/FandolFang(0)/m/n/16.06 合
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -502,7 +502,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -515,20 +515,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -552,19 +552,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/master-1-5.tlg
+++ b/testfiles/01-cover/master-1-5.tlg
@@ -125,20 +125,20 @@ Completed box being shipped out [1]
 .....\hbox(12.5268+2.79442)x398.3386, glue set 300.2031fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -19.63246
-......\TU/FandolHei-Regular(0)/m/n/16.06 秘
+......\TU/FandolHei(0)/m/n/16.06 秘
 ......\glue 0.0 plus 1.3163
-......\TU/FandolHei-Regular(0)/m/n/16.06 密
+......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 5.34798 plus 2.67398 minus 1.78265
-......\TU/FandolHei-Regular(0)/m/n/16.06 ★
+......\TU/FandolHei(0)/m/n/16.06 ★
 ......\kern -0.0002
 ......\kern 0.0002
 ......\hbox(10.88867+0.3533)x48.18, glue set 16.06fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-.......\TU/FandolHei-Regular(0)/m/n/16.06 10
+.......\TU/FandolHei(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-......\TU/FandolHei-Regular(0)/m/n/16.06 年
+......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -154,31 +154,31 @@ Completed box being shipped out [1]
 ...\hbox(20.46043+4.48875)x398.3386, glue set 29.53563fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 透
+....\TU/FandolHei(0)/m/n/26.09749 透
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 水
+....\TU/FandolHei(0)/m/n/26.09749 水
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 性
+....\TU/FandolHei(0)/m/n/26.09749 性
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 混
+....\TU/FandolHei(0)/m/n/26.09749 混
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 凝
+....\TU/FandolHei(0)/m/n/26.09749 凝
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 土
+....\TU/FandolHei(0)/m/n/26.09749 土
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 路
+....\TU/FandolHei(0)/m/n/26.09749 路
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 面
+....\TU/FandolHei(0)/m/n/26.09749 面
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 材
+....\TU/FandolHei(0)/m/n/26.09749 材
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 料
+....\TU/FandolHei(0)/m/n/26.09749 料
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 的
+....\TU/FandolHei(0)/m/n/26.09749 的
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -190,37 +190,37 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 47.61919fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 工
+....\TU/FandolSong(0)/m/n/18.06749 工
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 程
+....\TU/FandolSong(0)/m/n/18.06749 程
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 硕
+....\TU/FandolSong(0)/m/n/18.06749 硕
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 专
+....\TU/FandolSong(0)/m/n/18.06749 专
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 业
+....\TU/FandolSong(0)/m/n/18.06749 业
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -248,13 +248,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.73558+2.87473)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.73558+2.87473)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 培
+............\TU/FandolFang(0)/m/n/16.06 培
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 养
+............\TU/FandolFang(0)/m/n/16.06 养
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 单
+............\TU/FandolFang(0)/m/n/16.06 单
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 位
+............\TU/FandolFang(0)/m/n/16.06 位
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -263,7 +263,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -272,15 +272,15 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 土
+..........\TU/FandolFang(0)/m/n/16.06 土
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 木
+..........\TU/FandolFang(0)/m/n/16.06 木
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 系
+..........\TU/FandolFang(0)/m/n/16.06 系
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -296,13 +296,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.51074+2.8426)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.51074+2.8426)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 工
+............\TU/FandolFang(0)/m/n/16.06 工
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 程
+............\TU/FandolFang(0)/m/n/16.06 程
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 领
+............\TU/FandolFang(0)/m/n/16.06 领
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 域
+............\TU/FandolFang(0)/m/n/16.06 域
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -311,7 +311,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -320,19 +320,19 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 建
+..........\TU/FandolFang(0)/m/n/16.06 建
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 筑
+..........\TU/FandolFang(0)/m/n/16.06 筑
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 与
+..........\TU/FandolFang(0)/m/n/16.06 与
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 土
+..........\TU/FandolFang(0)/m/n/16.06 土
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 木
+..........\TU/FandolFang(0)/m/n/16.06 木
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 工
+..........\TU/FandolFang(0)/m/n/16.06 工
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 程
+..........\TU/FandolFang(0)/m/n/16.06 程
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -348,11 +348,11 @@ Completed box being shipped out [1]
 ..........\hbox(12.70346+2.95502)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.70346+2.95502)x79.6678, glue set 7.87195filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 申
+............\TU/FandolFang(0)/m/n/16.06 申
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 请
+............\TU/FandolFang(0)/m/n/16.06 请
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 人
+............\TU/FandolFang(0)/m/n/16.06 人
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -361,7 +361,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -374,9 +374,9 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 16.06filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -397,13 +397,13 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set 2.5713filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -412,7 +412,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -425,20 +425,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -455,17 +455,17 @@ Completed box being shipped out [1]
 ..........\hbox(12.81587+3.05139)x79.6678
 ...........\special{color push gray 0}
 ...........\hbox(12.81587+3.05139)x79.6678, glue set - 3.33844filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 联
+............\TU/FandolFang(0)/m/n/16.06 联
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 合
+............\TU/FandolFang(0)/m/n/16.06 合
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 指
+............\TU/FandolFang(0)/m/n/16.06 指
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 导
+............\TU/FandolFang(0)/m/n/16.06 导
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 教
+............\TU/FandolFang(0)/m/n/16.06 教
 ............\glue 0.0 plus 2.0filll minus 1.0filll
-............\TU/FandolFang-Regular(0)/m/n/16.06 师
+............\TU/FandolFang(0)/m/n/16.06 师
 ............\kern -0.00017
 ............\kern 0.00017
 ............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -474,7 +474,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -487,20 +487,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -524,19 +524,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/master-1-6.tlg
+++ b/testfiles/01-cover/master-1-6.tlg
@@ -125,20 +125,20 @@ Completed box being shipped out [1]
 .....\hbox(12.5268+2.79442)x398.3386, glue set 300.2031fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -19.63246
-......\TU/FandolHei-Regular(0)/m/n/16.06 秘
+......\TU/FandolHei(0)/m/n/16.06 秘
 ......\glue 0.0 plus 1.3163
-......\TU/FandolHei-Regular(0)/m/n/16.06 密
+......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 5.34798 plus 2.67398 minus 1.78265
-......\TU/FandolHei-Regular(0)/m/n/16.06 ★
+......\TU/FandolHei(0)/m/n/16.06 ★
 ......\kern -0.0002
 ......\kern 0.0002
 ......\hbox(10.88867+0.3533)x48.18, glue set 16.06fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-.......\TU/FandolHei-Regular(0)/m/n/16.06 10
+.......\TU/FandolHei(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
-......\TU/FandolHei-Regular(0)/m/n/16.06 年
+......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -154,21 +154,21 @@ Completed box being shipped out [1]
 ...\hbox(20.22556+4.48875)x398.3386, glue set 94.77934fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 行
+....\TU/FandolHei(0)/m/n/26.09749 行
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 政
+....\TU/FandolHei(0)/m/n/26.09749 政
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 审
+....\TU/FandolHei(0)/m/n/26.09749 审
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 批
+....\TU/FandolHei(0)/m/n/26.09749 批
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 制
+....\TU/FandolHei(0)/m/n/26.09749 制
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 度
+....\TU/FandolHei(0)/m/n/26.09749 度
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 研
+....\TU/FandolHei(0)/m/n/26.09749 研
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 究
+....\TU/FandolHei(0)/m/n/26.09749 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -183,24 +183,24 @@ Completed box being shipped out [1]
 ....\penalty 0
 ....\glue 0.0
 ....\rule(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolHei-Regular(0)/m/n/26.09749 —
+....\TU/FandolHei(0)/m/n/26.09749 —
 ....\rule(0.0+0.0)x0.0
 ....\glue 0.0
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 以
+....\TU/FandolHei(0)/m/n/26.09749 以
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 深
+....\TU/FandolHei(0)/m/n/26.09749 深
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 圳
+....\TU/FandolHei(0)/m/n/26.09749 圳
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 市
+....\TU/FandolHei(0)/m/n/26.09749 市
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 为
+....\TU/FandolHei(0)/m/n/26.09749 为
 ....\glue 0.0 plus 2.53644
-....\TU/FandolHei-Regular(0)/m/n/26.09749 例
+....\TU/FandolHei(0)/m/n/26.09749 例
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -212,41 +212,41 @@ Completed box being shipped out [1]
 ...\hbox(14.09264+4.51686)x398.3386, glue set 29.5517fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/18.06749 (申
+....\TU/FandolSong(0)/m/n/18.06749 (申
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 请
+....\TU/FandolSong(0)/m/n/18.06749 请
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 清
+....\TU/FandolSong(0)/m/n/18.06749 清
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 华
+....\TU/FandolSong(0)/m/n/18.06749 华
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 大
+....\TU/FandolSong(0)/m/n/18.06749 大
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 公
+....\TU/FandolSong(0)/m/n/18.06749 公
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 共
+....\TU/FandolSong(0)/m/n/18.06749 共
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 管
+....\TU/FandolSong(0)/m/n/18.06749 管
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 理
+....\TU/FandolSong(0)/m/n/18.06749 理
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 硕
+....\TU/FandolSong(0)/m/n/18.06749 硕
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 士
+....\TU/FandolSong(0)/m/n/18.06749 士
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 专
+....\TU/FandolSong(0)/m/n/18.06749 专
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 业
+....\TU/FandolSong(0)/m/n/18.06749 业
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 学
+....\TU/FandolSong(0)/m/n/18.06749 学
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 位
+....\TU/FandolSong(0)/m/n/18.06749 位
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 论
+....\TU/FandolSong(0)/m/n/18.06749 论
 ....\glue 0.0 plus 0.94606
-....\TU/FandolSong-Regular(0)/m/n/18.06749 文)
+....\TU/FandolSong(0)/m/n/18.06749 文)
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
@@ -275,13 +275,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.73558+2.87473)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.73558+2.87473)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 培
+.............\TU/FandolFang(0)/m/n/16.06 培
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 养
+.............\TU/FandolFang(0)/m/n/16.06 养
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 单
+.............\TU/FandolFang(0)/m/n/16.06 单
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 位
+.............\TU/FandolFang(0)/m/n/16.06 位
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -291,7 +291,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -300,17 +300,17 @@ Completed box being shipped out [1]
 ............\glue 11.19382 minus 8.03
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\TU/FandolFang-Regular(0)/m/n/16.06 公
+..........\TU/FandolFang(0)/m/n/16.06 公
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 共
+..........\TU/FandolFang(0)/m/n/16.06 共
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 管
+..........\TU/FandolFang(0)/m/n/16.06 管
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 理
+..........\TU/FandolFang(0)/m/n/16.06 理
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 学
+..........\TU/FandolFang(0)/m/n/16.06 学
 ..........\glue 0.0 plus 1.3163
-..........\TU/FandolFang-Regular(0)/m/n/16.06 院
+..........\TU/FandolFang(0)/m/n/16.06 院
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
@@ -327,11 +327,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.70346+2.95502)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.70346+2.95502)x80.29999, glue set 8.03filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 申
+.............\TU/FandolFang(0)/m/n/16.06 申
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 请
+.............\TU/FandolFang(0)/m/n/16.06 请
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 人
+.............\TU/FandolFang(0)/m/n/16.06 人
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -341,7 +341,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -354,11 +354,11 @@ Completed box being shipped out [1]
 ...........\hbox(12.71951+2.9229)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.71951+2.9229)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 李
+.............\TU/FandolFang(0)/m/n/16.06 李
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -380,13 +380,13 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x80.29999, glue set 2.67667filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -396,7 +396,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -409,20 +409,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -440,17 +440,17 @@ Completed box being shipped out [1]
 ...........\hbox(12.81587+3.05139)x80.29999
 ............\special{color push gray 0}
 ............\hbox(12.81587+3.05139)x80.29999, glue set - 3.212filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 联
+.............\TU/FandolFang(0)/m/n/16.06 联
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 合
+.............\TU/FandolFang(0)/m/n/16.06 合
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 指
+.............\TU/FandolFang(0)/m/n/16.06 指
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 导
+.............\TU/FandolFang(0)/m/n/16.06 导
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 教
+.............\TU/FandolFang(0)/m/n/16.06 教
 .............\glue 0.0 plus 2.0filll minus 1.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 师
+.............\TU/FandolFang(0)/m/n/16.06 师
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
@@ -460,7 +460,7 @@ Completed box being shipped out [1]
 ...........\hbox(8.47968+0.0)x16.06
 ............\special{color push gray 0}
 ............\penalty 10000
-............\TU/FandolFang-Regular(0)/m/n/16.06 ：
+............\TU/FandolFang(0)/m/n/16.06 ：
 ............\rule(0.0+0.0)x-11.19382
 ............\kern 0.00069
 ............\kern -0.00069
@@ -473,20 +473,20 @@ Completed box being shipped out [1]
 ...........\hbox(12.67134+2.82654)x64.23999
 ............\special{color push gray 0}
 ............\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\glue 0.0 plus 2.0filll
-.............\TU/FandolFang-Regular(0)/m/n/16.06 某
+.............\TU/FandolFang(0)/m/n/16.06 某
 .............\kern -0.00017
 .............\kern 0.00017
 .............\glue 0.0 plus 1.0fil minus 1.0fil
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.74625)x48.18, glue set 8.03filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 教
+...........\TU/FandolFang(0)/m/n/16.06 教
 ...........\glue 0.0 plus 2.0filll
-...........\TU/FandolFang-Regular(0)/m/n/16.06 授
+...........\TU/FandolFang(0)/m/n/16.06 授
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -510,19 +510,19 @@ Completed box being shipped out [1]
 .....\hbox(12.39832+2.73018)x398.3386, glue set 142.9593fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 二
+......\TU/FandolSong(0)/m/n/16.06 二
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 〇
+......\TU/FandolSong(0)/m/n/16.06 〇
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 一
+......\TU/FandolSong(0)/m/n/16.06 一
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 六
+......\TU/FandolSong(0)/m/n/16.06 六
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 年
+......\TU/FandolSong(0)/m/n/16.06 年
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 三
+......\TU/FandolSong(0)/m/n/16.06 三
 ......\glue 0.0 plus 1.3163
-......\TU/FandolSong-Regular(0)/m/n/16.06 月
+......\TU/FandolSong(0)/m/n/16.06 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000

--- a/testfiles/01-cover/postdoc-1.tlg
+++ b/testfiles/01-cover/postdoc-1.tlg
@@ -99,11 +99,11 @@ Completed box being shipped out [1]
 .....\glue 4.81792
 ....\penalty 0
 ....\hbox(10.96094+2.44511)x43.5628, glue set 0.35133filll
-.....\TU/FandolSong-Regular(0)/m/n/14.05249 分
+.....\TU/FandolSong(0)/m/n/14.05249 分
 .....\glue 0.0 plus 2.0filll
-.....\TU/FandolSong-Regular(0)/m/n/14.05249 类
+.....\TU/FandolSong(0)/m/n/14.05249 类
 .....\glue 0.0 plus 2.0filll
-.....\TU/FandolSong-Regular(0)/m/n/14.05249 号
+.....\TU/FandolSong(0)/m/n/14.05249 号
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -119,9 +119,9 @@ Completed box being shipped out [1]
 ....\mathoff
 ....\glue 3.0
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/14.05249 密
+....\TU/FandolSong(0)/m/n/14.05249 密
 ....\glue 0.0 plus 0.68819
-....\TU/FandolSong-Regular(0)/m/n/14.05249 级
+....\TU/FandolSong(0)/m/n/14.05249 级
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 1.0
@@ -167,9 +167,9 @@ Completed box being shipped out [1]
 ....\mathoff
 ....\glue 3.0
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/14.05249 编
+....\TU/FandolSong(0)/m/n/14.05249 编
 ....\glue 0.0 plus 0.68819
-....\TU/FandolSong-Regular(0)/m/n/14.05249 号
+....\TU/FandolSong(0)/m/n/14.05249 号
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 1.0
@@ -191,13 +191,13 @@ Completed box being shipped out [1]
 ...\hbox(14.18298+3.08952)x426.79135, glue set 136.60886fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/b/n/18.06749 清
+....\TU/FandolHei(0)/b/n/18.06749 清
 ....\glue 27.10123 plus 0.24504 minus 4.29633
-....\TU/FandolHei-Regular(0)/b/n/18.06749 华
+....\TU/FandolHei(0)/b/n/18.06749 华
 ....\glue 27.10123 plus 0.24504 minus 4.29633
-....\TU/FandolHei-Regular(0)/b/n/18.06749 大
+....\TU/FandolHei(0)/b/n/18.06749 大
 ....\glue 27.10123 plus 0.24504 minus 4.29633
-....\TU/FandolHei-Regular(0)/b/n/18.06749 学
+....\TU/FandolHei(0)/b/n/18.06749 学
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -208,23 +208,23 @@ Completed box being shipped out [1]
 ...\hbox(13.9481+3.17987)x426.79135, glue set 95.95703fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolHei-Regular(0)/b/n/18.06749 博
+....\TU/FandolHei(0)/b/n/18.06749 博
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 士
+....\TU/FandolHei(0)/b/n/18.06749 士
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 后
+....\TU/FandolHei(0)/b/n/18.06749 后
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 研
+....\TU/FandolHei(0)/b/n/18.06749 研
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 究
+....\TU/FandolHei(0)/b/n/18.06749 究
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 工
+....\TU/FandolHei(0)/b/n/18.06749 工
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 作
+....\TU/FandolHei(0)/b/n/18.06749 作
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 报
+....\TU/FandolHei(0)/b/n/18.06749 报
 ....\glue 9.03374 plus 0.14703 minus 1.55598
-....\TU/FandolHei-Regular(0)/b/n/18.06749 告
+....\TU/FandolHei(0)/b/n/18.06749 告
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -255,7 +255,7 @@ Completed box being shipped out [1]
 ......\hbox(10.94688+2.48727)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 新
+.......\TU/FandolSong(0)/m/n/14.05249 新
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -278,7 +278,7 @@ Completed box being shipped out [1]
 ......\hbox(10.7642+1.55981)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 型
+.......\TU/FandolSong(0)/m/n/14.05249 型
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -301,7 +301,7 @@ Completed box being shipped out [1]
 ......\hbox(10.90474+2.48727)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 有
+.......\TU/FandolSong(0)/m/n/14.05249 有
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -324,7 +324,7 @@ Completed box being shipped out [1]
 ......\hbox(10.72205+2.0657)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 机
+.......\TU/FandolSong(0)/m/n/14.05249 机
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -347,7 +347,7 @@ Completed box being shipped out [1]
 ......\hbox(10.83447+2.36081)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 非
+.......\TU/FandolSong(0)/m/n/14.05249 非
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -370,7 +370,7 @@ Completed box being shipped out [1]
 ......\hbox(10.72205+1.85492)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 线
+.......\TU/FandolSong(0)/m/n/14.05249 线
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -393,7 +393,7 @@ Completed box being shipped out [1]
 ......\hbox(10.59558+2.47322)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 性
+.......\TU/FandolSong(0)/m/n/14.05249 性
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -416,7 +416,7 @@ Completed box being shipped out [1]
 ......\hbox(10.80637+2.22028)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 光
+.......\TU/FandolSong(0)/m/n/14.05249 光
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -439,7 +439,7 @@ Completed box being shipped out [1]
 ......\hbox(10.6518+2.29054)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 学
+.......\TU/FandolSong(0)/m/n/14.05249 学
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -462,7 +462,7 @@ Completed box being shipped out [1]
 ......\hbox(10.90474+2.31865)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 材
+.......\TU/FandolSong(0)/m/n/14.05249 材
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -485,7 +485,7 @@ Completed box being shipped out [1]
 ......\hbox(10.83447+2.44511)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 料
+.......\TU/FandolSong(0)/m/n/14.05249 料
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -508,7 +508,7 @@ Completed box being shipped out [1]
 ......\hbox(10.67989+2.3046)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 的
+.......\TU/FandolSong(0)/m/n/14.05249 的
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -531,7 +531,7 @@ Completed box being shipped out [1]
 ......\hbox(10.82042+2.55754)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 探
+.......\TU/FandolSong(0)/m/n/14.05249 探
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -554,7 +554,7 @@ Completed box being shipped out [1]
 ......\hbox(10.83447+2.40295)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 索
+.......\TU/FandolSong(0)/m/n/14.05249 索
 ......\rule(*+*)x0.0
 ......\penalty 10000
 ......\glue -1.40521
@@ -593,10 +593,10 @@ Completed box being shipped out [1]
 ......\hbox(4.37033+0.0)x28.10498
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 —
+.......\TU/FandolSong(0)/m/n/14.05249 —
 .......\penalty 10000
 .......\glue 0.0
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 —
+.......\TU/FandolSong(0)/m/n/14.05249 —
 .......\rule(0.0+0.0)x0.0
 ......\glue -1.40521
 ......\leaders 2.81042
@@ -628,7 +628,7 @@ Completed box being shipped out [1]
 ......\hbox(10.7361+2.24838)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 从
+.......\TU/FandolSong(0)/m/n/14.05249 从
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -651,7 +651,7 @@ Completed box being shipped out [1]
 ......\hbox(10.7361+2.44511)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 分
+.......\TU/FandolSong(0)/m/n/14.05249 分
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -674,7 +674,7 @@ Completed box being shipped out [1]
 ......\hbox(10.708+1.95328)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 子
+.......\TU/FandolSong(0)/m/n/14.05249 子
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -697,7 +697,7 @@ Completed box being shipped out [1]
 ......\hbox(10.83447+2.27649)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 到
+.......\TU/FandolSong(0)/m/n/14.05249 到
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -720,7 +720,7 @@ Completed box being shipped out [1]
 ......\hbox(10.7361+2.26244)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 晶
+.......\TU/FandolSong(0)/m/n/14.05249 晶
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -743,7 +743,7 @@ Completed box being shipped out [1]
 ......\hbox(10.86258+2.29054)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 体
+.......\TU/FandolSong(0)/m/n/14.05249 体
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -766,7 +766,7 @@ Completed box being shipped out [1]
 ......\hbox(10.67989+2.3046)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 的
+.......\TU/FandolSong(0)/m/n/14.05249 的
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -789,7 +789,7 @@ Completed box being shipped out [1]
 ......\hbox(10.90474+2.31865)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 材
+.......\TU/FandolSong(0)/m/n/14.05249 材
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -812,7 +812,7 @@ Completed box being shipped out [1]
 ......\hbox(10.83447+2.44511)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 料
+.......\TU/FandolSong(0)/m/n/14.05249 料
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -835,7 +835,7 @@ Completed box being shipped out [1]
 ......\hbox(10.66585+2.13596)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 化
+.......\TU/FandolSong(0)/m/n/14.05249 化
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -858,7 +858,7 @@ Completed box being shipped out [1]
 ......\hbox(10.6518+2.29054)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 学
+.......\TU/FandolSong(0)/m/n/14.05249 学
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -881,7 +881,7 @@ Completed box being shipped out [1]
 ......\hbox(10.93283+1.89706)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 过
+.......\TU/FandolSong(0)/m/n/14.05249 过
 ......\glue -1.40521
 ......\leaders 2.81042 plus 0.68819
 .......\hbox(0.0+14.75249)x2.81044
@@ -904,7 +904,7 @@ Completed box being shipped out [1]
 ......\hbox(10.59558+2.27649)x14.05249
 .......\kern -0.00005
 .......\kern 0.00005
-.......\TU/FandolSong-Regular(0)/m/n/14.05249 程
+.......\TU/FandolSong(0)/m/n/14.05249 程
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -920,9 +920,9 @@ Completed box being shipped out [1]
 ...\hbox(9.50351+2.1199)x426.79135, glue set 201.35068fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 奇
+....\TU/FandolSong(0)/m/n/12.045 奇
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -934,17 +934,17 @@ Completed box being shipped out [1]
 ...\hbox(9.38306+11.54042)x426.79135, glue set 87.30264fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 完
+....\TU/FandolSong(0)/m/n/12.045 完
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
@@ -968,27 +968,27 @@ Completed box being shipped out [1]
 ......\kern -0.00021
 ......\kern 0.00021
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong-Regular(0)/m/n/12.045 年
+......\TU/FandolSong(0)/m/n/12.045 年
 ......\glue 3.01125 plus 1.50562 minus 1.00374
 ......\TU/texgyretermes(0)/m/n/12.045 2
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong-Regular(0)/m/n/12.045 月
+......\TU/FandolSong(0)/m/n/12.045 月
 ......\penalty 0
 ......\glue 0.0 plus 0.52307
 ......\glue 0.0
 ......\rule(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/12.045 —
+......\TU/FandolSong(0)/m/n/12.045 —
 ......\rule(0.0+0.0)x0.0
 ......\glue 0.0
 ......\TU/texgyretermes(0)/m/n/12.045 1994
 ......\kern -0.00021
 ......\kern 0.00021
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong-Regular(0)/m/n/12.045 年
+......\TU/FandolSong(0)/m/n/12.045 年
 ......\glue 3.01125 plus 1.50562 minus 1.00374
 ......\TU/texgyretermes(0)/m/n/12.045 2
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong-Regular(0)/m/n/12.045 月
+......\TU/FandolSong(0)/m/n/12.045 月
 ......\kern -0.00018
 ......\kern 0.00018
 ......\glue 3.01125 plus 1.50562 minus 1.00374
@@ -1002,17 +1002,17 @@ Completed box being shipped out [1]
 ...\hbox(9.33487+11.54042)x426.79135, glue set 87.30264fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 报
+....\TU/FandolSong(0)/m/n/12.045 报
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 告
+....\TU/FandolSong(0)/m/n/12.045 告
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
@@ -1036,11 +1036,11 @@ Completed box being shipped out [1]
 ......\kern -0.00021
 ......\kern 0.00021
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong-Regular(0)/m/n/12.045 年
+......\TU/FandolSong(0)/m/n/12.045 年
 ......\glue 3.01125 plus 1.50562 minus 1.00374
 ......\TU/texgyretermes(0)/m/n/12.045 4
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong-Regular(0)/m/n/12.045 月
+......\TU/FandolSong(0)/m/n/12.045 月
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1053,23 +1053,23 @@ Completed box being shipped out [1]
 ...\hbox(9.636+2.40898)x426.79135, glue set 144.94395fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 清
+....\TU/FandolSong(0)/m/n/12.045 清
 ....\glue 12.045 plus 0.30685 minus 1.04854
-....\TU/FandolSong-Regular(0)/m/n/12.045 华
+....\TU/FandolSong(0)/m/n/12.045 华
 ....\glue 12.045 plus 0.30685 minus 1.04854
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 12.045 plus 0.30685 minus 1.04854
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （北
+....\TU/FandolSong(0)/m/n/12.045 （北
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 京
+....\TU/FandolSong(0)/m/n/12.045 京
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1088,11 +1088,11 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 4
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000

--- a/testfiles/01-cover/postdoc-2.tlg
+++ b/testfiles/01-cover/postdoc-2.tlg
@@ -103,33 +103,33 @@ Completed box being shipped out [1]
 .....\hbox(12.51074+2.9229)x426.79135, glue set 100.9757fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 新
+......\TU/FandolSong(0)/m/n/16.06 新
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 型
+......\TU/FandolSong(0)/m/n/16.06 型
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 有
+......\TU/FandolSong(0)/m/n/16.06 有
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 机
+......\TU/FandolSong(0)/m/n/16.06 机
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 非
+......\TU/FandolSong(0)/m/n/16.06 非
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 线
+......\TU/FandolSong(0)/m/n/16.06 线
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 性
+......\TU/FandolSong(0)/m/n/16.06 性
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 光
+......\TU/FandolSong(0)/m/n/16.06 光
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 学
+......\TU/FandolSong(0)/m/n/16.06 学
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 材
+......\TU/FandolSong(0)/m/n/16.06 材
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 料
+......\TU/FandolSong(0)/m/n/16.06 料
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 的
+......\TU/FandolSong(0)/m/n/16.06 的
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 探
+......\TU/FandolSong(0)/m/n/16.06 探
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 索
+......\TU/FandolSong(0)/m/n/16.06 索
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -144,38 +144,38 @@ Completed box being shipped out [1]
 ......\penalty 0
 ......\glue 0.0
 ......\rule(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 —
+......\TU/FandolSong(0)/m/n/16.06 —
 ......\penalty 10000
 ......\glue 0.0
-......\TU/FandolSong-Regular(0)/m/n/16.06 —
+......\TU/FandolSong(0)/m/n/16.06 —
 ......\rule(0.0+0.0)x0.0
 ......\glue 0.0
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 从
+......\TU/FandolSong(0)/m/n/16.06 从
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 分
+......\TU/FandolSong(0)/m/n/16.06 分
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 子
+......\TU/FandolSong(0)/m/n/16.06 子
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 到
+......\TU/FandolSong(0)/m/n/16.06 到
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 晶
+......\TU/FandolSong(0)/m/n/16.06 晶
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 体
+......\TU/FandolSong(0)/m/n/16.06 体
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 的
+......\TU/FandolSong(0)/m/n/16.06 的
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 材
+......\TU/FandolSong(0)/m/n/16.06 材
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 料
+......\TU/FandolSong(0)/m/n/16.06 料
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 化
+......\TU/FandolSong(0)/m/n/16.06 化
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 学
+......\TU/FandolSong(0)/m/n/16.06 学
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 过
+......\TU/FandolSong(0)/m/n/16.06 过
 ......\glue 0.0 plus 1.0538
-......\TU/FandolSong-Regular(0)/m/n/16.06 程
+......\TU/FandolSong(0)/m/n/16.06 程
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
@@ -231,7 +231,7 @@ Completed box being shipped out [1]
 ......\penalty 0
 ......\glue 0.0
 ......\rule(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/14.05249 —
+......\TU/FandolSong(0)/m/n/14.05249 —
 ......\rule(0.0+0.0)x0.0
 ......\glue 0.0
 ......\TU/texgyretermes(0)/m/n/14.05249 MATERIALS
@@ -265,7 +265,7 @@ Completed box being shipped out [1]
 ......\penalty 0
 ......\glue 0.0
 ......\rule(0.0+0.0)x0.0
-......\TU/FandolSong-Regular(0)/m/n/14.05249 —
+......\TU/FandolSong(0)/m/n/14.05249 —
 ......\rule(0.0+0.0)x0.0
 ......\glue 0.0
 ......\TU/texgyretermes(0)/m/n/14.05249 FROM
@@ -306,15 +306,15 @@ Completed box being shipped out [1]
 ........\glue 6.0
 ........\glue 0.00002
 ........\hbox(9.33487+2.10786)x132.49498, glue set 9.03375filll
-.........\TU/FandolSong-Regular(0)/m/n/12.045 博
+.........\TU/FandolSong(0)/m/n/12.045 博
 .........\glue 0.0 plus 2.0filll
-.........\TU/FandolSong-Regular(0)/m/n/12.045 士
+.........\TU/FandolSong(0)/m/n/12.045 士
 .........\glue 0.0 plus 2.0filll
-.........\TU/FandolSong-Regular(0)/m/n/12.045 后
+.........\TU/FandolSong(0)/m/n/12.045 后
 .........\glue 0.0 plus 2.0filll
-.........\TU/FandolSong-Regular(0)/m/n/12.045 姓
+.........\TU/FandolSong(0)/m/n/12.045 姓
 .........\glue 0.0 plus 2.0filll
-.........\TU/FandolSong-Regular(0)/m/n/12.045 名
+.........\TU/FandolSong(0)/m/n/12.045 名
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -323,9 +323,9 @@ Completed box being shipped out [1]
 .......\glue(\tabskip) 0.0
 .......\hbox(21.92184+9.3952)x90.315, glue set 60.22499fil
 ........\glue 0.00002
-........\TU/FandolSong-Regular(0)/m/n/12.045 方
+........\TU/FandolSong(0)/m/n/12.045 方
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 奇
+........\TU/FandolSong(0)/m/n/12.045 奇
 ........\kern -0.00017
 ........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
@@ -340,29 +340,29 @@ Completed box being shipped out [1]
 ........\glue 0.00002
 ........\hbox(9.636+2.40898)x132.49498
 .........\special{color push gray 0}
-.........\TU/FandolSong-Regular(0)/m/n/12.045 流
+.........\TU/FandolSong(0)/m/n/12.045 流
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 动
+.........\TU/FandolSong(0)/m/n/12.045 动
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 站
+.........\TU/FandolSong(0)/m/n/12.045 站
 .........\glue 0.0 plus 0.52307
 .........\glue 7.63654 minus 6.0225
 .........\rule(0.0+0.0)x-7.63654
-.........\TU/FandolSong-Regular(0)/m/n/12.045 （一
+.........\TU/FandolSong(0)/m/n/12.045 （一
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 级
+.........\TU/FandolSong(0)/m/n/12.045 级
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 学
+.........\TU/FandolSong(0)/m/n/12.045 学
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 科
+.........\TU/FandolSong(0)/m/n/12.045 科
 .........\penalty 10000
-.........\TU/FandolSong-Regular(0)/m/n/12.045 ）
+.........\TU/FandolSong(0)/m/n/12.045 ）
 .........\rule(0.0+0.0)x-7.63654
 .........\glue 7.63654 minus 6.0225
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 名
+.........\TU/FandolSong(0)/m/n/12.045 名
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 称
+.........\TU/FandolSong(0)/m/n/12.045 称
 .........\kern -0.00017
 .........\kern 0.00017
 .........\special{color pop}
@@ -371,19 +371,19 @@ Completed box being shipped out [1]
 .......\glue(\tabskip) 0.0
 .......\hbox(21.92184+9.3952)x90.315
 ........\glue 0.00002
-........\TU/FandolSong-Regular(0)/m/n/12.045 清
+........\TU/FandolSong(0)/m/n/12.045 清
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 华
+........\TU/FandolSong(0)/m/n/12.045 华
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 大
+........\TU/FandolSong(0)/m/n/12.045 大
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 学
+........\TU/FandolSong(0)/m/n/12.045 学
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 物
+........\TU/FandolSong(0)/m/n/12.045 物
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 理
+........\TU/FandolSong(0)/m/n/12.045 理
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 学
+........\TU/FandolSong(0)/m/n/12.045 学
 ........\kern -0.00017
 ........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
@@ -398,29 +398,29 @@ Completed box being shipped out [1]
 ........\glue 0.00002
 ........\hbox(9.636+2.40898)x132.49498
 .........\special{color push gray 0}
-.........\TU/FandolSong-Regular(0)/m/n/12.045 专
+.........\TU/FandolSong(0)/m/n/12.045 专
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 12.045
-.........\TU/FandolSong-Regular(0)/m/n/12.045 业
+.........\TU/FandolSong(0)/m/n/12.045 业
 .........\glue 0.0 plus 0.52307
 .........\glue 7.63654 minus 6.0225
 .........\rule(0.0+0.0)x-7.63654
-.........\TU/FandolSong-Regular(0)/m/n/12.045 （二
+.........\TU/FandolSong(0)/m/n/12.045 （二
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 级
+.........\TU/FandolSong(0)/m/n/12.045 级
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 学
+.........\TU/FandolSong(0)/m/n/12.045 学
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 科
+.........\TU/FandolSong(0)/m/n/12.045 科
 .........\penalty 10000
-.........\TU/FandolSong-Regular(0)/m/n/12.045 ）
+.........\TU/FandolSong(0)/m/n/12.045 ）
 .........\rule(0.0+0.0)x-7.63654
 .........\glue 7.63654 minus 6.0225
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 名
+.........\TU/FandolSong(0)/m/n/12.045 名
 .........\glue 0.0 plus 0.52307
-.........\TU/FandolSong-Regular(0)/m/n/12.045 称
+.........\TU/FandolSong(0)/m/n/12.045 称
 .........\kern -0.00017
 .........\kern 0.00017
 .........\special{color pop}
@@ -429,15 +429,15 @@ Completed box being shipped out [1]
 .......\glue(\tabskip) 0.0
 .......\hbox(21.92184+9.3952)x90.315, glue set 24.09fil
 ........\glue 0.00002
-........\TU/FandolSong-Regular(0)/m/n/12.045 凝
+........\TU/FandolSong(0)/m/n/12.045 凝
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 聚
+........\TU/FandolSong(0)/m/n/12.045 聚
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 态
+........\TU/FandolSong(0)/m/n/12.045 态
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 物
+........\TU/FandolSong(0)/m/n/12.045 物
 ........\glue 0.0 plus 0.52307
-........\TU/FandolSong-Regular(0)/m/n/12.045 理
+........\TU/FandolSong(0)/m/n/12.045 理
 ........\kern -0.00017
 ........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
@@ -453,21 +453,21 @@ Completed box being shipped out [1]
 ...\hbox(9.3951+2.13194)x426.79135, glue set 112.51883fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 起
+....\TU/FandolSong(0)/m/n/12.045 起
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 始
+....\TU/FandolSong(0)/m/n/12.045 始
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
@@ -475,15 +475,15 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 4
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 28
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -495,21 +495,21 @@ Completed box being shipped out [1]
 ...\hbox(9.3951+2.13194)x426.79135, glue set 112.51883fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 满
+....\TU/FandolSong(0)/m/n/12.045 满
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
@@ -517,15 +517,15 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 4
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 11
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -537,27 +537,27 @@ Completed box being shipped out [1]
 ...\hbox(9.636+2.40898)x426.79135, glue set 150.96646fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 清
+....\TU/FandolSong(0)/m/n/12.045 清
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 华
+....\TU/FandolSong(0)/m/n/12.045 华
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 事
+....\TU/FandolSong(0)/m/n/12.045 事
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （北
+....\TU/FandolSong(0)/m/n/12.045 （北
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 京
+....\TU/FandolSong(0)/m/n/12.045 京
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\kern 0.00047
 ....\kern -0.00047
@@ -576,11 +576,11 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 6
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 月
+....\TU/FandolSong(0)/m/n/10.53937 月
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000

--- a/testfiles/02-copyright-bachelor.tlg
+++ b/testfiles/02-copyright-bachelor.tlg
@@ -104,31 +104,31 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolHei-Regular(0)/m/n/22.08249 关
+....\TU/FandolHei(0)/m/n/22.08249 关
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 于
+....\TU/FandolHei(0)/m/n/22.08249 于
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 学
+....\TU/FandolHei(0)/m/n/22.08249 学
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 位
+....\TU/FandolHei(0)/m/n/22.08249 位
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 论
+....\TU/FandolHei(0)/m/n/22.08249 论
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 文
+....\TU/FandolHei(0)/m/n/22.08249 文
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 使
+....\TU/FandolHei(0)/m/n/22.08249 使
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 用
+....\TU/FandolHei(0)/m/n/22.08249 用
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 授
+....\TU/FandolHei(0)/m/n/22.08249 授
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 权
+....\TU/FandolHei(0)/m/n/22.08249 权
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 的
+....\TU/FandolHei(0)/m/n/22.08249 的
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 说
+....\TU/FandolHei(0)/m/n/22.08249 说
 ....\glue 0.0 plus 1.38918
-....\TU/FandolHei-Regular(0)/m/n/22.08249 明
+....\TU/FandolHei(0)/m/n/22.08249 明
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -141,213 +141,213 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 6.6629
 ...\hbox(9.50351+2.32468)x421.10089, glue set - 0.02623
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 完
+....\TU/FandolSong(0)/m/n/12.045 完
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 清
+....\TU/FandolSong(0)/m/n/12.045 清
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 华
+....\TU/FandolSong(0)/m/n/12.045 华
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 保
+....\TU/FandolSong(0)/m/n/12.045 保
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 留
+....\TU/FandolSong(0)/m/n/12.045 留
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 即
+....\TU/FandolSong(0)/m/n/12.045 即
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\glue 8.39537 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 校
+....\TU/FandolSong(0)/m/n/12.045 校
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 权
+....\TU/FandolSong(0)/m/n/12.045 权
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 保
+....\TU/FandolSong(0)/m/n/12.045 保
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 留
+....\TU/FandolSong(0)/m/n/12.045 留
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set - 0.03935
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 复
+....\TU/FandolSong(0)/m/n/12.045 复
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 印
+....\TU/FandolSong(0)/m/n/12.045 印
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 允
+....\TU/FandolSong(0)/m/n/12.045 允
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 许
+....\TU/FandolSong(0)/m/n/12.045 许
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 查
+....\TU/FandolSong(0)/m/n/12.045 查
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 阅
+....\TU/FandolSong(0)/m/n/12.045 阅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 借
+....\TU/FandolSong(0)/m/n/12.045 借
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 阅
+....\TU/FandolSong(0)/m/n/12.045 阅
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 校
+....\TU/FandolSong(0)/m/n/12.045 校
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 公
+....\TU/FandolSong(0)/m/n/12.045 公
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.28296
 ...\hbox(9.46736+2.32468)x421.10089, glue set 115.68791fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 采
+....\TU/FandolSong(0)/m/n/12.045 采
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 影
+....\TU/FandolSong(0)/m/n/12.045 影
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 印
+....\TU/FandolSong(0)/m/n/12.045 印
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 缩
+....\TU/FandolSong(0)/m/n/12.045 缩
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 印
+....\TU/FandolSong(0)/m/n/12.045 印
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 复
+....\TU/FandolSong(0)/m/n/12.045 复
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 手
+....\TU/FandolSong(0)/m/n/12.045 手
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 保
+....\TU/FandolSong(0)/m/n/12.045 保
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -361,39 +361,39 @@ Completed box being shipped out [1]
 ...\hbox(9.2867+2.07173)x421.10089, glue set 184.22395fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/b/n/12.045 (
-....\TU/FandolSong-Regular(0)/b/n/12.045 涉
+....\TU/FandolSong(0)/b/n/12.045 涉
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 密
+....\TU/FandolSong(0)/b/n/12.045 密
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 的
+....\TU/FandolSong(0)/b/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 学
+....\TU/FandolSong(0)/b/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 位
+....\TU/FandolSong(0)/b/n/12.045 位
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 论
+....\TU/FandolSong(0)/b/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 文
+....\TU/FandolSong(0)/b/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 在
+....\TU/FandolSong(0)/b/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 解
+....\TU/FandolSong(0)/b/n/12.045 解
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 密
+....\TU/FandolSong(0)/b/n/12.045 密
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 后
+....\TU/FandolSong(0)/b/n/12.045 后
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 应
+....\TU/FandolSong(0)/b/n/12.045 应
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 遵
+....\TU/FandolSong(0)/b/n/12.045 遵
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 守
+....\TU/FandolSong(0)/b/n/12.045 守
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 此
+....\TU/FandolSong(0)/b/n/12.045 此
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 规
+....\TU/FandolSong(0)/b/n/12.045 规
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/b/n/12.045 定
+....\TU/FandolSong(0)/b/n/12.045 定
 ....\TU/texgyretermes(0)/b/n/12.045 )
 ....\kern 0.0
 ....\kern -0.0002
@@ -407,13 +407,13 @@ Completed box being shipped out [1]
 ...\hbox(9.32283+3.97446)x421.10089, glue set 11.61595fil
 ....\hbox(0.0+0.0)x24.09
 ....\hbox(9.32283+3.97446)x385.39494
-.....\TU/FandolSong-Regular(0)/m/n/12.045 签
+.....\TU/FandolSong(0)/m/n/12.045 签
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 12.045
-.....\TU/FandolSong-Regular(0)/m/n/12.045 名
+.....\TU/FandolSong(0)/m/n/12.045 名
 .....\penalty 10000
-.....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+.....\TU/FandolSong(0)/m/n/12.045 ：
 .....\rule(0.0+0.0)x-8.39537
 .....\kern 0.00052
 .....\kern -0.00052
@@ -431,15 +431,15 @@ Completed box being shipped out [1]
 ......\rule(0.79489+0.0)x*
 .....\mathoff
 .....\glue 3.0
-.....\TU/FandolSong-Regular(0)/m/n/12.045 导
+.....\TU/FandolSong(0)/m/n/12.045 导
 .....\glue 0.0 plus 0.73799
-.....\TU/FandolSong-Regular(0)/m/n/12.045 师
+.....\TU/FandolSong(0)/m/n/12.045 师
 .....\glue 0.0 plus 0.73799
-.....\TU/FandolSong-Regular(0)/m/n/12.045 签
+.....\TU/FandolSong(0)/m/n/12.045 签
 .....\glue 0.0 plus 0.73799
-.....\TU/FandolSong-Regular(0)/m/n/12.045 名
+.....\TU/FandolSong(0)/m/n/12.045 名
 .....\penalty 10000
-.....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+.....\TU/FandolSong(0)/m/n/12.045 ：
 .....\rule(0.0+0.0)x-8.39537
 .....\kern 0.00052
 .....\kern -0.00052
@@ -457,13 +457,13 @@ Completed box being shipped out [1]
 ......\rule(0.79489+0.0)x*
 .....\mathoff
 .....\glue 3.0
-.....\TU/FandolSong-Regular(0)/m/n/12.045 日
+.....\TU/FandolSong(0)/m/n/12.045 日
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 12.045
-.....\TU/FandolSong-Regular(0)/m/n/12.045 期
+.....\TU/FandolSong(0)/m/n/12.045 期
 .....\penalty 10000
-.....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+.....\TU/FandolSong(0)/m/n/12.045 ：
 .....\rule(0.0+0.0)x-8.39537
 .....\kern 0.00052
 .....\kern -0.00052

--- a/testfiles/02-copyright-doctor.tlg
+++ b/testfiles/02-copyright-doctor.tlg
@@ -114,31 +114,31 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolHei-Regular(0)/m/n/22.08249 关
+....\TU/FandolHei(0)/m/n/22.08249 关
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 于
+....\TU/FandolHei(0)/m/n/22.08249 于
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 学
+....\TU/FandolHei(0)/m/n/22.08249 学
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 位
+....\TU/FandolHei(0)/m/n/22.08249 位
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 论
+....\TU/FandolHei(0)/m/n/22.08249 论
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 文
+....\TU/FandolHei(0)/m/n/22.08249 文
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 使
+....\TU/FandolHei(0)/m/n/22.08249 使
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 用
+....\TU/FandolHei(0)/m/n/22.08249 用
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 授
+....\TU/FandolHei(0)/m/n/22.08249 授
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 权
+....\TU/FandolHei(0)/m/n/22.08249 权
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 的
+....\TU/FandolHei(0)/m/n/22.08249 的
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 说
+....\TU/FandolHei(0)/m/n/22.08249 说
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 明
+....\TU/FandolHei(0)/m/n/22.08249 明
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -149,63 +149,63 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 13.53053
 ...\hbox(11.08742+2.71211)x421.66989, glue set 23.94226fil, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
-....\TU/FandolSong-Regular(0)/m/n/14.05249 本
+....\TU/FandolSong(0)/m/n/14.05249 本
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 人
+....\TU/FandolSong(0)/m/n/14.05249 人
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 完
+....\TU/FandolSong(0)/m/n/14.05249 完
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 全
+....\TU/FandolSong(0)/m/n/14.05249 全
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 了
+....\TU/FandolSong(0)/m/n/14.05249 了
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 解
+....\TU/FandolSong(0)/m/n/14.05249 解
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 清
+....\TU/FandolSong(0)/m/n/14.05249 清
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 华
+....\TU/FandolSong(0)/m/n/14.05249 华
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 大
+....\TU/FandolSong(0)/m/n/14.05249 大
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 有
+....\TU/FandolSong(0)/m/n/14.05249 有
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 关
+....\TU/FandolSong(0)/m/n/14.05249 关
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 保
+....\TU/FandolSong(0)/m/n/14.05249 保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 留
+....\TU/FandolSong(0)/m/n/14.05249 留
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 、
+....\TU/FandolSong(0)/m/n/14.05249 、
 ....\rule(0.0+0.0)x-9.16223
 ....\glue 9.16223 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 使
+....\TU/FandolSong(0)/m/n/14.05249 使
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 用
+....\TU/FandolSong(0)/m/n/14.05249 用
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 即
+....\TU/FandolSong(0)/m/n/14.05249 即
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ：
+....\TU/FandolSong(0)/m/n/14.05249 ：
 ....\rule(0.0+0.0)x-9.79459
 ....\kern 0.0006
 ....\kern -0.0006
@@ -218,435 +218,435 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 14.727
 ...\hbox(11.08742+2.71211)x421.66989, glue set 0.00725, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
-....\TU/FandolSong-Regular(0)/m/n/14.05249 清
+....\TU/FandolSong(0)/m/n/14.05249 清
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 华
+....\TU/FandolSong(0)/m/n/14.05249 华
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 大
+....\TU/FandolSong(0)/m/n/14.05249 大
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 拥
+....\TU/FandolSong(0)/m/n/14.05249 拥
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 有
+....\TU/FandolSong(0)/m/n/14.05249 有
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 在
+....\TU/FandolSong(0)/m/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 著
+....\TU/FandolSong(0)/m/n/14.05249 著
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 作
+....\TU/FandolSong(0)/m/n/14.05249 作
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 权
+....\TU/FandolSong(0)/m/n/14.05249 权
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 法
+....\TU/FandolSong(0)/m/n/14.05249 法
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 范
+....\TU/FandolSong(0)/m/n/14.05249 范
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 围
+....\TU/FandolSong(0)/m/n/14.05249 围
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 使
+....\TU/FandolSong(0)/m/n/14.05249 使
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 用
+....\TU/FandolSong(0)/m/n/14.05249 用
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 权
+....\TU/FandolSong(0)/m/n/14.05249 权
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 其
+....\TU/FandolSong(0)/m/n/14.05249 其
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 中
+....\TU/FandolSong(0)/m/n/14.05249 中
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 包
+....\TU/FandolSong(0)/m/n/14.05249 包
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 14.57243
 ...\hbox(11.24199+2.81049)x421.66989, glue set - 0.60785, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 括
+....\TU/FandolSong(0)/m/n/14.05249 括
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ：
+....\TU/FandolSong(0)/m/n/14.05249 ：
 ....\penalty 10000
 ....\glue -7.02625 plus 7.02625 minus 8.90929
-....\TU/FandolSong-Regular(0)/m/n/14.05249 （
+....\TU/FandolSong(0)/m/n/14.05249 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/14.05249 1
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ）
+....\TU/FandolSong(0)/m/n/14.05249 ）
 ....\rule(0.0+0.0)x-8.90929
 ....\glue 8.90929 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 已
+....\TU/FandolSong(0)/m/n/14.05249 已
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 获
+....\TU/FandolSong(0)/m/n/14.05249 获
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 研
+....\TU/FandolSong(0)/m/n/14.05249 研
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 究
+....\TU/FandolSong(0)/m/n/14.05249 究
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 必
+....\TU/FandolSong(0)/m/n/14.05249 必
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 须
+....\TU/FandolSong(0)/m/n/14.05249 须
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 按
+....\TU/FandolSong(0)/m/n/14.05249 按
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 提
+....\TU/FandolSong(0)/m/n/14.05249 提
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 交
+....\TU/FandolSong(0)/m/n/14.05249 交
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 可
+....\TU/FandolSong(0)/m/n/14.05249 可
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 以
+....\TU/FandolSong(0)/m/n/14.05249 以
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 采
+....\TU/FandolSong(0)/m/n/14.05249 采
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 14.47406
 ...\hbox(11.24199+2.81049)x421.66989, glue set - 0.60785, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 用
+....\TU/FandolSong(0)/m/n/14.05249 用
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 影
+....\TU/FandolSong(0)/m/n/14.05249 影
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 印
+....\TU/FandolSong(0)/m/n/14.05249 印
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 、
+....\TU/FandolSong(0)/m/n/14.05249 、
 ....\rule(0.0+0.0)x-9.16223
 ....\glue 9.16223 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 缩
+....\TU/FandolSong(0)/m/n/14.05249 缩
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 印
+....\TU/FandolSong(0)/m/n/14.05249 印
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 或
+....\TU/FandolSong(0)/m/n/14.05249 或
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 其
+....\TU/FandolSong(0)/m/n/14.05249 其
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 他
+....\TU/FandolSong(0)/m/n/14.05249 他
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 复
+....\TU/FandolSong(0)/m/n/14.05249 复
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 制
+....\TU/FandolSong(0)/m/n/14.05249 制
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 手
+....\TU/FandolSong(0)/m/n/14.05249 手
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 段
+....\TU/FandolSong(0)/m/n/14.05249 段
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 保
+....\TU/FandolSong(0)/m/n/14.05249 保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 存
+....\TU/FandolSong(0)/m/n/14.05249 存
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 研
+....\TU/FandolSong(0)/m/n/14.05249 研
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 究
+....\TU/FandolSong(0)/m/n/14.05249 究
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 上
+....\TU/FandolSong(0)/m/n/14.05249 上
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 交
+....\TU/FandolSong(0)/m/n/14.05249 交
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ；
+....\TU/FandolSong(0)/m/n/14.05249 ；
 ....\penalty 10000
 ....\glue -7.02625 plus 7.02625 minus 8.90929
-....\TU/FandolSong-Regular(0)/m/n/14.05249 （
+....\TU/FandolSong(0)/m/n/14.05249 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/14.05249 2
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ）
+....\TU/FandolSong(0)/m/n/14.05249 ）
 ....\rule(0.0+0.0)x-8.90929
 ....\glue 8.90929 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 为
+....\TU/FandolSong(0)/m/n/14.05249 为
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 教
+....\TU/FandolSong(0)/m/n/14.05249 教
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 14.75511
 ...\hbox(10.96094+2.71211)x421.66989, glue set 0.00697, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 和
+....\TU/FandolSong(0)/m/n/14.05249 和
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 科
+....\TU/FandolSong(0)/m/n/14.05249 科
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 研
+....\TU/FandolSong(0)/m/n/14.05249 研
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 目
+....\TU/FandolSong(0)/m/n/14.05249 目
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 可
+....\TU/FandolSong(0)/m/n/14.05249 可
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 以
+....\TU/FandolSong(0)/m/n/14.05249 以
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 将
+....\TU/FandolSong(0)/m/n/14.05249 将
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 公
+....\TU/FandolSong(0)/m/n/14.05249 公
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 开
+....\TU/FandolSong(0)/m/n/14.05249 开
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 作
+....\TU/FandolSong(0)/m/n/14.05249 作
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 为
+....\TU/FandolSong(0)/m/n/14.05249 为
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 资
+....\TU/FandolSong(0)/m/n/14.05249 资
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 料
+....\TU/FandolSong(0)/m/n/14.05249 料
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 在
+....\TU/FandolSong(0)/m/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 图
+....\TU/FandolSong(0)/m/n/14.05249 图
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 书
+....\TU/FandolSong(0)/m/n/14.05249 书
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 馆
+....\TU/FandolSong(0)/m/n/14.05249 馆
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 、
+....\TU/FandolSong(0)/m/n/14.05249 、
 ....\rule(0.0+0.0)x-9.16223
 ....\glue 9.16223 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 资
+....\TU/FandolSong(0)/m/n/14.05249 资
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 料
+....\TU/FandolSong(0)/m/n/14.05249 料
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 室
+....\TU/FandolSong(0)/m/n/14.05249 室
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 14.57243
 ...\hbox(11.24199+2.81049)x421.66989, glue set - 0.31677, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 等
+....\TU/FandolSong(0)/m/n/14.05249 等
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 场
+....\TU/FandolSong(0)/m/n/14.05249 场
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 所
+....\TU/FandolSong(0)/m/n/14.05249 所
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 供
+....\TU/FandolSong(0)/m/n/14.05249 供
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 师
+....\TU/FandolSong(0)/m/n/14.05249 师
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 阅
+....\TU/FandolSong(0)/m/n/14.05249 阅
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 读
+....\TU/FandolSong(0)/m/n/14.05249 读
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 或
+....\TU/FandolSong(0)/m/n/14.05249 或
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 在
+....\TU/FandolSong(0)/m/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 园
+....\TU/FandolSong(0)/m/n/14.05249 园
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 网
+....\TU/FandolSong(0)/m/n/14.05249 网
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 上
+....\TU/FandolSong(0)/m/n/14.05249 上
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 供
+....\TU/FandolSong(0)/m/n/14.05249 供
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 师
+....\TU/FandolSong(0)/m/n/14.05249 师
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 浏
+....\TU/FandolSong(0)/m/n/14.05249 浏
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 览
+....\TU/FandolSong(0)/m/n/14.05249 览
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 部
+....\TU/FandolSong(0)/m/n/14.05249 部
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 分
+....\TU/FandolSong(0)/m/n/14.05249 分
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 容
+....\TU/FandolSong(0)/m/n/14.05249 容
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ；
+....\TU/FandolSong(0)/m/n/14.05249 ；
 ....\rule(0.0+0.0)x-9.71027
 ....\penalty 10000
 ....\glue 11.5933 plus 7.02625 minus 8.90929
 ....\rule(0.0+0.0)x-8.90929
-....\TU/FandolSong-Regular(0)/m/n/14.05249 （
+....\TU/FandolSong(0)/m/n/14.05249 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/14.05249 3
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ）
+....\TU/FandolSong(0)/m/n/14.05249 ）
 ....\rule(0.0+0.0)x-8.90929
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 14.75511
 ...\hbox(10.96094+2.71211)x421.66989, glue set 0.35318, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 根
+....\TU/FandolSong(0)/m/n/14.05249 根
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 据
+....\TU/FandolSong(0)/m/n/14.05249 据
 ....\glue 0.0 plus 0.50528
 ....\glue 7.65862 minus 7.0122
 ....\rule(0.0+0.0)x-7.65862
-....\TU/FandolSong-Regular(0)/m/n/14.05249 《中
+....\TU/FandolSong(0)/m/n/14.05249 《中
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 华
+....\TU/FandolSong(0)/m/n/14.05249 华
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 人
+....\TU/FandolSong(0)/m/n/14.05249 人
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 民
+....\TU/FandolSong(0)/m/n/14.05249 民
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 共
+....\TU/FandolSong(0)/m/n/14.05249 共
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 和
+....\TU/FandolSong(0)/m/n/14.05249 和
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 国
+....\TU/FandolSong(0)/m/n/14.05249 国
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 条
+....\TU/FandolSong(0)/m/n/14.05249 条
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 例
+....\TU/FandolSong(0)/m/n/14.05249 例
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 暂
+....\TU/FandolSong(0)/m/n/14.05249 暂
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 行
+....\TU/FandolSong(0)/m/n/14.05249 行
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 实
+....\TU/FandolSong(0)/m/n/14.05249 实
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 施
+....\TU/FandolSong(0)/m/n/14.05249 施
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 办
+....\TU/FandolSong(0)/m/n/14.05249 办
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 法
+....\TU/FandolSong(0)/m/n/14.05249 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 》
+....\TU/FandolSong(0)/m/n/14.05249 》
 ....\penalty 10000
 ....\glue -7.02625 plus 7.02625 minus 0.64641
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 向
+....\TU/FandolSong(0)/m/n/14.05249 向
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 国
+....\TU/FandolSong(0)/m/n/14.05249 国
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 家
+....\TU/FandolSong(0)/m/n/14.05249 家
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 图
+....\TU/FandolSong(0)/m/n/14.05249 图
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 书
+....\TU/FandolSong(0)/m/n/14.05249 书
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 馆
+....\TU/FandolSong(0)/m/n/14.05249 馆
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 报
+....\TU/FandolSong(0)/m/n/14.05249 报
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 送
+....\TU/FandolSong(0)/m/n/14.05249 送
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 14.85349
 ...\hbox(10.96094+2.36081)x421.66989, glue set 290.1948fil, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 可
+....\TU/FandolSong(0)/m/n/14.05249 可
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 以
+....\TU/FandolSong(0)/m/n/14.05249 以
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 公
+....\TU/FandolSong(0)/m/n/14.05249 公
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 开
+....\TU/FandolSong(0)/m/n/14.05249 开
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 。
+....\TU/FandolSong(0)/m/n/14.05249 。
 ....\rule(0.0+0.0)x-9.0498
 ....\kern 0.00055
 ....\kern -0.00055
@@ -659,27 +659,27 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 15.12047
 ...\hbox(11.04526+2.58565)x421.66989, glue set 248.03732fil, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
-....\TU/FandolSong-Regular(0)/m/n/14.05249 本
+....\TU/FandolSong(0)/m/n/14.05249 本
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 人
+....\TU/FandolSong(0)/m/n/14.05249 人
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 保
+....\TU/FandolSong(0)/m/n/14.05249 保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 证
+....\TU/FandolSong(0)/m/n/14.05249 证
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 遵
+....\TU/FandolSong(0)/m/n/14.05249 遵
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 守
+....\TU/FandolSong(0)/m/n/14.05249 守
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 上
+....\TU/FandolSong(0)/m/n/14.05249 上
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 述
+....\TU/FandolSong(0)/m/n/14.05249 述
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 。
+....\TU/FandolSong(0)/m/n/14.05249 。
 ....\rule(0.0+0.0)x-9.0498
 ....\kern 0.00055
 ....\kern -0.00055
@@ -693,37 +693,37 @@ Completed box being shipped out [1]
 ...\hbox(11.22794+2.81049)x421.66989, glue set 172.37872fil, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
 ....\rule(0.0+0.0)x-8.85307
-....\TU/FandolSong-Regular(0)/b/n/14.05249 （保
+....\TU/FandolSong(0)/b/n/14.05249 （保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 密
+....\TU/FandolSong(0)/b/n/14.05249 密
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 的
+....\TU/FandolSong(0)/b/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 论
+....\TU/FandolSong(0)/b/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 文
+....\TU/FandolSong(0)/b/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 在
+....\TU/FandolSong(0)/b/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 解
+....\TU/FandolSong(0)/b/n/14.05249 解
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 密
+....\TU/FandolSong(0)/b/n/14.05249 密
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 后
+....\TU/FandolSong(0)/b/n/14.05249 后
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 应
+....\TU/FandolSong(0)/b/n/14.05249 应
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 遵
+....\TU/FandolSong(0)/b/n/14.05249 遵
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 守
+....\TU/FandolSong(0)/b/n/14.05249 守
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 此
+....\TU/FandolSong(0)/b/n/14.05249 此
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 规
+....\TU/FandolSong(0)/b/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 定
+....\TU/FandolSong(0)/b/n/14.05249 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/b/n/14.05249 ）
+....\TU/FandolSong(0)/b/n/14.05249 ）
 ....\rule(0.0+0.0)x-8.85307
 ....\kern 0.00053
 ....\kern -0.00053
@@ -741,15 +741,15 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 42.67912
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 者
+....\TU/FandolSong(0)/m/n/12.045 者
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 签
+....\TU/FandolSong(0)/m/n/12.045 签
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -768,15 +768,15 @@ Completed box being shipped out [1]
 ....\mathoff
 ....\glue 3.0
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 师
+....\TU/FandolSong(0)/m/n/12.045 师
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 签
+....\TU/FandolSong(0)/m/n/12.045 签
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -809,13 +809,13 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 42.67912
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -834,13 +834,13 @@ Completed box being shipped out [1]
 ....\mathoff
 ....\glue 3.0
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052

--- a/testfiles/02-copyright-master.tlg
+++ b/testfiles/02-copyright-master.tlg
@@ -114,31 +114,31 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolHei-Regular(0)/m/n/22.08249 关
+....\TU/FandolHei(0)/m/n/22.08249 关
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 于
+....\TU/FandolHei(0)/m/n/22.08249 于
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 学
+....\TU/FandolHei(0)/m/n/22.08249 学
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 位
+....\TU/FandolHei(0)/m/n/22.08249 位
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 论
+....\TU/FandolHei(0)/m/n/22.08249 论
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 文
+....\TU/FandolHei(0)/m/n/22.08249 文
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 使
+....\TU/FandolHei(0)/m/n/22.08249 使
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 用
+....\TU/FandolHei(0)/m/n/22.08249 用
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 授
+....\TU/FandolHei(0)/m/n/22.08249 授
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 权
+....\TU/FandolHei(0)/m/n/22.08249 权
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 的
+....\TU/FandolHei(0)/m/n/22.08249 的
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 说
+....\TU/FandolHei(0)/m/n/22.08249 说
 ....\glue 0.0 plus 1.42265
-....\TU/FandolHei-Regular(0)/m/n/22.08249 明
+....\TU/FandolHei(0)/m/n/22.08249 明
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -149,63 +149,63 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 13.53053
 ...\hbox(11.08742+2.71211)x421.66989, glue set 23.94226fil, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
-....\TU/FandolSong-Regular(0)/m/n/14.05249 本
+....\TU/FandolSong(0)/m/n/14.05249 本
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 人
+....\TU/FandolSong(0)/m/n/14.05249 人
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 完
+....\TU/FandolSong(0)/m/n/14.05249 完
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 全
+....\TU/FandolSong(0)/m/n/14.05249 全
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 了
+....\TU/FandolSong(0)/m/n/14.05249 了
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 解
+....\TU/FandolSong(0)/m/n/14.05249 解
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 清
+....\TU/FandolSong(0)/m/n/14.05249 清
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 华
+....\TU/FandolSong(0)/m/n/14.05249 华
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 大
+....\TU/FandolSong(0)/m/n/14.05249 大
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 有
+....\TU/FandolSong(0)/m/n/14.05249 有
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 关
+....\TU/FandolSong(0)/m/n/14.05249 关
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 保
+....\TU/FandolSong(0)/m/n/14.05249 保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 留
+....\TU/FandolSong(0)/m/n/14.05249 留
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 、
+....\TU/FandolSong(0)/m/n/14.05249 、
 ....\rule(0.0+0.0)x-9.16223
 ....\glue 9.16223 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 使
+....\TU/FandolSong(0)/m/n/14.05249 使
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 用
+....\TU/FandolSong(0)/m/n/14.05249 用
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 即
+....\TU/FandolSong(0)/m/n/14.05249 即
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ：
+....\TU/FandolSong(0)/m/n/14.05249 ：
 ....\rule(0.0+0.0)x-9.79459
 ....\kern 0.0006
 ....\kern -0.0006
@@ -218,337 +218,337 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 14.727
 ...\hbox(11.08742+2.71211)x421.66989, glue set 0.00725, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
-....\TU/FandolSong-Regular(0)/m/n/14.05249 清
+....\TU/FandolSong(0)/m/n/14.05249 清
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 华
+....\TU/FandolSong(0)/m/n/14.05249 华
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 大
+....\TU/FandolSong(0)/m/n/14.05249 大
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 拥
+....\TU/FandolSong(0)/m/n/14.05249 拥
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 有
+....\TU/FandolSong(0)/m/n/14.05249 有
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 在
+....\TU/FandolSong(0)/m/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 著
+....\TU/FandolSong(0)/m/n/14.05249 著
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 作
+....\TU/FandolSong(0)/m/n/14.05249 作
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 权
+....\TU/FandolSong(0)/m/n/14.05249 权
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 法
+....\TU/FandolSong(0)/m/n/14.05249 法
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 范
+....\TU/FandolSong(0)/m/n/14.05249 范
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 围
+....\TU/FandolSong(0)/m/n/14.05249 围
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 使
+....\TU/FandolSong(0)/m/n/14.05249 使
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 用
+....\TU/FandolSong(0)/m/n/14.05249 用
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 权
+....\TU/FandolSong(0)/m/n/14.05249 权
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 其
+....\TU/FandolSong(0)/m/n/14.05249 其
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 中
+....\TU/FandolSong(0)/m/n/14.05249 中
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 包
+....\TU/FandolSong(0)/m/n/14.05249 包
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 14.57243
 ...\hbox(11.24199+2.81049)x421.66989, glue set 0.00484, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 括
+....\TU/FandolSong(0)/m/n/14.05249 括
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ：
+....\TU/FandolSong(0)/m/n/14.05249 ：
 ....\penalty 10000
 ....\glue -7.02625 plus 7.02625 minus 8.90929
-....\TU/FandolSong-Regular(0)/m/n/14.05249 （
+....\TU/FandolSong(0)/m/n/14.05249 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/14.05249 1
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ）
+....\TU/FandolSong(0)/m/n/14.05249 ）
 ....\rule(0.0+0.0)x-8.90929
 ....\glue 8.90929 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 已
+....\TU/FandolSong(0)/m/n/14.05249 已
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 获
+....\TU/FandolSong(0)/m/n/14.05249 获
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 研
+....\TU/FandolSong(0)/m/n/14.05249 研
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 究
+....\TU/FandolSong(0)/m/n/14.05249 究
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 必
+....\TU/FandolSong(0)/m/n/14.05249 必
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 须
+....\TU/FandolSong(0)/m/n/14.05249 须
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 按
+....\TU/FandolSong(0)/m/n/14.05249 按
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 提
+....\TU/FandolSong(0)/m/n/14.05249 提
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 交
+....\TU/FandolSong(0)/m/n/14.05249 交
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 可
+....\TU/FandolSong(0)/m/n/14.05249 可
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 以
+....\TU/FandolSong(0)/m/n/14.05249 以
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 14.47406
 ...\hbox(11.24199+2.81049)x421.66989, glue set - 0.60785, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 采
+....\TU/FandolSong(0)/m/n/14.05249 采
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 用
+....\TU/FandolSong(0)/m/n/14.05249 用
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 影
+....\TU/FandolSong(0)/m/n/14.05249 影
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 印
+....\TU/FandolSong(0)/m/n/14.05249 印
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 、
+....\TU/FandolSong(0)/m/n/14.05249 、
 ....\rule(0.0+0.0)x-9.16223
 ....\glue 9.16223 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 缩
+....\TU/FandolSong(0)/m/n/14.05249 缩
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 印
+....\TU/FandolSong(0)/m/n/14.05249 印
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 或
+....\TU/FandolSong(0)/m/n/14.05249 或
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 其
+....\TU/FandolSong(0)/m/n/14.05249 其
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 他
+....\TU/FandolSong(0)/m/n/14.05249 他
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 复
+....\TU/FandolSong(0)/m/n/14.05249 复
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 制
+....\TU/FandolSong(0)/m/n/14.05249 制
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 手
+....\TU/FandolSong(0)/m/n/14.05249 手
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 段
+....\TU/FandolSong(0)/m/n/14.05249 段
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 保
+....\TU/FandolSong(0)/m/n/14.05249 保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 存
+....\TU/FandolSong(0)/m/n/14.05249 存
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 研
+....\TU/FandolSong(0)/m/n/14.05249 研
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 究
+....\TU/FandolSong(0)/m/n/14.05249 究
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 上
+....\TU/FandolSong(0)/m/n/14.05249 上
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 交
+....\TU/FandolSong(0)/m/n/14.05249 交
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ；
+....\TU/FandolSong(0)/m/n/14.05249 ；
 ....\penalty 10000
 ....\glue -7.02625 plus 7.02625 minus 8.90929
-....\TU/FandolSong-Regular(0)/m/n/14.05249 （
+....\TU/FandolSong(0)/m/n/14.05249 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/14.05249 2
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ）
+....\TU/FandolSong(0)/m/n/14.05249 ）
 ....\rule(0.0+0.0)x-8.90929
 ....\glue 8.90929 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 为
+....\TU/FandolSong(0)/m/n/14.05249 为
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 教
+....\TU/FandolSong(0)/m/n/14.05249 教
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 14.75511
 ...\hbox(10.96094+2.71211)x421.66989, glue set 0.00697, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 和
+....\TU/FandolSong(0)/m/n/14.05249 和
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 科
+....\TU/FandolSong(0)/m/n/14.05249 科
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 研
+....\TU/FandolSong(0)/m/n/14.05249 研
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 目
+....\TU/FandolSong(0)/m/n/14.05249 目
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 可
+....\TU/FandolSong(0)/m/n/14.05249 可
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 以
+....\TU/FandolSong(0)/m/n/14.05249 以
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 将
+....\TU/FandolSong(0)/m/n/14.05249 将
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 公
+....\TU/FandolSong(0)/m/n/14.05249 公
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 开
+....\TU/FandolSong(0)/m/n/14.05249 开
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 的
+....\TU/FandolSong(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 学
+....\TU/FandolSong(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 位
+....\TU/FandolSong(0)/m/n/14.05249 位
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 论
+....\TU/FandolSong(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 文
+....\TU/FandolSong(0)/m/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 作
+....\TU/FandolSong(0)/m/n/14.05249 作
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 为
+....\TU/FandolSong(0)/m/n/14.05249 为
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 资
+....\TU/FandolSong(0)/m/n/14.05249 资
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 料
+....\TU/FandolSong(0)/m/n/14.05249 料
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 在
+....\TU/FandolSong(0)/m/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 图
+....\TU/FandolSong(0)/m/n/14.05249 图
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 书
+....\TU/FandolSong(0)/m/n/14.05249 书
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 馆
+....\TU/FandolSong(0)/m/n/14.05249 馆
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 、
+....\TU/FandolSong(0)/m/n/14.05249 、
 ....\rule(0.0+0.0)x-9.16223
 ....\glue 9.16223 minus 7.02626
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 资
+....\TU/FandolSong(0)/m/n/14.05249 资
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 料
+....\TU/FandolSong(0)/m/n/14.05249 料
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 14.82538
 ...\hbox(10.98904+2.71211)x421.66989, glue set 9.14499fil, shifted 2.56073
-....\TU/FandolSong-Regular(0)/m/n/14.05249 室
+....\TU/FandolSong(0)/m/n/14.05249 室
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 等
+....\TU/FandolSong(0)/m/n/14.05249 等
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 场
+....\TU/FandolSong(0)/m/n/14.05249 场
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 所
+....\TU/FandolSong(0)/m/n/14.05249 所
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 供
+....\TU/FandolSong(0)/m/n/14.05249 供
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 师
+....\TU/FandolSong(0)/m/n/14.05249 师
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 阅
+....\TU/FandolSong(0)/m/n/14.05249 阅
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 读
+....\TU/FandolSong(0)/m/n/14.05249 读
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 ，
+....\TU/FandolSong(0)/m/n/14.05249 ，
 ....\rule(0.0+0.0)x-9.72432
 ....\glue 9.72432 minus 7.02625
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 或
+....\TU/FandolSong(0)/m/n/14.05249 或
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 在
+....\TU/FandolSong(0)/m/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 园
+....\TU/FandolSong(0)/m/n/14.05249 园
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 网
+....\TU/FandolSong(0)/m/n/14.05249 网
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 上
+....\TU/FandolSong(0)/m/n/14.05249 上
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 供
+....\TU/FandolSong(0)/m/n/14.05249 供
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 校
+....\TU/FandolSong(0)/m/n/14.05249 校
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 师
+....\TU/FandolSong(0)/m/n/14.05249 师
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 生
+....\TU/FandolSong(0)/m/n/14.05249 生
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 浏
+....\TU/FandolSong(0)/m/n/14.05249 浏
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 览
+....\TU/FandolSong(0)/m/n/14.05249 览
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 部
+....\TU/FandolSong(0)/m/n/14.05249 部
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 分
+....\TU/FandolSong(0)/m/n/14.05249 分
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 内
+....\TU/FandolSong(0)/m/n/14.05249 内
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 容
+....\TU/FandolSong(0)/m/n/14.05249 容
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 。
+....\TU/FandolSong(0)/m/n/14.05249 。
 ....\rule(0.0+0.0)x-9.0498
 ....\kern 0.00055
 ....\kern -0.00055
@@ -561,27 +561,27 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 14.76917
 ...\hbox(11.04526+2.58565)x421.66989, glue set 248.03732fil, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
-....\TU/FandolSong-Regular(0)/m/n/14.05249 本
+....\TU/FandolSong(0)/m/n/14.05249 本
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 人
+....\TU/FandolSong(0)/m/n/14.05249 人
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 保
+....\TU/FandolSong(0)/m/n/14.05249 保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 证
+....\TU/FandolSong(0)/m/n/14.05249 证
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 遵
+....\TU/FandolSong(0)/m/n/14.05249 遵
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 守
+....\TU/FandolSong(0)/m/n/14.05249 守
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 上
+....\TU/FandolSong(0)/m/n/14.05249 上
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 述
+....\TU/FandolSong(0)/m/n/14.05249 述
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 规
+....\TU/FandolSong(0)/m/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/m/n/14.05249 定
+....\TU/FandolSong(0)/m/n/14.05249 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/14.05249 。
+....\TU/FandolSong(0)/m/n/14.05249 。
 ....\rule(0.0+0.0)x-9.0498
 ....\kern 0.00055
 ....\kern -0.00055
@@ -595,37 +595,37 @@ Completed box being shipped out [1]
 ...\hbox(11.22794+2.81049)x421.66989, glue set 172.37872fil, shifted 2.56073
 ....\hbox(0.0+0.0)x28.10498
 ....\rule(0.0+0.0)x-8.85307
-....\TU/FandolSong-Regular(0)/b/n/14.05249 （保
+....\TU/FandolSong(0)/b/n/14.05249 （保
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 密
+....\TU/FandolSong(0)/b/n/14.05249 密
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 的
+....\TU/FandolSong(0)/b/n/14.05249 的
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 论
+....\TU/FandolSong(0)/b/n/14.05249 论
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 文
+....\TU/FandolSong(0)/b/n/14.05249 文
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 在
+....\TU/FandolSong(0)/b/n/14.05249 在
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 解
+....\TU/FandolSong(0)/b/n/14.05249 解
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 密
+....\TU/FandolSong(0)/b/n/14.05249 密
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 后
+....\TU/FandolSong(0)/b/n/14.05249 后
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 应
+....\TU/FandolSong(0)/b/n/14.05249 应
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 遵
+....\TU/FandolSong(0)/b/n/14.05249 遵
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 守
+....\TU/FandolSong(0)/b/n/14.05249 守
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 此
+....\TU/FandolSong(0)/b/n/14.05249 此
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 规
+....\TU/FandolSong(0)/b/n/14.05249 规
 ....\glue 0.0 plus 0.50528
-....\TU/FandolSong-Regular(0)/b/n/14.05249 定
+....\TU/FandolSong(0)/b/n/14.05249 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/b/n/14.05249 ）
+....\TU/FandolSong(0)/b/n/14.05249 ）
 ....\rule(0.0+0.0)x-8.85307
 ....\kern 0.00053
 ....\kern -0.00053
@@ -643,15 +643,15 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 42.67912
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 者
+....\TU/FandolSong(0)/m/n/12.045 者
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 签
+....\TU/FandolSong(0)/m/n/12.045 签
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -670,15 +670,15 @@ Completed box being shipped out [1]
 ....\mathoff
 ....\glue 3.0
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 师
+....\TU/FandolSong(0)/m/n/12.045 师
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 签
+....\TU/FandolSong(0)/m/n/12.045 签
 ....\glue 0.0 plus 0.36787
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -711,13 +711,13 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 42.67912
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -736,13 +736,13 @@ Completed box being shipped out [1]
 ....\mathoff
 ....\glue 3.0
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052

--- a/testfiles/03-abstract-bachelor.tlg
+++ b/testfiles/03-abstract-bachelor.tlg
@@ -90,13 +90,13 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.40126
 ...\hbox(11.6686+2.61977)x421.10089, glue set 180.43796fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 中
+....\TU/FandolHei(0)/m/n/15.05624 中
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 文
+....\TU/FandolHei(0)/m/n/15.05624 文
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 摘
+....\TU/FandolHei(0)/m/n/15.05624 摘
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 要
+....\TU/FandolHei(0)/m/n/15.05624 要
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -110,205 +110,205 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 7.95172
 ...\hbox(9.50351+2.32468)x421.10089, glue set - 0.0787
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 球
+....\TU/FandolSong(0)/m/n/12.045 球
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 暖
+....\TU/FandolSong(0)/m/n/12.045 暖
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 起
+....\TU/FandolSong(0)/m/n/12.045 起
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 界
+....\TU/FandolSong(0)/m/n/12.045 界
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 范
+....\TU/FandolSong(0)/m/n/12.045 范
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 围
+....\TU/FandolSong(0)/m/n/12.045 围
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 注
+....\TU/FandolSong(0)/m/n/12.045 注
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 粮
+....\TU/FandolSong(0)/m/n/12.045 粮
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 食
+....\TU/FandolSong(0)/m/n/12.045 食
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.27649)x421.10089, glue set - 0.0787
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 影
+....\TU/FandolSong(0)/m/n/12.045 影
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 粮
+....\TU/FandolSong(0)/m/n/12.045 粮
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 食
+....\TU/FandolSong(0)/m/n/12.045 食
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 安
+....\TU/FandolSong(0)/m/n/12.045 安
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 冬
+....\TU/FandolSong(0)/m/n/12.045 冬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 影
+....\TU/FandolSong(0)/m/n/12.045 影
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.40341
 ...\hbox(9.3951+2.2283)x421.10089, glue set 103.64291fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 科
+....\TU/FandolSong(0)/m/n/12.045 科
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 农
+....\TU/FandolSong(0)/m/n/12.045 农
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 政
+....\TU/FandolSong(0)/m/n/12.045 政
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 策
+....\TU/FandolSong(0)/m/n/12.045 策
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -321,63 +321,63 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.4516
 ...\hbox(9.3951+2.26445)x421.10089, glue set 0.38292
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 采
+....\TU/FandolSong(0)/m/n/12.045 采
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1999
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\penalty 10000
 ....\glue 0.0 plus 0.73799
 ....\glue 3.34851 minus 1.67426
 ....\rule(0.0+0.0)x-3.34851
-....\TU/FandolSong-Regular(0)/m/n/12.045 ～
+....\TU/FandolSong(0)/m/n/12.045 ～
 ....\rule(0.0+0.0)x-3.34851
 ....\glue 3.34851 minus 1.67426
 ....\TU/texgyretermes(0)/m/n/12.045 2001
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 北
+....\TU/FandolSong(0)/m/n/12.045 北
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 京
+....\TU/FandolSong(0)/m/n/12.045 京
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 永
+....\TU/FandolSong(0)/m/n/12.045 永
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 乐
+....\TU/FandolSong(0)/m/n/12.045 乐
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 店
+....\TU/FandolSong(0)/m/n/12.045 店
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 冬
+....\TU/FandolSong(0)/m/n/12.045 冬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 田
+....\TU/FandolSong(0)/m/n/12.045 田
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 试
+....\TU/FandolSong(0)/m/n/12.045 试
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 料
+....\TU/FandolSong(0)/m/n/12.045 料
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 ThuSPAC-
 ....\discretionary
@@ -389,132 +389,132 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 CERES-Wheat
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 析
+....\TU/FandolSong(0)/m/n/12.045 析
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1951
 ....\penalty 10000
 ....\glue 3.34851 minus 1.67426
 ....\rule(0.0+0.0)x-3.34851
-....\TU/FandolSong-Regular(0)/m/n/12.045 ～
+....\TU/FandolSong(0)/m/n/12.045 ～
 ....\rule(0.0+0.0)x-3.34851
 ....\glue 3.34851 minus 1.67426
 ....\TU/texgyretermes(0)/m/n/12.045 2006
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set 0.135
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 冬
+....\TU/FandolSong(0)/m/n/12.045 冬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 影
+....\TU/FandolSong(0)/m/n/12.045 影
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 置
+....\TU/FandolSong(0)/m/n/12.045 置
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 景
+....\TU/FandolSong(0)/m/n/12.045 景
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 CERES-
 ....\discretionary
@@ -526,59 +526,59 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 析
+....\TU/FandolSong(0)/m/n/12.045 析
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 景
+....\TU/FandolSong(0)/m/n/12.045 景
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -593,59 +593,59 @@ Completed box being shipped out [1]
 ...\hbox(9.33487+2.20422)x421.10089, glue set 37.52792fil
 ....\hbox(0.0+0.0)x24.09
 ....\hbox(9.23851+1.91515)x48.18
-.....\TU/FandolSong-Regular(0)/b/n/12.045 关
+.....\TU/FandolSong(0)/b/n/12.045 关
 .....\glue 0.0 plus 0.73799
-.....\TU/FandolSong-Regular(0)/b/n/12.045 键
+.....\TU/FandolSong(0)/b/n/12.045 键
 .....\glue 0.0 plus 0.73799
-.....\TU/FandolSong-Regular(0)/b/n/12.045 词
+.....\TU/FandolSong(0)/b/n/12.045 词
 .....\penalty 10000
-.....\TU/FandolSong-Regular(0)/b/n/12.045 ：
+.....\TU/FandolSong(0)/b/n/12.045 ：
 .....\rule(0.0+0.0)x-8.09424
 .....\kern 0.00049
 .....\kern -0.00049
 .....\kern -0.99649
 .....\kern 0.99649
 .....\glue 8.09424 minus 6.02249
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 冬
+....\TU/FandolSong(0)/m/n/12.045 冬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\TU/texgyretermes(0)/m/n/12.045 ThuSPAC-Wheat
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\TU/texgyretermes(0)/m/n/12.045 CERES-Wheat

--- a/testfiles/03-abstract.tlg
+++ b/testfiles/03-abstract.tlg
@@ -46,11 +46,11 @@ Completed box being shipped out [1]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 摘
+..........\TU/FandolSong(0)/m/n/10.53937 摘
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 要
+..........\TU/FandolSong(0)/m/n/10.53937 要
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -95,11 +95,11 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 3.6938
 ...\hbox(12.3662+2.79442)x426.79135, glue set 189.30568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 摘
+....\TU/FandolHei(0)/m/n/16.06 摘
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 要
+....\TU/FandolHei(0)/m/n/16.06 要
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -113,309 +113,309 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 7.87343
 ...\hbox(9.40715+2.2283)x426.79135, glue set 0.3217
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 摘
+....\TU/FandolSong(0)/m/n/12.045 摘
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 括
+....\TU/FandolSong(0)/m/n/12.045 括
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 摘
+....\TU/FandolSong(0)/m/n/12.045 摘
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.4516
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 描
+....\TU/FandolSong(0)/m/n/12.045 描
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 简
+....\TU/FandolSong(0)/m/n/12.045 简
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 介
+....\TU/FandolSong(0)/m/n/12.045 介
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 绍
+....\TU/FandolSong(0)/m/n/12.045 绍
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 括
+....\TU/FandolSong(0)/m/n/12.045 括
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 摘
+....\TU/FandolSong(0)/m/n/12.045 摘
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 独
+....\TU/FandolSong(0)/m/n/12.045 独
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 包
+....\TU/FandolSong(0)/m/n/12.045 包
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 含
+....\TU/FandolSong(0)/m/n/12.045 含
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 读
+....\TU/FandolSong(0)/m/n/12.045 读
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 者
+....\TU/FandolSong(0)/m/n/12.045 者
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 即
+....\TU/FandolSong(0)/m/n/12.045 即
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阅
+....\TU/FandolSong(0)/m/n/12.045 阅
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 读
+....\TU/FandolSong(0)/m/n/12.045 读
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 摘
+....\TU/FandolSong(0)/m/n/12.045 摘
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.70453
 ...\hbox(9.04579+1.89105)x426.79135, glue set 410.45833fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -428,163 +428,163 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.69249
 ...\hbox(9.49146+2.2283)x426.79135, glue set 0.33243
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 摘
+....\TU/FandolSong(0)/m/n/12.045 摘
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 书
+....\TU/FandolSong(0)/m/n/12.045 书
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 精
+....\TU/FandolSong(0)/m/n/12.045 精
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 确
+....\TU/FandolSong(0)/m/n/12.045 确
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 简
+....\TU/FandolSong(0)/m/n/12.045 简
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 切
+....\TU/FandolSong(0)/m/n/12.045 切
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 忌
+....\TU/FandolSong(0)/m/n/12.045 忌
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 书
+....\TU/FandolSong(0)/m/n/12.045 书
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 形
+....\TU/FandolSong(0)/m/n/12.045 形
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 8.4516
 ...\hbox(9.3951+2.32468)x426.79135, glue set 25.01839fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 尤
+....\TU/FandolSong(0)/m/n/12.045 尤
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 避
+....\TU/FandolSong(0)/m/n/12.045 避
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 免
+....\TU/FandolSong(0)/m/n/12.045 免
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “第
+....\TU/FandolSong(0)/m/n/12.045 “第
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 …
+....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 …
+....\TU/FandolSong(0)/m/n/12.045 …
 ....\rule(0.0+0.0)x-2.04765
 ....\glue 2.04765 minus 2.04765
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 …
+....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 …
+....\TU/FandolSong(0)/m/n/12.045 …
 ....\rule(0.0+0.0)x-2.04765
 ....\glue 2.04765 minus 2.04765
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 8.07014
-....\TU/FandolSong-Regular(0)/m/n/12.045 …
+....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 …
+....\TU/FandolSong(0)/m/n/12.045 …
 ....\rule(0.0+0.0)x-2.04765
 ....\glue 2.04765 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 似
+....\TU/FandolSong(0)/m/n/12.045 似
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 陈
+....\TU/FandolSong(0)/m/n/12.045 陈
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -597,124 +597,124 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.21626)x426.79135, glue set 0.33243
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 献
+....\TU/FandolSong(0)/m/n/12.045 献
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 示
+....\TU/FandolSong(0)/m/n/12.045 示
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 术
+....\TU/FandolSong(0)/m/n/12.045 术
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 语
+....\TU/FandolSong(0)/m/n/12.045 语
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 8.37932
 ...\hbox(9.47942+2.32468)x426.79135, glue set 181.60336fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 超
+....\TU/FandolSong(0)/m/n/12.045 超
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 每
+....\TU/FandolSong(0)/m/n/12.045 每
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 隔
+....\TU/FandolSong(0)/m/n/12.045 隔
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -728,80 +728,80 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.47568
 ...\hbox(9.27464+2.21626)x426.79135, glue set 104.58763fil
 ....\hbox(9.23851+1.91515)x48.18
-.....\TU/FandolSong-Regular(0)/b/n/12.045 关
+.....\TU/FandolSong(0)/b/n/12.045 关
 .....\glue 0.0 plus 0.52307
-.....\TU/FandolSong-Regular(0)/b/n/12.045 键
+.....\TU/FandolSong(0)/b/n/12.045 键
 .....\glue 0.0 plus 0.52307
-.....\TU/FandolSong-Regular(0)/b/n/12.045 词
+.....\TU/FandolSong(0)/b/n/12.045 词
 .....\penalty 10000
-.....\TU/FandolSong-Regular(0)/b/n/12.045 ：
+.....\TU/FandolSong(0)/b/n/12.045 ：
 .....\rule(0.0+0.0)x-8.09424
 .....\kern 0.00049
 .....\kern -0.00049
 .....\kern -0.99649
 .....\kern 0.99649
 .....\glue 8.09424 minus 6.02249
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 4
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\kern -0.0002

--- a/testfiles/05-toc.tlg
+++ b/testfiles/05-toc.tlg
@@ -45,11 +45,11 @@ Completed box being shipped out [3]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 目
+..........\TU/FandolSong(0)/m/n/10.53937 目
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 录
+..........\TU/FandolSong(0)/m/n/10.53937 录
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -94,11 +94,11 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 4.3362
 ...\hbox(11.7238+2.7623)x426.79135, glue set 189.30568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 目
+....\TU/FandolHei(0)/m/n/16.06 目
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 录
+....\TU/FandolHei(0)/m/n/16.06 录
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -122,18 +122,18 @@ Completed box being shipped out [3]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 1
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 引
+....\TU/FandolHei(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 言
+....\TU/FandolHei(0)/m/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -175,17 +175,17 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -229,21 +229,21 @@ Completed box being shipped out [3]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 简
+....\TU/FandolSong(0)/m/n/12.045 简
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 史
+....\TU/FandolSong(0)/m/n/12.045 史
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 顾
+....\TU/FandolSong(0)/m/n/12.045 顾
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -287,19 +287,19 @@ Completed box being shipped out [3]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -341,25 +341,25 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 技
+....\TU/FandolSong(0)/m/n/12.045 技
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 术
+....\TU/FandolSong(0)/m/n/12.045 术
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -403,33 +403,33 @@ Completed box being shipped out [3]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 当
+....\TU/FandolSong(0)/m/n/12.045 当
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 况
+....\TU/FandolSong(0)/m/n/12.045 况
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -471,51 +471,51 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 功
+....\TU/FandolSong(0)/m/n/12.045 功
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 必
+....\TU/FandolSong(0)/m/n/12.045 必
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -559,27 +559,27 @@ Completed box being shipped out [3]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 困
+....\TU/FandolSong(0)/m/n/12.045 困
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 难
+....\TU/FandolSong(0)/m/n/12.045 难
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 挑
+....\TU/FandolSong(0)/m/n/12.045 挑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 战
+....\TU/FandolSong(0)/m/n/12.045 战
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -621,33 +621,33 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 贡
+....\TU/FandolSong(0)/m/n/12.045 贡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 献
+....\TU/FandolSong(0)/m/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -689,25 +689,25 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 什
+....\TU/FandolSong(0)/m/n/12.045 什
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 么
+....\TU/FandolSong(0)/m/n/12.045 么
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 什
+....\TU/FandolSong(0)/m/n/12.045 什
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 么
+....\TU/FandolSong(0)/m/n/12.045 么
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -749,17 +749,17 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 简
+....\TU/FandolSong(0)/m/n/12.045 简
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 介
+....\TU/FandolSong(0)/m/n/12.045 介
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -801,19 +801,19 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 贡
+....\TU/FandolSong(0)/m/n/12.045 贡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 献
+....\TU/FandolSong(0)/m/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -851,22 +851,22 @@ Completed box being shipped out [3]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 2
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 相
+....\TU/FandolHei(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 关
+....\TU/FandolHei(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 工
+....\TU/FandolHei(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 作
+....\TU/FandolHei(0)/m/n/12.045 作
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -908,21 +908,21 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 施
+....\TU/FandolSong(0)/m/n/12.045 施
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -964,33 +964,33 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 敛
+....\TU/FandolSong(0)/m/n/12.045 敛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1032,29 +1032,29 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 敛
+....\TU/FandolSong(0)/m/n/12.045 敛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1098,25 +1098,25 @@ Completed box being shipped out [3]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 策
+....\TU/FandolSong(0)/m/n/12.045 策
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 略
+....\TU/FandolSong(0)/m/n/12.045 略
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1158,31 +1158,31 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 传
+....\TU/FandolSong(0)/m/n/12.045 传
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 集
+....\TU/FandolSong(0)/m/n/12.045 集
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 环
+....\TU/FandolSong(0)/m/n/12.045 环
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 境
+....\TU/FandolSong(0)/m/n/12.045 境
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1224,17 +1224,17 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 技
+....\TU/FandolSong(0)/m/n/12.045 技
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 术
+....\TU/FandolSong(0)/m/n/12.045 术
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1276,17 +1276,17 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 缓
+....\TU/FandolSong(0)/m/n/12.045 缓
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 技
+....\TU/FandolSong(0)/m/n/12.045 技
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 术
+....\TU/FandolSong(0)/m/n/12.045 术
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1328,19 +1328,19 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 评
+....\TU/FandolSong(0)/m/n/12.045 评
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 估
+....\TU/FandolSong(0)/m/n/12.045 估
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 技
+....\TU/FandolSong(0)/m/n/12.045 技
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 术
+....\TU/FandolSong(0)/m/n/12.045 术
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1382,25 +1382,25 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1442,19 +1442,19 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1496,19 +1496,19 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 严
+....\TU/FandolSong(0)/m/n/12.045 严
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 格
+....\TU/FandolSong(0)/m/n/12.045 格
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1550,23 +1550,23 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 语
+....\TU/FandolSong(0)/m/n/12.045 语
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1608,13 +1608,13 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1652,54 +1652,54 @@ Completed box being shipped out [3]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 3
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 对
+....\TU/FandolHei(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 等
+....\TU/FandolHei(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 网
+....\TU/FandolHei(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 络
+....\TU/FandolHei(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 中
+....\TU/FandolHei(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 宽
+....\TU/FandolHei(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 松
+....\TU/FandolHei(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 约
+....\TU/FandolHei(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 束
+....\TU/FandolHei(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 的
+....\TU/FandolHei(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 一
+....\TU/FandolHei(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 般
+....\TU/FandolHei(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 性
+....\TU/FandolHei(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 搜
+....\TU/FandolHei(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 索
+....\TU/FandolHei(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 的
+....\TU/FandolHei(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 理
+....\TU/FandolHei(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 论
+....\TU/FandolHei(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 模
+....\TU/FandolHei(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 型
+....\TU/FandolHei(0)/m/n/12.045 型
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1741,13 +1741,13 @@ Completed box being shipped out [3]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1881,11 +1881,11 @@ Completed box being shipped out [4]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 目
+..........\TU/FandolSong(0)/m/n/10.53937 目
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 录
+..........\TU/FandolSong(0)/m/n/10.53937 录
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -1922,17 +1922,17 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1974,17 +1974,17 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2026,13 +2026,13 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2074,15 +2074,15 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 短
+....\TU/FandolSong(0)/m/n/12.045 短
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 稳
+....\TU/FandolSong(0)/m/n/12.045 稳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2124,23 +2124,23 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 叙
+....\TU/FandolSong(0)/m/n/12.045 叙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2182,37 +2182,37 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2254,41 +2254,41 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2330,29 +2330,29 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2394,33 +2394,33 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2462,39 +2462,39 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 公
+....\TU/FandolSong(0)/m/n/12.045 公
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2536,17 +2536,17 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 叙
+....\TU/FandolSong(0)/m/n/12.045 叙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2588,27 +2588,27 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2650,25 +2650,25 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2710,31 +2710,31 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2776,21 +2776,21 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 测
+....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2832,19 +2832,19 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2886,17 +2886,17 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 讨
+....\TU/FandolSong(0)/m/n/12.045 讨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2938,17 +2938,17 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2990,21 +2990,21 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 比
+....\TU/FandolSong(0)/m/n/12.045 比
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3046,13 +3046,13 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3090,44 +3090,44 @@ Completed box being shipped out [4]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 4
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 近
+....\TU/FandolHei(0)/m/n/12.045 近
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 似
+....\TU/FandolHei(0)/m/n/12.045 似
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 最
+....\TU/FandolHei(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 优
+....\TU/FandolHei(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 性
+....\TU/FandolHei(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 能
+....\TU/FandolHei(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 的
+....\TU/FandolHei(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 宽
+....\TU/FandolHei(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 松
+....\TU/FandolHei(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 约
+....\TU/FandolHei(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 束
+....\TU/FandolHei(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 搜
+....\TU/FandolHei(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 索
+....\TU/FandolHei(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 算
+....\TU/FandolHei(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 法
+....\TU/FandolHei(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3169,13 +3169,13 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3217,19 +3217,19 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 Hierarchical
@@ -3246,7 +3246,7 @@ Completed box being shipped out [4]
 ....\glue 3.01125 plus 1.88202 minus 0.80298
 ....\TU/texgyretermes(0)/m/n/12.045 HGM
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\kern 0.00047
 ....\kern -0.00047
@@ -3294,21 +3294,21 @@ Completed box being shipped out [4]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 HGM
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3352,15 +3352,15 @@ Completed box being shipped out [4]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 HGM
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3404,25 +3404,25 @@ Completed box being shipped out [4]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 HGM
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 逐
+....\TU/FandolSong(0)/m/n/12.045 逐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3464,19 +3464,19 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 局
+....\TU/FandolSong(0)/m/n/12.045 局
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 域
+....\TU/FandolSong(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 原
+....\TU/FandolSong(0)/m/n/12.045 原
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 Principle
@@ -3489,7 +3489,7 @@ Completed box being shipped out [4]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Locality
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\kern 0.00047
 ....\kern -0.00047
@@ -3535,29 +3535,29 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 HGM
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3599,35 +3599,35 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 Pastry
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 施
+....\TU/FandolSong(0)/m/n/12.045 施
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3671,23 +3671,23 @@ Completed box being shipped out [4]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 Pastry
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 HGM
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3729,45 +3729,45 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 Pastry
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 逐
+....\TU/FandolSong(0)/m/n/12.045 逐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 局
+....\TU/FandolSong(0)/m/n/12.045 局
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 域
+....\TU/FandolSong(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 播
+....\TU/FandolSong(0)/m/n/12.045 播
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3809,21 +3809,21 @@ Completed box being shipped out [4]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -3958,11 +3958,11 @@ Completed box being shipped out [5]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 目
+..........\TU/FandolSong(0)/m/n/10.53937 目
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 录
+..........\TU/FandolSong(0)/m/n/10.53937 录
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -4000,35 +4000,35 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 SkipNet
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 施
+....\TU/FandolSong(0)/m/n/12.045 施
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4072,23 +4072,23 @@ Completed box being shipped out [5]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 SkipNet
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 HGM
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4130,45 +4130,45 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 SkipNet
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 逐
+....\TU/FandolSong(0)/m/n/12.045 逐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 局
+....\TU/FandolSong(0)/m/n/12.045 局
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 域
+....\TU/FandolSong(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 播
+....\TU/FandolSong(0)/m/n/12.045 播
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4210,21 +4210,21 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4266,17 +4266,17 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 讨
+....\TU/FandolSong(0)/m/n/12.045 讨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4318,13 +4318,13 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 错
+....\TU/FandolSong(0)/m/n/12.045 错
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4366,23 +4366,23 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 操
+....\TU/FandolSong(0)/m/n/12.045 操
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4424,13 +4424,13 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4468,46 +4468,46 @@ Completed box being shipped out [5]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 5
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 对
+....\TU/FandolHei(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 等
+....\TU/FandolHei(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 网
+....\TU/FandolHei(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 络
+....\TU/FandolHei(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 中
+....\TU/FandolHei(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 严
+....\TU/FandolHei(0)/m/n/12.045 严
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 格
+....\TU/FandolHei(0)/m/n/12.045 格
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 约
+....\TU/FandolHei(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 束
+....\TU/FandolHei(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 的
+....\TU/FandolHei(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 区
+....\TU/FandolHei(0)/m/n/12.045 区
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 域
+....\TU/FandolHei(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 搜
+....\TU/FandolHei(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 索
+....\TU/FandolHei(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 算
+....\TU/FandolHei(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 法
+....\TU/FandolHei(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4549,13 +4549,13 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4597,45 +4597,45 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 属
+....\TU/FandolSong(0)/m/n/12.045 属
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 匹
+....\TU/FandolSong(0)/m/n/12.045 匹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 配
+....\TU/FandolSong(0)/m/n/12.045 配
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 储
+....\TU/FandolSong(0)/m/n/12.045 储
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 区
+....\TU/FandolSong(0)/m/n/12.045 区
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 域
+....\TU/FandolSong(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4677,38 +4677,38 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 心
+....\TU/FandolSong(0)/m/n/12.045 心
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 施
+....\TU/FandolSong(0)/m/n/12.045 施
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 DRMI
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\kern 0.00047
 ....\kern -0.00047
@@ -4754,27 +4754,27 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4816,21 +4816,21 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 Resource
@@ -4843,12 +4843,12 @@ Completed box being shipped out [5]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Table
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 RMT
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\kern 0.00047
 ....\kern -0.00047
@@ -4896,15 +4896,15 @@ Completed box being shipped out [5]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 RMT
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -4946,35 +4946,35 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 DRMI
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 负
+....\TU/FandolSong(0)/m/n/12.045 负
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衡
+....\TU/FandolSong(0)/m/n/12.045 衡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5016,29 +5016,29 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 监
+....\TU/FandolSong(0)/m/n/12.045 监
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 测
+....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5082,21 +5082,21 @@ Completed box being shipped out [5]
 ......\special{color pop}
 ....\TU/texgyretermes(0)/m/n/12.045 DRMI
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 渐
+....\TU/FandolSong(0)/m/n/12.045 渐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 策
+....\TU/FandolSong(0)/m/n/12.045 策
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5138,39 +5138,39 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 利
+....\TU/FandolSong(0)/m/n/12.045 利
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 DRMI
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 负
+....\TU/FandolSong(0)/m/n/12.045 负
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衡
+....\TU/FandolSong(0)/m/n/12.045 衡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 属
+....\TU/FandolSong(0)/m/n/12.045 属
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 匹
+....\TU/FandolSong(0)/m/n/12.045 匹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 配
+....\TU/FandolSong(0)/m/n/12.045 配
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5212,19 +5212,19 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 析
+....\TU/FandolSong(0)/m/n/12.045 析
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5266,31 +5266,31 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 监
+....\TU/FandolSong(0)/m/n/12.045 监
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 测
+....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 确
+....\TU/FandolSong(0)/m/n/12.045 确
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5332,17 +5332,17 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 负
+....\TU/FandolSong(0)/m/n/12.045 负
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 迁
+....\TU/FandolSong(0)/m/n/12.045 迁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 移
+....\TU/FandolSong(0)/m/n/12.045 移
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5384,13 +5384,13 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5432,13 +5432,13 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5476,18 +5476,18 @@ Completed box being shipped out [5]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 6
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 结
+....\TU/FandolHei(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 论
+....\TU/FandolHei(0)/m/n/12.045 论
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5529,13 +5529,13 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5577,23 +5577,23 @@ Completed box being shipped out [5]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5626,13 +5626,13 @@ Completed box being shipped out [5]
 ...\hbox(14.05243+6.02255)x426.79135, glue set 367.57011fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 参
+....\TU/FandolHei(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 考
+....\TU/FandolHei(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 文
+....\TU/FandolHei(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 献
+....\TU/FandolHei(0)/m/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5665,11 +5665,11 @@ Completed box being shipped out [5]
 ...\hbox(14.05243+6.02255)x426.79135, glue set 379.61511fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 致
+....\TU/FandolHei(0)/m/n/12.045 致
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolHei-Regular(0)/m/n/12.045 谢
+....\TU/FandolHei(0)/m/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5702,11 +5702,11 @@ Completed box being shipped out [5]
 ...\hbox(14.05243+6.02255)x426.79135, glue set 379.61511fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 声
+....\TU/FandolHei(0)/m/n/12.045 声
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolHei-Regular(0)/m/n/12.045 明
+....\TU/FandolHei(0)/m/n/12.045 明
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5744,26 +5744,26 @@ Completed box being shipped out [5]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.10602+2.07173)x47.51752
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 附
+......\TU/FandolHei(0)/m/n/12.045 附
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 录
+......\TU/FandolHei(0)/m/n/12.045 录
 ......\glue 3.34851 plus 1.67258 minus 1.11728
 ......\TU/texgyreheros(0)/m/n/12.045 A
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 资
+....\TU/FandolHei(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 源
+....\TU/FandolHei(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 元
+....\TU/FandolHei(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 数
+....\TU/FandolHei(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 据
+....\TU/FandolHei(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 表
+....\TU/FandolHei(0)/m/n/12.045 表
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5897,11 +5897,11 @@ Completed box being shipped out [6]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 目
+..........\TU/FandolSong(0)/m/n/10.53937 目
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 录
+..........\TU/FandolSong(0)/m/n/10.53937 录
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -5928,49 +5928,49 @@ Completed box being shipped out [6]
 ...\hbox(14.05243+6.02255)x426.79135, glue set 162.80515fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 个
+....\TU/FandolHei(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 人
+....\TU/FandolHei(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 简
+....\TU/FandolHei(0)/m/n/12.045 简
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 历
+....\TU/FandolHei(0)/m/n/12.045 历
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 、
+....\TU/FandolHei(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 在
+....\TU/FandolHei(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 学
+....\TU/FandolHei(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 期
+....\TU/FandolHei(0)/m/n/12.045 期
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 间
+....\TU/FandolHei(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 发
+....\TU/FandolHei(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 表
+....\TU/FandolHei(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 的
+....\TU/FandolHei(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 学
+....\TU/FandolHei(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 术
+....\TU/FandolHei(0)/m/n/12.045 术
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 论
+....\TU/FandolHei(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 文
+....\TU/FandolHei(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 与
+....\TU/FandolHei(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 研
+....\TU/FandolHei(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 究
+....\TU/FandolHei(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 成
+....\TU/FandolHei(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 果
+....\TU/FandolHei(0)/m/n/12.045 果
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0

--- a/testfiles/06-notation-nomencl/06-notation-nomencl.tlg
+++ b/testfiles/06-notation-nomencl/06-notation-nomencl.tlg
@@ -64,19 +64,19 @@ Completed box being shipped out [8]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 主
+..........\TU/FandolSong(0)/m/n/10.53937 主
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 要
+..........\TU/FandolSong(0)/m/n/10.53937 要
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 符
+..........\TU/FandolSong(0)/m/n/10.53937 符
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 号
+..........\TU/FandolSong(0)/m/n/10.53937 号
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 照
+..........\TU/FandolSong(0)/m/n/10.53937 照
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 表
+..........\TU/FandolSong(0)/m/n/10.53937 表
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -120,19 +120,19 @@ Completed box being shipped out [8]
 ...\glue(\baselineskip) 3.62956
 ...\hbox(12.43044+2.89078)x426.79135, glue set 157.18568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 主
+....\TU/FandolHei(0)/m/n/16.06 主
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 要
+....\TU/FandolHei(0)/m/n/16.06 要
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 符
+....\TU/FandolHei(0)/m/n/16.06 符
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 号
+....\TU/FandolHei(0)/m/n/16.06 号
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 对
+....\TU/FandolHei(0)/m/n/16.06 对
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 照
+....\TU/FandolHei(0)/m/n/16.06 照
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 表
+....\TU/FandolHei(0)/m/n/16.06 表
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -167,15 +167,15 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 活
+....\TU/FandolSong(0)/m/n/12.045 活
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Activation
 ....\kern -0.00021
@@ -212,13 +212,13 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 传
+....\TU/FandolSong(0)/m/n/12.045 传
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 输
+....\TU/FandolSong(0)/m/n/12.045 输
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Transmission
 ....\kern -0.00021
@@ -252,9 +252,9 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 虚
+....\TU/FandolSong(0)/m/n/12.045 虚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 频
+....\TU/FandolSong(0)/m/n/12.045 频
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Imaginary
 ....\kern -0.00021
@@ -288,21 +288,21 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 活
+....\TU/FandolSong(0)/m/n/12.045 活
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Activation
 ....\kern -0.00021
@@ -339,51 +339,51 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 原
+....\TU/FandolSong(0)/m/n/12.045 原
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 头
+....\TU/FandolSong(0)/m/n/12.045 头
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -409,21 +409,21 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -449,17 +449,17 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 密
+....\TU/FandolSong(0)/m/n/12.045 密
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 函
+....\TU/FandolSong(0)/m/n/12.045 函
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Density
 ....\kern -0.00021
@@ -495,52 +495,52 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 双
+....\TU/FandolSong(0)/m/n/12.045 双
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (
-....\TU/FandolSong-Regular(0)/m/n/12.045 水
+....\TU/FandolSong(0)/m/n/12.045 水
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\TU/texgyretermes(0)/m/n/12.045 )
 ....\kern -0.0002
 ....\kern 0.0002
@@ -567,43 +567,43 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -629,37 +629,37 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -685,35 +685,35 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -739,39 +739,39 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 喹
+....\TU/FandolSong(0)/m/n/12.045 喹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 噁
+....\TU/FandolSong(0)/m/n/12.045 噁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 啉
+....\TU/FandolSong(0)/m/n/12.045 啉
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -797,33 +797,33 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -849,41 +849,41 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -909,23 +909,23 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 毛
+....\TU/FandolSong(0)/m/n/12.045 毛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 细
+....\TU/FandolSong(0)/m/n/12.045 细
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泳
+....\TU/FandolSong(0)/m/n/12.045 泳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 色
+....\TU/FandolSong(0)/m/n/12.045 色
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (High
 ....\kern -0.00021
@@ -965,17 +965,17 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 液
+....\TU/FandolSong(0)/m/n/12.045 液
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 色
+....\TU/FandolSong(0)/m/n/12.045 色
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (High
 ....\kern -0.00021
@@ -1015,17 +1015,17 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 禀
+....\TU/FandolSong(0)/m/n/12.045 禀
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 坐
+....\TU/FandolSong(0)/m/n/12.045 坐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Intrinsic
 ....\kern -0.00021
@@ -1061,22 +1061,22 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 液
+....\TU/FandolSong(0)/m/n/12.045 液
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 色
+....\TU/FandolSong(0)/m/n/12.045 色
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\TU/texgyretermes(0)/m/n/12.045 -
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 联
+....\TU/FandolSong(0)/m/n/12.045 联
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Liquid
 ....\kern -0.00021
@@ -1112,49 +1112,49 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 3,5,6-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\TU/texgyretermes(0)/m/n/12.045 -1,2,4-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1180,42 +1180,42 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 N-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1241,42 +1241,42 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 N-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 邻
+....\TU/FandolSong(0)/m/n/12.045 邻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1302,46 +1302,46 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 喹
+....\TU/FandolSong(0)/m/n/12.045 喹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 噁
+....\TU/FandolSong(0)/m/n/12.045 噁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 啉
+....\TU/FandolSong(0)/m/n/12.045 啉
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 3,4-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 二
+....\TU/FandolSong(0)/m/n/12.045 二
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 二
+....\TU/FandolSong(0)/m/n/12.045 二
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1367,21 +1367,21 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1407,45 +1407,45 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 2,4,6-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\TU/texgyretermes(0)/m/n/12.045 -1,3,5-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1471,13 +1471,13 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 层
+....\TU/FandolSong(0)/m/n/12.045 层
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Our
 ....\kern -0.00021
@@ -1540,15 +1540,15 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1574,15 +1574,15 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 热
+....\TU/FandolSong(0)/m/n/12.045 热
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1608,11 +1608,11 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 势
+....\TU/FandolSong(0)/m/n/12.045 势
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Potential
 ....\kern -0.00021
@@ -1648,13 +1648,13 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1680,43 +1680,43 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 四
+....\TU/FandolSong(0)/m/n/12.045 四
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酸
+....\TU/FandolSong(0)/m/n/12.045 酸
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 二
+....\TU/FandolSong(0)/m/n/12.045 二
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酐
+....\TU/FandolSong(0)/m/n/12.045 酐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 联
+....\TU/FandolSong(0)/m/n/12.045 联
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 四
+....\TU/FandolSong(0)/m/n/12.045 四
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 薄
+....\TU/FandolSong(0)/m/n/12.045 薄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 膜
+....\TU/FandolSong(0)/m/n/12.045 膜
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1832,19 +1832,19 @@ Completed box being shipped out [9]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 主
+..........\TU/FandolSong(0)/m/n/10.53937 主
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 要
+..........\TU/FandolSong(0)/m/n/10.53937 要
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 符
+..........\TU/FandolSong(0)/m/n/10.53937 符
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 号
+..........\TU/FandolSong(0)/m/n/10.53937 号
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 照
+..........\TU/FandolSong(0)/m/n/10.53937 照
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 表
+..........\TU/FandolSong(0)/m/n/10.53937 表
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -1885,17 +1885,17 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 喹
+....\TU/FandolSong(0)/m/n/12.045 喹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 噁
+....\TU/FandolSong(0)/m/n/12.045 噁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 啉
+....\TU/FandolSong(0)/m/n/12.045 啉
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1921,11 +1921,11 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1951,19 +1951,19 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1989,11 +1989,11 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 洽
+....\TU/FandolSong(0)/m/n/12.045 洽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 场
+....\TU/FandolSong(0)/m/n/12.045 场
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Self-Consistent
 ....\kern -0.00021
@@ -2025,15 +2025,15 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 洽
+....\TU/FandolSong(0)/m/n/12.045 洽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 场
+....\TU/FandolSong(0)/m/n/12.045 场
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Self-Consistent
 ....\kern -0.00021
@@ -2069,15 +2069,15 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 离
+....\TU/FandolSong(0)/m/n/12.045 离
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 浓
+....\TU/FandolSong(0)/m/n/12.045 浓
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Total
 ....\kern -0.00021
@@ -2113,11 +2113,11 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 渡
+....\TU/FandolSong(0)/m/n/12.045 渡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Transition
 ....\kern -0.00021
@@ -2149,15 +2149,15 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 渡
+....\TU/FandolSong(0)/m/n/12.045 渡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Transition
 ....\kern -0.00021
@@ -2193,15 +2193,15 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 零
+....\TU/FandolSong(0)/m/n/12.045 零
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 振
+....\TU/FandolSong(0)/m/n/12.045 振
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Zero
 ....\kern -0.00021

--- a/testfiles/06-notation.tlg
+++ b/testfiles/06-notation.tlg
@@ -63,19 +63,19 @@ Completed box being shipped out [8]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 主
+..........\TU/FandolSong(0)/m/n/10.53937 主
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 要
+..........\TU/FandolSong(0)/m/n/10.53937 要
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 符
+..........\TU/FandolSong(0)/m/n/10.53937 符
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 号
+..........\TU/FandolSong(0)/m/n/10.53937 号
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 照
+..........\TU/FandolSong(0)/m/n/10.53937 照
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 表
+..........\TU/FandolSong(0)/m/n/10.53937 表
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -119,19 +119,19 @@ Completed box being shipped out [8]
 ...\glue(\baselineskip) 3.62956
 ...\hbox(12.43044+2.89078)x426.79135, glue set 157.18568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 主
+....\TU/FandolHei(0)/m/n/16.06 主
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 要
+....\TU/FandolHei(0)/m/n/16.06 要
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 符
+....\TU/FandolHei(0)/m/n/16.06 符
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 号
+....\TU/FandolHei(0)/m/n/16.06 号
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 对
+....\TU/FandolHei(0)/m/n/16.06 对
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 照
+....\TU/FandolHei(0)/m/n/16.06 照
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 表
+....\TU/FandolHei(0)/m/n/16.06 表
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -162,13 +162,13 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -194,42 +194,42 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 N-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 邻
+....\TU/FandolSong(0)/m/n/12.045 邻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -255,15 +255,15 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -289,42 +289,42 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 N-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -350,11 +350,11 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -380,43 +380,43 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 四
+....\TU/FandolSong(0)/m/n/12.045 四
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酸
+....\TU/FandolSong(0)/m/n/12.045 酸
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 二
+....\TU/FandolSong(0)/m/n/12.045 二
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酐
+....\TU/FandolSong(0)/m/n/12.045 酐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 联
+....\TU/FandolSong(0)/m/n/12.045 联
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 四
+....\TU/FandolSong(0)/m/n/12.045 四
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 薄
+....\TU/FandolSong(0)/m/n/12.045 薄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 膜
+....\TU/FandolSong(0)/m/n/12.045 膜
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -442,21 +442,21 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -482,21 +482,21 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -522,49 +522,49 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 3,5,6-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\TU/texgyretermes(0)/m/n/12.045 -1,2,4-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -590,52 +590,52 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 双
+....\TU/FandolSong(0)/m/n/12.045 双
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (
-....\TU/FandolSong-Regular(0)/m/n/12.045 水
+....\TU/FandolSong(0)/m/n/12.045 水
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\TU/texgyretermes(0)/m/n/12.045 )
 ....\kern -0.00021
 ....\kern 0.00021
@@ -662,19 +662,19 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -700,45 +700,45 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 2,4,6-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\TU/texgyretermes(0)/m/n/12.045 -1,3,5-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -764,17 +764,17 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 喹
+....\TU/FandolSong(0)/m/n/12.045 喹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 噁
+....\TU/FandolSong(0)/m/n/12.045 噁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 啉
+....\TU/FandolSong(0)/m/n/12.045 啉
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -800,46 +800,46 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 喹
+....\TU/FandolSong(0)/m/n/12.045 喹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 噁
+....\TU/FandolSong(0)/m/n/12.045 噁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 啉
+....\TU/FandolSong(0)/m/n/12.045 啉
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 3,4-
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 二
+....\TU/FandolSong(0)/m/n/12.045 二
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 二
+....\TU/FandolSong(0)/m/n/12.045 二
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -865,35 +865,35 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 酰
+....\TU/FandolSong(0)/m/n/12.045 酰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 亚
+....\TU/FandolSong(0)/m/n/12.045 亚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胺
+....\TU/FandolSong(0)/m/n/12.045 胺
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -919,33 +919,33 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 吡
+....\TU/FandolSong(0)/m/n/12.045 吡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咙
+....\TU/FandolSong(0)/m/n/12.045 咙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -971,37 +971,37 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 咪
+....\TU/FandolSong(0)/m/n/12.045 咪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 唑
+....\TU/FandolSong(0)/m/n/12.045 唑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -1027,43 +1027,43 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -1089,41 +1089,41 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 嗪
+....\TU/FandolSong(0)/m/n/12.045 嗪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -1149,39 +1149,39 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 聚
+....\TU/FandolSong(0)/m/n/12.045 聚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 苯
+....\TU/FandolSong(0)/m/n/12.045 苯
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 喹
+....\TU/FandolSong(0)/m/n/12.045 喹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 噁
+....\TU/FandolSong(0)/m/n/12.045 噁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 啉
+....\TU/FandolSong(0)/m/n/12.045 啉
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -1207,15 +1207,15 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 热
+....\TU/FandolSong(0)/m/n/12.045 热
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -1241,17 +1241,17 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 液
+....\TU/FandolSong(0)/m/n/12.045 液
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 色
+....\TU/FandolSong(0)/m/n/12.045 色
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (High
 ....\kern -0.00021
@@ -1291,23 +1291,23 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 毛
+....\TU/FandolSong(0)/m/n/12.045 毛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 细
+....\TU/FandolSong(0)/m/n/12.045 细
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泳
+....\TU/FandolSong(0)/m/n/12.045 泳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 色
+....\TU/FandolSong(0)/m/n/12.045 色
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (High
 ....\kern -0.00021
@@ -1347,22 +1347,22 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 液
+....\TU/FandolSong(0)/m/n/12.045 液
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 色
+....\TU/FandolSong(0)/m/n/12.045 色
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\TU/texgyretermes(0)/m/n/12.045 -
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谱
+....\TU/FandolSong(0)/m/n/12.045 谱
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 联
+....\TU/FandolSong(0)/m/n/12.045 联
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Liquid
 ....\kern -0.00021
@@ -1398,15 +1398,15 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 离
+....\TU/FandolSong(0)/m/n/12.045 离
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 浓
+....\TU/FandolSong(0)/m/n/12.045 浓
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Total
 ....\kern -0.00021
@@ -1447,51 +1447,51 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 原
+....\TU/FandolSong(0)/m/n/12.045 原
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 头
+....\TU/FandolSong(0)/m/n/12.045 头
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -1517,17 +1517,17 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 密
+....\TU/FandolSong(0)/m/n/12.045 密
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 函
+....\TU/FandolSong(0)/m/n/12.045 函
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Density
 ....\kern -0.00021
@@ -1565,21 +1565,21 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 活
+....\TU/FandolSong(0)/m/n/12.045 活
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Activation
 ....\kern -0.00021
@@ -1611,15 +1611,15 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 零
+....\TU/FandolSong(0)/m/n/12.045 零
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 振
+....\TU/FandolSong(0)/m/n/12.045 振
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Zero
 ....\kern -0.00021
@@ -1655,11 +1655,11 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 势
+....\TU/FandolSong(0)/m/n/12.045 势
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Potential
 ....\kern -0.00021
@@ -1695,11 +1695,11 @@ Completed box being shipped out [8]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 渡
+....\TU/FandolSong(0)/m/n/12.045 渡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Transition
 ....\kern -0.00021
@@ -1820,19 +1820,19 @@ Completed box being shipped out [9]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 主
+..........\TU/FandolSong(0)/m/n/10.53937 主
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 要
+..........\TU/FandolSong(0)/m/n/10.53937 要
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 符
+..........\TU/FandolSong(0)/m/n/10.53937 符
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 号
+..........\TU/FandolSong(0)/m/n/10.53937 号
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 照
+..........\TU/FandolSong(0)/m/n/10.53937 照
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 表
+..........\TU/FandolSong(0)/m/n/10.53937 表
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -1873,15 +1873,15 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 渡
+....\TU/FandolSong(0)/m/n/12.045 渡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Transition
 ....\kern -0.00021
@@ -1921,15 +1921,15 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 活
+....\TU/FandolSong(0)/m/n/12.045 活
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Activation
 ....\kern -0.00021
@@ -1966,13 +1966,13 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 传
+....\TU/FandolSong(0)/m/n/12.045 传
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 输
+....\TU/FandolSong(0)/m/n/12.045 输
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Transmission
 ....\kern -0.00021
@@ -2004,17 +2004,17 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 禀
+....\TU/FandolSong(0)/m/n/12.045 禀
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 坐
+....\TU/FandolSong(0)/m/n/12.045 坐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Intrinsic
 ....\kern -0.00021
@@ -2052,9 +2052,9 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 虚
+....\TU/FandolSong(0)/m/n/12.045 虚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 频
+....\TU/FandolSong(0)/m/n/12.045 频
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Imaginary
 ....\kern -0.00021
@@ -2086,13 +2086,13 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 层
+....\TU/FandolSong(0)/m/n/12.045 层
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Our
 ....\kern -0.00021
@@ -2155,11 +2155,11 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 洽
+....\TU/FandolSong(0)/m/n/12.045 洽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 场
+....\TU/FandolSong(0)/m/n/12.045 场
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Self-Consistent
 ....\kern -0.00021
@@ -2191,15 +2191,15 @@ Completed box being shipped out [9]
 ......\special{color pop}
 .....\glue 14.22636
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 洽
+....\TU/FandolSong(0)/m/n/12.045 洽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 场
+....\TU/FandolSong(0)/m/n/12.045 场
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (Self-Consistent
 ....\kern -0.00021

--- a/testfiles/07-main-bachelor.tlg
+++ b/testfiles/07-main-bachelor.tlg
@@ -83,11 +83,11 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 9.0788
 ...\hbox(10.99106+2.58966)x421.10089, glue set 187.96608fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 目
+....\TU/FandolHei(0)/m/n/15.05624 目
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 15.05624
-....\TU/FandolHei-Regular(0)/m/n/15.05624 录
+....\TU/FandolHei(0)/m/n/15.05624 录
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -111,18 +111,18 @@ Completed box being shipped out [1]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 1
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 引
+....\TU/FandolHei(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 言
+....\TU/FandolHei(0)/m/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -164,13 +164,13 @@ Completed box being shipped out [1]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 背
+....\TU/FandolSong(0)/m/n/12.045 背
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 景
+....\TU/FandolSong(0)/m/n/12.045 景
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -212,13 +212,13 @@ Completed box being shipped out [1]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 状
+....\TU/FandolSong(0)/m/n/12.045 状
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -260,21 +260,21 @@ Completed box being shipped out [1]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -312,24 +312,24 @@ Completed box being shipped out [1]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.41919+2.13194)x49.52904
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 第
+......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 2
 ......\glue 3.34851 plus 1.67426 minus 1.11617
-......\TU/FandolHei-Regular(0)/m/n/12.045 章
+......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 资
+....\TU/FandolHei(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 料
+....\TU/FandolHei(0)/m/n/12.045 料
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 与
+....\TU/FandolHei(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 试
+....\TU/FandolHei(0)/m/n/12.045 试
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 验
+....\TU/FandolHei(0)/m/n/12.045 验
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -371,13 +371,13 @@ Completed box being shipped out [1]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 象
+....\TU/FandolSong(0)/m/n/12.045 象
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 料
+....\TU/FandolSong(0)/m/n/12.045 料
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -419,21 +419,21 @@ Completed box being shipped out [1]
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 原
+....\TU/FandolSong(0)/m/n/12.045 原
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 料
+....\TU/FandolSong(0)/m/n/12.045 料
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 趋
+....\TU/FandolSong(0)/m/n/12.045 趋
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 势
+....\TU/FandolSong(0)/m/n/12.045 势
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -466,13 +466,13 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x421.10089, glue set 367.90215fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 插
+....\TU/FandolHei(0)/m/n/12.045 插
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 图
+....\TU/FandolHei(0)/m/n/12.045 图
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 索
+....\TU/FandolHei(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 引
+....\TU/FandolHei(0)/m/n/12.045 引
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -505,13 +505,13 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x421.10089, glue set 367.90215fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 表
+....\TU/FandolHei(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 格
+....\TU/FandolHei(0)/m/n/12.045 格
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 索
+....\TU/FandolHei(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 引
+....\TU/FandolHei(0)/m/n/12.045 引
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -544,13 +544,13 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x421.10089, glue set 367.90215fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 参
+....\TU/FandolHei(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 考
+....\TU/FandolHei(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 文
+....\TU/FandolHei(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 献
+....\TU/FandolHei(0)/m/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -583,11 +583,11 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x421.10089, glue set 379.94714fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 致
+....\TU/FandolHei(0)/m/n/12.045 致
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolHei-Regular(0)/m/n/12.045 谢
+....\TU/FandolHei(0)/m/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -620,11 +620,11 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x421.10089, glue set 379.94714fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolHei-Regular(0)/m/n/12.045 声
+....\TU/FandolHei(0)/m/n/12.045 声
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolHei-Regular(0)/m/n/12.045 明
+....\TU/FandolHei(0)/m/n/12.045 明
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -662,36 +662,36 @@ Completed box being shipped out [1]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.10602+2.07173)x47.51752
 ......\special{color push gray 0}
-......\TU/FandolHei-Regular(0)/m/n/12.045 附
+......\TU/FandolHei(0)/m/n/12.045 附
 ......\glue 0.0 plus 0.73799
-......\TU/FandolHei-Regular(0)/m/n/12.045 录
+......\TU/FandolHei(0)/m/n/12.045 录
 ......\glue 3.34851 plus 1.67258 minus 1.11728
 ......\TU/texgyreheros(0)/m/n/12.045 A
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolHei-Regular(0)/m/n/12.045 外
+....\TU/FandolHei(0)/m/n/12.045 外
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 文
+....\TU/FandolHei(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 资
+....\TU/FandolHei(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 料
+....\TU/FandolHei(0)/m/n/12.045 料
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 的
+....\TU/FandolHei(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 调
+....\TU/FandolHei(0)/m/n/12.045 调
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 研
+....\TU/FandolHei(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 阅
+....\TU/FandolHei(0)/m/n/12.045 阅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 读
+....\TU/FandolHei(0)/m/n/12.045 读
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 报
+....\TU/FandolHei(0)/m/n/12.045 报
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 告
+....\TU/FandolHei(0)/m/n/12.045 告
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -993,17 +993,17 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.29587
 ...\hbox(11.77399+2.66495)x421.10089, glue set 164.53856fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 第
+....\TU/FandolHei(0)/m/n/15.05624 第
 ....\glue 4.18564 plus 2.09282 minus 1.3952
 ....\TU/texgyreheros(0)/m/n/15.05624 1
 ....\glue 4.18564 plus 2.09282 minus 1.3952
-....\TU/FandolHei-Regular(0)/m/n/15.05624 章
+....\TU/FandolHei(0)/m/n/15.05624 章
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 15.05624
-....\TU/FandolHei-Regular(0)/m/n/15.05624 引
+....\TU/FandolHei(0)/m/n/15.05624 引
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 言
+....\TU/FandolHei(0)/m/n/15.05624 言
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1019,13 +1019,13 @@ Completed box being shipped out [1]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 14.05249
-....\TU/FandolHei-Regular(0)/m/n/14.05249 研
+....\TU/FandolHei(0)/m/n/14.05249 研
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 究
+....\TU/FandolHei(0)/m/n/14.05249 究
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 背
+....\TU/FandolHei(0)/m/n/14.05249 背
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 景
+....\TU/FandolHei(0)/m/n/14.05249 景
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1046,364 +1046,364 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 初
+....\TU/FandolSong(0)/m/n/12.045 初
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 政
+....\TU/FandolSong(0)/m/n/12.045 政
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 府
+....\TU/FandolSong(0)/m/n/12.045 府
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 专
+....\TU/FandolSong(0)/m/n/12.045 专
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 门
+....\TU/FandolSong(0)/m/n/12.045 门
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 委
+....\TU/FandolSong(0)/m/n/12.045 委
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 员
+....\TU/FandolSong(0)/m/n/12.045 员
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.73799
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 IPCC
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 四
+....\TU/FandolSong(0)/m/n/12.045 四
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.33115
 ...\hbox(9.33487+2.32468)x421.10089, glue set 0.26146
-....\TU/FandolSong-Regular(0)/m/n/12.045 报
+....\TU/FandolSong(0)/m/n/12.045 报
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 告
+....\TU/FandolSong(0)/m/n/12.045 告
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 6.56453
-....\TU/FandolSong-Regular(0)/m/n/12.045 《气
+....\TU/FandolSong(0)/m/n/12.045 《气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2007
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\glue 8.39537 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 科
+....\TU/FandolSong(0)/m/n/12.045 科
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 》
+....\TU/FandolSong(0)/m/n/12.045 》
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 0.55406
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 球
+....\TU/FandolSong(0)/m/n/12.045 球
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 暖
+....\TU/FandolSong(0)/m/n/12.045 暖
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 球
+....\TU/FandolSong(0)/m/n/12.045 球
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 范
+....\TU/FandolSong(0)/m/n/12.045 范
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 围
+....\TU/FandolSong(0)/m/n/12.045 围
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.37932
 ...\hbox(9.371+2.20422)x421.10089, glue set 0.23494
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 素
+....\TU/FandolSong(0)/m/n/12.045 素
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 经
+....\TU/FandolSong(0)/m/n/12.045 经
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 置
+....\TU/FandolSong(0)/m/n/12.045 置
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 疑
+....\TU/FandolSong(0)/m/n/12.045 疑
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 事
+....\TU/FandolSong(0)/m/n/12.045 事
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\kern -0.00017
 ....\kern 0.00017
 ....\TU/texgyretermes(0)/b/n/12.045 ?
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 球
+....\TU/FandolSong(0)/m/n/12.045 球
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 室
+....\TU/FandolSong(0)/m/n/12.045 室
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 浓
+....\TU/FandolSong(0)/m/n/12.045 浓
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 远
+....\TU/FandolSong(0)/m/n/12.045 远
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 超
+....\TU/FandolSong(0)/m/n/12.045 超
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.42749
 ...\hbox(9.44328+2.61375)x421.10089, glue set 0.1491
-....\TU/FandolSong-Regular(0)/m/n/12.045 几
+....\TU/FandolSong(0)/m/n/12.045 几
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 浓
+....\TU/FandolSong(0)/m/n/12.045 浓
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 CO2
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 浓
+....\TU/FandolSong(0)/m/n/12.045 浓
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 280ppm
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2005
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.0541
 ...\hbox(9.40715+2.61375)x421.10089, glue set - 0.23802
 ....\TU/texgyretermes(0)/m/n/12.045 379ppm
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 球
+....\TU/FandolSong(0)/m/n/12.045 球
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 呈
+....\TU/FandolSong(0)/m/n/12.045 呈
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 暖
+....\TU/FandolSong(0)/m/n/12.045 暖
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 征
+....\TU/FandolSong(0)/m/n/12.045 征
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 12
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 11
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 7.98183
 ...\hbox(9.47942+2.32468)x421.10089, glue set - 0.14087
@@ -1411,220 +1411,220 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 暖
+....\TU/FandolSong(0)/m/n/12.045 暖
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 12
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 份
+....\TU/FandolSong(0)/m/n/12.045 份
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 列
+....\TU/FandolSong(0)/m/n/12.045 列
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 50
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 速
+....\TU/FandolSong(0)/m/n/12.045 速
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 每
+....\TU/FandolSong(0)/m/n/12.045 每
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 10
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 0.13^^b0C
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x421.10089, glue set 0.21335
-....\TU/FandolSong-Regular(0)/m/n/12.045 几
+....\TU/FandolSong(0)/m/n/12.045 几
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 乎
+....\TU/FandolSong(0)/m/n/12.045 乎
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 100
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 倍
+....\TU/FandolSong(0)/m/n/12.045 倍
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1980
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 陆
+....\TU/FandolSong(0)/m/n/12.045 陆
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 海
+....\TU/FandolSong(0)/m/n/12.045 海
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 洋
+....\TU/FandolSong(0)/m/n/12.045 洋
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 空
+....\TU/FandolSong(0)/m/n/12.045 空
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 流
+....\TU/FandolSong(0)/m/n/12.045 流
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 层
+....\TU/FandolSong(0)/m/n/12.045 层
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 层
+....\TU/FandolSong(0)/m/n/12.045 层
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.4034
 ...\hbox(9.34692+2.13194)x421.10089, glue set - 0.33592
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 水
+....\TU/FandolSong(0)/m/n/12.045 水
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 汽
+....\TU/FandolSong(0)/m/n/12.045 汽
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 含
+....\TU/FandolSong(0)/m/n/12.045 含
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 许
+....\TU/FandolSong(0)/m/n/12.045 许
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 区
+....\TU/FandolSong(0)/m/n/12.045 区
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 观
+....\TU/FandolSong(0)/m/n/12.045 观
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 测
+....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 降
+....\TU/FandolSong(0)/m/n/12.045 降
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 水
+....\TU/FandolSong(0)/m/n/12.045 水
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1901
 ....\penalty 10000
 ....\glue 3.34851 minus 1.67426
 ....\rule(0.0+0.0)x-3.34851
-....\TU/FandolSong-Regular(0)/m/n/12.045 ～
+....\TU/FandolSong(0)/m/n/12.045 ～
 ....\rule(0.0+0.0)x-3.34851
 ....\glue 3.34851 minus 1.67426
 ....\TU/texgyretermes(0)/m/n/12.045 2005
@@ -1633,198 +1633,198 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.52386
 ...\hbox(9.41919+2.30058)x421.10089, glue set - 0.0787
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 减
+....\TU/FandolSong(0)/m/n/12.045 减
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 趋
+....\TU/FandolSong(0)/m/n/12.045 趋
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 势
+....\TU/FandolSong(0)/m/n/12.045 势
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 球
+....\TU/FandolSong(0)/m/n/12.045 球
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 暖
+....\TU/FandolSong(0)/m/n/12.045 暖
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 征
+....\TU/FandolSong(0)/m/n/12.045 征
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.36726
 ...\hbox(9.40715+2.32468)x421.10089, glue set 0.33643
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 100
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 升
+....\TU/FandolSong(0)/m/n/12.045 升
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 0.65^^b10.15^^b0C
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 略
+....\TU/FandolSong(0)/m/n/12.045 略
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 球
+....\TU/FandolSong(0)/m/n/12.045 球
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 幅
+....\TU/FandolSong(0)/m/n/12.045 幅
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x421.10089, glue set 151.8229fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 尤
+....\TU/FandolSong(0)/m/n/12.045 尤
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 华
+....\TU/FandolSong(0)/m/n/12.045 华
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 北
+....\TU/FandolSong(0)/m/n/12.045 北
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 蒙
+....\TU/FandolSong(0)/m/n/12.045 蒙
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 古
+....\TU/FandolSong(0)/m/n/12.045 古
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 东
+....\TU/FandolSong(0)/m/n/12.045 东
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 东
+....\TU/FandolSong(0)/m/n/12.045 东
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 北
+....\TU/FandolSong(0)/m/n/12.045 北
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 区
+....\TU/FandolSong(0)/m/n/12.045 区
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 升
+....\TU/FandolSong(0)/m/n/12.045 升
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1843,13 +1843,13 @@ C.}
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 14.05249
-....\TU/FandolHei-Regular(0)/m/n/14.05249 研
+....\TU/FandolHei(0)/m/n/14.05249 研
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 究
+....\TU/FandolHei(0)/m/n/14.05249 究
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 现
+....\TU/FandolHei(0)/m/n/14.05249 现
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 状
+....\TU/FandolHei(0)/m/n/14.05249 状
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1868,21 +1868,21 @@ C.}
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 12.045
-....\TU/FandolHei-Regular(0)/m/n/12.045 作
+....\TU/FandolHei(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 物
+....\TU/FandolHei(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 模
+....\TU/FandolHei(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 型
+....\TU/FandolHei(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 发
+....\TU/FandolHei(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 展
+....\TU/FandolHei(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 概
+....\TU/FandolHei(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.73799
-....\TU/FandolHei-Regular(0)/m/n/12.045 述
+....\TU/FandolHei(0)/m/n/12.045 述
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -1896,98 +1896,98 @@ C.}
 ...\glue(\baselineskip) 8.57204
 ...\hbox(9.3951+2.32468)x421.10089, glue set - 0.0787
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 念
+....\TU/FandolSong(0)/m/n/12.045 念
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 农
+....\TU/FandolSong(0)/m/n/12.045 农
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.30704
 ...\hbox(9.44328+2.32468)x421.10089, glue set 0.1038
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 域
+....\TU/FandolSong(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1998,265 +1998,265 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纪
+....\TU/FandolSong(0)/m/n/12.045 纪
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 60
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 代
+....\TU/FandolSong(0)/m/n/12.045 代
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 美
+....\TU/FandolSong(0)/m/n/12.045 美
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 荷
+....\TU/FandolSong(0)/m/n/12.045 荷
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 兰
+....\TU/FandolSong(0)/m/n/12.045 兰
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 先
+....\TU/FandolSong(0)/m/n/12.045 先
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 始
+....\TU/FandolSong(0)/m/n/12.045 始
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set - 0.51968
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 荷
+....\TU/FandolSong(0)/m/n/12.045 荷
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 兰
+....\TU/FandolSong(0)/m/n/12.045 兰
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 强
+....\TU/FandolSong(0)/m/n/12.045 强
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 调
+....\TU/FandolSong(0)/m/n/12.045 调
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set - 0.03935
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 角
+....\TU/FandolSong(0)/m/n/12.045 角
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 深
+....\TU/FandolSong(0)/m/n/12.045 深
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 入
+....\TU/FandolSong(0)/m/n/12.045 入
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 深
+....\TU/FandolSong(0)/m/n/12.045 深
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 入
+....\TU/FandolSong(0)/m/n/12.045 入
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set - 0.17468
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 评
+....\TU/FandolSong(0)/m/n/12.045 评
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 价
+....\TU/FandolSong(0)/m/n/12.045 价
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 农
+....\TU/FandolSong(0)/m/n/12.045 农
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 农
+....\TU/FandolSong(0)/m/n/12.045 农
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 场
+....\TU/FandolSong(0)/m/n/12.045 场
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 策
+....\TU/FandolSong(0)/m/n/12.045 策
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2267,9 +2267,9 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 de
@@ -2280,69 +2280,69 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.36726
 ...\hbox(9.38306+2.32468)x421.10089, glue set - 0.1225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “叶
+....\TU/FandolSong(0)/m/n/12.045 “叶
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 冠
+....\TU/FandolSong(0)/m/n/12.045 冠
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 层
+....\TU/FandolSong(0)/m/n/12.045 层
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 光
+....\TU/FandolSong(0)/m/n/12.045 光
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 奠
+....\TU/FandolSong(0)/m/n/12.045 奠
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2353,83 +2353,83 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 光
+....\TU/FandolSong(0)/m/n/12.045 光
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.36726
 ...\hbox(9.38306+2.32468)x421.10089, glue set - 0.07231
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 入
+....\TU/FandolSong(0)/m/n/12.045 入
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 呼
+....\TU/FandolSong(0)/m/n/12.045 呼
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 吸
+....\TU/FandolSong(0)/m/n/12.045 吸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 早
+....\TU/FandolSong(0)/m/n/12.045 早
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 完
+....\TU/FandolSong(0)/m/n/12.045 完
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 ELCROS
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 1978
@@ -2438,357 +2438,357 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set 0.33083
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 做
+....\TU/FandolSong(0)/m/n/12.045 做
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 碳
+....\TU/FandolSong(0)/m/n/12.045 碳
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 衡
+....\TU/FandolSong(0)/m/n/12.045 衡
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 蒸
+....\TU/FandolSong(0)/m/n/12.045 蒸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 腾
+....\TU/FandolSong(0)/m/n/12.045 腾
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 阐
+....\TU/FandolSong(0)/m/n/12.045 阐
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 BACROS
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set 0.06703
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 PHOTO
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 些
+....\TU/FandolSong(0)/m/n/12.045 些
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 综
+....\TU/FandolSong(0)/m/n/12.045 综
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 许
+....\TU/FandolSong(0)/m/n/12.045 许
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 描
+....\TU/FandolSong(0)/m/n/12.045 描
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 细
+....\TU/FandolSong(0)/m/n/12.045 细
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set 0.11047
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1980
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\penalty 10000
 ....\glue 0.0 plus 0.73799
 ....\glue 3.34851 minus 1.67426
 ....\rule(0.0+0.0)x-3.34851
-....\TU/FandolSong-Regular(0)/m/n/12.045 ～
+....\TU/FandolSong(0)/m/n/12.045 ～
 ....\rule(0.0+0.0)x-3.34851
 ....\glue 3.34851 minus 1.67426
 ....\TU/texgyretermes(0)/m/n/12.045 1990
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 农
+....\TU/FandolSong(0)/m/n/12.045 农
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 划
+....\TU/FandolSong(0)/m/n/12.045 划
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 土
+....\TU/FandolSong(0)/m/n/12.045 土
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 评
+....\TU/FandolSong(0)/m/n/12.045 评
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 价
+....\TU/FandolSong(0)/m/n/12.045 价
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 预
+....\TU/FandolSong(0)/m/n/12.045 预
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 报
+....\TU/FandolSong(0)/m/n/12.045 报
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.27649)x421.10089, glue set 0.33409
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 际
+....\TU/FandolSong(0)/m/n/12.045 际
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 促
+....\TU/FandolSong(0)/m/n/12.045 促
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 SUCROS
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.43954
 ...\hbox(9.35896+2.32468)x421.10089, glue set 0.23201
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 潜
+....\TU/FandolSong(0)/m/n/12.045 潜
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 形
+....\TU/FandolSong(0)/m/n/12.045 形
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 SUCROS1
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 土
+....\TU/FandolSong(0)/m/n/12.045 土
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 壤
+....\TU/FandolSong(0)/m/n/12.045 壤
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 水
+....\TU/FandolSong(0)/m/n/12.045 水
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 衡
+....\TU/FandolSong(0)/m/n/12.045 衡
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 块
+....\TU/FandolSong(0)/m/n/12.045 块
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 SAHEL
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 联
+....\TU/FandolSong(0)/m/n/12.045 联
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue -2.32468
 ...\glue 0.0 plus 0.0001fil
@@ -2925,124 +2925,124 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 水
+....\TU/FandolSong(0)/m/n/12.045 水
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 限
+....\TU/FandolSong(0)/m/n/12.045 限
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 形
+....\TU/FandolSong(0)/m/n/12.045 形
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 SUCROS
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.4516
 ...\hbox(9.3951+2.32468)x421.10089, glue set 23.43527fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 简
+....\TU/FandolSong(0)/m/n/12.045 简
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 WOFOST
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 又
+....\TU/FandolSong(0)/m/n/12.045 又
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 MACROS
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -3208,23 +3208,23 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.28082
 ...\hbox(11.78903+2.71011)x421.10089, glue set 141.9542fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 第
+....\TU/FandolHei(0)/m/n/15.05624 第
 ....\glue 4.18564 plus 2.09282 minus 1.3952
 ....\TU/texgyreheros(0)/m/n/15.05624 2
 ....\glue 4.18564 plus 2.09282 minus 1.3952
-....\TU/FandolHei-Regular(0)/m/n/15.05624 章
+....\TU/FandolHei(0)/m/n/15.05624 章
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 15.05624
-....\TU/FandolHei-Regular(0)/m/n/15.05624 资
+....\TU/FandolHei(0)/m/n/15.05624 资
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 料
+....\TU/FandolHei(0)/m/n/15.05624 料
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 与
+....\TU/FandolHei(0)/m/n/15.05624 与
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 试
+....\TU/FandolHei(0)/m/n/15.05624 试
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 验
+....\TU/FandolHei(0)/m/n/15.05624 验
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -3240,13 +3240,13 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 14.05249
-....\TU/FandolHei-Regular(0)/m/n/14.05249 气
+....\TU/FandolHei(0)/m/n/14.05249 气
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 象
+....\TU/FandolHei(0)/m/n/14.05249 象
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 资
+....\TU/FandolHei(0)/m/n/14.05249 资
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 料
+....\TU/FandolHei(0)/m/n/14.05249 料
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -3262,100 +3262,100 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.15047
 ...\hbox(9.3951+2.32468)x421.10089, glue set 0.23436
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 候
+....\TU/FandolSong(0)/m/n/12.045 候
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 去
+....\TU/FandolSong(0)/m/n/12.045 去
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 55
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 冬
+....\TU/FandolSong(0)/m/n/12.045 冬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 趋
+....\TU/FandolSong(0)/m/n/12.045 趋
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 势
+....\TU/FandolSong(0)/m/n/12.045 势
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 析
+....\TU/FandolSong(0)/m/n/12.045 析
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 采
+....\TU/FandolSong(0)/m/n/12.045 采
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 象
+....\TU/FandolSong(0)/m/n/12.045 象
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x421.10089, glue set 230.69357fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 北
+....\TU/FandolSong(0)/m/n/12.045 北
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 京
+....\TU/FandolSong(0)/m/n/12.045 京
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 象
+....\TU/FandolSong(0)/m/n/12.045 象
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 站
+....\TU/FandolSong(0)/m/n/12.045 站
 ....\glue 0.0 plus 0.73799
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 No.54511
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （表
+....\TU/FandolSong(0)/m/n/12.045 （表
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -3365,10 +3365,10 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\hbox(0.0+0.0)x0.0
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -3393,7 +3393,7 @@ Completed box being shipped out [3]
 .......\hbox(10.0475+4.30612)x421.10089, glue set 141.54266fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
-........\TU/FandolSong-Regular(0)/m/n/11.04124 表
+........\TU/FandolSong(0)/m/n/11.04124 表
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
@@ -3405,23 +3405,23 @@ Completed box being shipped out [3]
 ........\rule(10.0475+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
-........\TU/FandolSong-Regular(0)/m/n/11.04124 北
+........\TU/FandolSong(0)/m/n/11.04124 北
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 京
+........\TU/FandolSong(0)/m/n/11.04124 京
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 气
+........\TU/FandolSong(0)/m/n/11.04124 气
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 象
+........\TU/FandolSong(0)/m/n/11.04124 象
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 站
+........\TU/FandolSong(0)/m/n/11.04124 站
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 基
+........\TU/FandolSong(0)/m/n/11.04124 基
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 本
+........\TU/FandolSong(0)/m/n/11.04124 本
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 信
+........\TU/FandolSong(0)/m/n/11.04124 信
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 息
+........\TU/FandolSong(0)/m/n/11.04124 息
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
@@ -3454,9 +3454,9 @@ Completed box being shipped out [3]
 ..........\glue 6.0
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 0.00002
-..........\TU/FandolSong-Regular(0)/m/n/12.045 站
+..........\TU/FandolSong(0)/m/n/12.045 站
 ..........\glue 0.0 plus 0.73799
-..........\TU/FandolSong-Regular(0)/m/n/12.045 点
+..........\TU/FandolSong(0)/m/n/12.045 点
 ..........\kern -0.00018
 ..........\kern 0.00018
 ..........\glue 0.0 plus 1.0fil
@@ -3466,9 +3466,9 @@ Completed box being shipped out [3]
 ..........\glue 6.0
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 0.00002
-..........\TU/FandolSong-Regular(0)/m/n/12.045 站
+..........\TU/FandolSong(0)/m/n/12.045 站
 ..........\glue 0.0 plus 0.73799
-..........\TU/FandolSong-Regular(0)/m/n/12.045 号
+..........\TU/FandolSong(0)/m/n/12.045 号
 ..........\kern -0.00018
 ..........\kern 0.00018
 ..........\glue 0.0 plus 1.0fil
@@ -3478,9 +3478,9 @@ Completed box being shipped out [3]
 ..........\glue 6.0
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 0.00002
-..........\TU/FandolSong-Regular(0)/m/n/12.045 纬
+..........\TU/FandolSong(0)/m/n/12.045 纬
 ..........\glue 0.0 plus 0.73799
-..........\TU/FandolSong-Regular(0)/m/n/12.045 度
+..........\TU/FandolSong(0)/m/n/12.045 度
 ..........\kern -0.00018
 ..........\kern 0.00018
 ..........\glue 0.0 plus 1.0fil
@@ -3490,9 +3490,9 @@ Completed box being shipped out [3]
 ..........\glue 6.0
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 0.00002
-..........\TU/FandolSong-Regular(0)/m/n/12.045 经
+..........\TU/FandolSong(0)/m/n/12.045 经
 ..........\glue 0.0 plus 0.73799
-..........\TU/FandolSong-Regular(0)/m/n/12.045 度
+..........\TU/FandolSong(0)/m/n/12.045 度
 ..........\kern -0.00018
 ..........\kern 0.00018
 ..........\glue 0.0 plus 1.0fil
@@ -3502,9 +3502,9 @@ Completed box being shipped out [3]
 ..........\glue 6.0
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 0.00002
-..........\TU/FandolSong-Regular(0)/m/n/12.045 高
+..........\TU/FandolSong(0)/m/n/12.045 高
 ..........\glue 0.0 plus 0.73799
-..........\TU/FandolSong-Regular(0)/m/n/12.045 度
+..........\TU/FandolSong(0)/m/n/12.045 度
 ..........\kern -0.00018
 ..........\kern 0.00018
 ..........\glue 0.0 plus 1.0fil
@@ -3620,9 +3620,9 @@ Completed box being shipped out [3]
 ..........\glue 6.0
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 0.00002
-..........\TU/FandolSong-Regular(0)/m/n/12.045 北
+..........\TU/FandolSong(0)/m/n/12.045 北
 ..........\glue 0.0 plus 0.73799
-..........\TU/FandolSong-Regular(0)/m/n/12.045 京
+..........\TU/FandolSong(0)/m/n/12.045 京
 ..........\glue 3.01125 plus 1.5041 minus 1.00473
 ..........\TU/texgyretermes(0)/m/n/12.045 Beijing
 ..........\kern -0.00021
@@ -3687,123 +3687,123 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.25887
 ...\hbox(9.40715+2.2283)x421.10089, glue set - 0.21962
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 象
+....\TU/FandolSong(0)/m/n/12.045 象
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 料
+....\TU/FandolSong(0)/m/n/12.045 料
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 包
+....\TU/FandolSong(0)/m/n/12.045 包
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 括
+....\TU/FandolSong(0)/m/n/12.045 括
 ....\TU/texgyretermes(0)/m/n/12.045 :
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 压
+....\TU/FandolSong(0)/m/n/12.045 压
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 低
+....\TU/FandolSong(0)/m/n/12.045 低
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 温
+....\TU/FandolSong(0)/m/n/12.045 温
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 湿
+....\TU/FandolSong(0)/m/n/12.045 湿
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 8.4516
 ...\hbox(9.3951+2.18013)x421.10089, glue set 236.1379fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 降
+....\TU/FandolSong(0)/m/n/12.045 降
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 水
+....\TU/FandolSong(0)/m/n/12.045 水
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 风
+....\TU/FandolSong(0)/m/n/12.045 风
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 速
+....\TU/FandolSong(0)/m/n/12.045 速
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 照
+....\TU/FandolSong(0)/m/n/12.045 照
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -3816,73 +3816,73 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.49977
 ...\hbox(9.3951+2.32468)x421.10089, glue set 0.50745
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 缺
+....\TU/FandolSong(0)/m/n/12.045 缺
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 辐
+....\TU/FandolSong(0)/m/n/12.045 辐
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 射
+....\TU/FandolSong(0)/m/n/12.045 射
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 监
+....\TU/FandolSong(0)/m/n/12.045 监
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 测
+....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 料
+....\TU/FandolSong(0)/m/n/12.045 料
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纬
+....\TU/FandolSong(0)/m/n/12.045 纬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 儒
+....\TU/FandolSong(0)/m/n/12.045 儒
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 略
+....\TU/FandolSong(0)/m/n/12.045 略
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 照
+....\TU/FandolSong(0)/m/n/12.045 照
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 依
+....\TU/FandolSong(0)/m/n/12.045 依
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 界
+....\TU/FandolSong(0)/m/n/12.045 界
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 粮
+....\TU/FandolSong(0)/m/n/12.045 粮
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 农
+....\TU/FandolSong(0)/m/n/12.045 农
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 织
+....\TU/FandolSong(0)/m/n/12.045 织
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 FAO
 ....\glue(\rightskip) 0.0
@@ -3890,7 +3890,7 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.6258)x421.10089, glue set - 0.35309
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 Food
@@ -3907,62 +3907,62 @@ Completed box being shipped out [3]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Organization
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 供
+....\TU/FandolSong(0)/m/n/12.045 供
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 净
+....\TU/FandolSong(0)/m/n/12.045 净
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 辐
+....\TU/FandolSong(0)/m/n/12.045 辐
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 射
+....\TU/FandolSong(0)/m/n/12.045 射
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 净
+....\TU/FandolSong(0)/m/n/12.045 净
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 短
+....\TU/FandolSong(0)/m/n/12.045 短
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 波
+....\TU/FandolSong(0)/m/n/12.045 波
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 辐
+....\TU/FandolSong(0)/m/n/12.045 辐
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 射
+....\TU/FandolSong(0)/m/n/12.045 射
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.9457
 ...\hbox(9.50351+2.28853)x421.10089, glue set 380.67787fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 推
+....\TU/FandolSong(0)/m/n/12.045 推
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -3979,17 +3979,17 @@ Completed box being shipped out [3]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 太
+....\TU/FandolSong(0)/m/n/12.045 太
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 阳
+....\TU/FandolSong(0)/m/n/12.045 阳
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 磁
+....\TU/FandolSong(0)/m/n/12.045 磁
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 角
+....\TU/FandolSong(0)/m/n/12.045 角
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -4063,11 +4063,11 @@ Completed box being shipped out [3]
 ...\glue(\belowdisplayshortskip) 12.045 plus 2.00749 minus 2.00749
 ...\glue(\baselineskip) 2.07887
 ...\hbox(9.3951+2.32468)x421.10089, glue set 276.36818fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\kern 0.0005
 ....\kern -0.0005
@@ -4081,26 +4081,26 @@ Completed box being shipped out [3]
 ....\penalty 0
 ....\glue 0.0
 ....\rule(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 —
+....\TU/FandolSong(0)/m/n/12.045 —
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 —
+....\TU/FandolSong(0)/m/n/12.045 —
 ....\rule(0.0+0.0)x0.0
 ....\glue 0.0
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 天
+....\TU/FandolSong(0)/m/n/12.045 天
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -4117,15 +4117,15 @@ Completed box being shipped out [3]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 落
+....\TU/FandolSong(0)/m/n/12.045 落
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 角
+....\TU/FandolSong(0)/m/n/12.045 角
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
@@ -4322,191 +4322,191 @@ Completed box being shipped out [4]
 ...\glue(\topskip) 2.6049
 ...\hbox(9.3951+2.32468)x421.10089, glue set - 0.00252
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 依
+....\TU/FandolSong(0)/m/n/12.045 依
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 CERES
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 WheatGrow
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 原
+....\TU/FandolSong(0)/m/n/12.045 原
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 别
+....\TU/FandolSong(0)/m/n/12.045 别
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.39136
 ...\hbox(9.35896+2.32468)x421.10089, glue set - 0.0787
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 育
+....\TU/FandolSong(0)/m/n/12.045 育
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 干
+....\TU/FandolSong(0)/m/n/12.045 干
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 积
+....\TU/FandolSong(0)/m/n/12.045 积
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 累
+....\TU/FandolSong(0)/m/n/12.045 累
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 拟
+....\TU/FandolSong(0)/m/n/12.045 拟
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 根
+....\TU/FandolSong(0)/m/n/12.045 根
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 田
+....\TU/FandolSong(0)/m/n/12.045 田
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 观
+....\TU/FandolSong(0)/m/n/12.045 观
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 测
+....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 料
+....\TU/FandolSong(0)/m/n/12.045 料
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 冬
+....\TU/FandolSong(0)/m/n/12.045 冬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.2283)x421.10089, glue set 95.54869fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 干
+....\TU/FandolSong(0)/m/n/12.045 干
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 配
+....\TU/FandolSong(0)/m/n/12.045 配
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 框
+....\TU/FandolSong(0)/m/n/12.045 框
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 架
+....\TU/FandolSong(0)/m/n/12.045 架
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 图
+....\TU/FandolSong(0)/m/n/12.045 图
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -4516,9 +4516,9 @@ Completed box being shipped out [4]
 ....\kern 0.0002
 ....\hbox(0.0+0.0)x0.0
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 示
+....\TU/FandolSong(0)/m/n/12.045 示
 ....\TU/texgyretermes(0)/m/n/12.045 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -4561,7 +4561,7 @@ Completed box being shipped out [4]
 .......\hbox(10.0475+4.30612)x421.10089, glue set 119.46017fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
-........\TU/FandolSong-Regular(0)/m/n/11.04124 图
+........\TU/FandolSong(0)/m/n/11.04124 图
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
@@ -4573,31 +4573,31 @@ Completed box being shipped out [4]
 ........\rule(10.0475+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
-........\TU/FandolSong-Regular(0)/m/n/11.04124 冬
+........\TU/FandolSong(0)/m/n/11.04124 冬
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 小
+........\TU/FandolSong(0)/m/n/11.04124 小
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 麦
+........\TU/FandolSong(0)/m/n/11.04124 麦
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 生
+........\TU/FandolSong(0)/m/n/11.04124 生
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 长
+........\TU/FandolSong(0)/m/n/11.04124 长
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 发
+........\TU/FandolSong(0)/m/n/11.04124 发
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 育
+........\TU/FandolSong(0)/m/n/11.04124 育
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 模
+........\TU/FandolSong(0)/m/n/11.04124 模
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 型
+........\TU/FandolSong(0)/m/n/11.04124 型
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 基
+........\TU/FandolSong(0)/m/n/11.04124 基
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 本
+........\TU/FandolSong(0)/m/n/11.04124 本
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 结
+........\TU/FandolSong(0)/m/n/11.04124 结
 ........\glue 0.0 plus 0.3493
-........\TU/FandolSong-Regular(0)/m/n/11.04124 构
+........\TU/FandolSong(0)/m/n/11.04124 构
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
@@ -4627,21 +4627,21 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 14.05249
-....\TU/FandolHei-Regular(0)/m/n/14.05249 原
+....\TU/FandolHei(0)/m/n/14.05249 原
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 料
+....\TU/FandolHei(0)/m/n/14.05249 料
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 结
+....\TU/FandolHei(0)/m/n/14.05249 结
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 构
+....\TU/FandolHei(0)/m/n/14.05249 构
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 变
+....\TU/FandolHei(0)/m/n/14.05249 变
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 化
+....\TU/FandolHei(0)/m/n/14.05249 化
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 趋
+....\TU/FandolHei(0)/m/n/14.05249 趋
 ....\glue 0.0 plus 1.02338
-....\TU/FandolHei-Regular(0)/m/n/14.05249 势
+....\TU/FandolHei(0)/m/n/14.05249 势
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -4655,106 +4655,106 @@ Completed box being shipped out [4]
 ...\glue(\baselineskip) 8.18057
 ...\hbox(9.40715+2.32468)x421.10089, glue set - 0.03935
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 着
+....\TU/FandolSong(0)/m/n/12.045 着
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 社
+....\TU/FandolSong(0)/m/n/12.045 社
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 经
+....\TU/FandolSong(0)/m/n/12.045 经
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 济
+....\TU/FandolSong(0)/m/n/12.045 济
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 速
+....\TU/FandolSong(0)/m/n/12.045 速
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 稳
+....\TU/FandolSong(0)/m/n/12.045 稳
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 品
+....\TU/FandolSong(0)/m/n/12.045 品
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 6.825
 ...\hbox(10.92532+2.32468)x421.10089, glue set 0.07953
-....\TU/FandolSong-Regular(0)/m/n/12.045 费
+....\TU/FandolSong(0)/m/n/12.045 费
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 呈
+....\TU/FandolSong(0)/m/n/12.045 呈
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 速
+....\TU/FandolSong(0)/m/n/12.045 速
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 升
+....\TU/FandolSong(0)/m/n/12.045 升
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 趋
+....\TU/FandolSong(0)/m/n/12.045 趋
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 势
+....\TU/FandolSong(0)/m/n/12.045 势
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -4771,62 +4771,62 @@ Completed box being shipped out [4]
 .....\mathoff
 ....\write1{\FN@pp@footnote@aux{1}{\thepage }}
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 品
+....\TU/FandolSong(0)/m/n/12.045 品
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 费
+....\TU/FandolSong(0)/m/n/12.045 费
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 幅
+....\TU/FandolSong(0)/m/n/12.045 幅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 推
+....\TU/FandolSong(0)/m/n/12.045 推
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 浆
+....\TU/FandolSong(0)/m/n/12.045 浆
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 造
+....\TU/FandolSong(0)/m/n/12.045 造
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.825
 ...\hbox(10.92532+2.20422)x421.10089, glue set 342.15181fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 快
+....\TU/FandolSong(0)/m/n/12.045 快
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 速
+....\TU/FandolSong(0)/m/n/12.045 速
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -4853,204 +4853,204 @@ Completed box being shipped out [4]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2001
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 浆
+....\TU/FandolSong(0)/m/n/12.045 浆
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 费
+....\TU/FandolSong(0)/m/n/12.045 费
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 4.9%
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 2001
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2980
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 万
+....\TU/FandolSong(0)/m/n/12.045 万
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 吨
+....\TU/FandolSong(0)/m/n/12.045 吨
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.2283)x421.10089, glue set 0.18108
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 浆
+....\TU/FandolSong(0)/m/n/12.045 浆
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 费
+....\TU/FandolSong(0)/m/n/12.045 费
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 速
+....\TU/FandolSong(0)/m/n/12.045 速
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 幅
+....\TU/FandolSong(0)/m/n/12.045 幅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 际
+....\TU/FandolSong(0)/m/n/12.045 际
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 映
+....\TU/FandolSong(0)/m/n/12.045 映
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 社
+....\TU/FandolSong(0)/m/n/12.045 社
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 终
+....\TU/FandolSong(0)/m/n/12.045 终
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 品
+....\TU/FandolSong(0)/m/n/12.045 品
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 板
+....\TU/FandolSong(0)/m/n/12.045 板
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 费
+....\TU/FandolSong(0)/m/n/12.045 费
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.43954
 ...\hbox(9.40715+2.32468)x421.10089, glue set 0.32634
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 剧
+....\TU/FandolSong(0)/m/n/12.045 剧
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\TU/texgyretermes(0)/m/n/12.045 )
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 2001
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2004
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 幅
+....\TU/FandolSong(0)/m/n/12.045 幅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 达
+....\TU/FandolSong(0)/m/n/12.045 达
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 14.3%
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 2004
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 费
+....\TU/FandolSong(0)/m/n/12.045 费
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 4455
 ....\kern -0.00021
@@ -5059,39 +5059,39 @@ Completed box being shipped out [4]
 ...\penalty 150
 ...\glue(\baselineskip) 8.41545
 ...\hbox(9.33487+2.1199)x421.10089, glue set 236.1379fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 万
+....\TU/FandolSong(0)/m/n/12.045 万
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 吨
+....\TU/FandolSong(0)/m/n/12.045 吨
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 造
+....\TU/FandolSong(0)/m/n/12.045 造
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 纸
+....\TU/FandolSong(0)/m/n/12.045 纸
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 速
+....\TU/FandolSong(0)/m/n/12.045 速
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 势
+....\TU/FandolSong(0)/m/n/12.045 势
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 头
+....\TU/FandolSong(0)/m/n/12.045 头
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -5122,108 +5122,108 @@ Completed box being shipped out [4]
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ....\hbox(8.4+0.0)x0.0
 .....\rule(8.4+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/9.03374 本
+....\TU/FandolSong(0)/m/n/9.03374 本
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 节
+....\TU/FandolSong(0)/m/n/9.03374 节
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 各
+....\TU/FandolSong(0)/m/n/9.03374 各
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 类
+....\TU/FandolSong(0)/m/n/9.03374 类
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 纸
+....\TU/FandolSong(0)/m/n/9.03374 纸
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 浆
+....\TU/FandolSong(0)/m/n/9.03374 浆
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 及
+....\TU/FandolSong(0)/m/n/9.03374 及
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 纸
+....\TU/FandolSong(0)/m/n/9.03374 纸
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 制
+....\TU/FandolSong(0)/m/n/9.03374 制
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 品
+....\TU/FandolSong(0)/m/n/9.03374 品
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 产
+....\TU/FandolSong(0)/m/n/9.03374 产
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 量
+....\TU/FandolSong(0)/m/n/9.03374 量
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 、
+....\TU/FandolSong(0)/m/n/9.03374 、
 ....\rule(0.0+0.0)x-5.89
 ....\glue 5.89 minus 4.51688
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 进
+....\TU/FandolSong(0)/m/n/9.03374 进
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 口
+....\TU/FandolSong(0)/m/n/9.03374 口
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 数
+....\TU/FandolSong(0)/m/n/9.03374 数
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 量
+....\TU/FandolSong(0)/m/n/9.03374 量
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 数
+....\TU/FandolSong(0)/m/n/9.03374 数
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 据
+....\TU/FandolSong(0)/m/n/9.03374 据
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 如
+....\TU/FandolSong(0)/m/n/9.03374 如
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 无
+....\TU/FandolSong(0)/m/n/9.03374 无
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 特
+....\TU/FandolSong(0)/m/n/9.03374 特
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 殊
+....\TU/FandolSong(0)/m/n/9.03374 殊
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 说
+....\TU/FandolSong(0)/m/n/9.03374 说
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 明
+....\TU/FandolSong(0)/m/n/9.03374 明
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 均
+....\TU/FandolSong(0)/m/n/9.03374 均
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 来
+....\TU/FandolSong(0)/m/n/9.03374 来
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 源
+....\TU/FandolSong(0)/m/n/9.03374 源
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 与
+....\TU/FandolSong(0)/m/n/9.03374 与
 ....\glue 0.0 plus 0.34721
 ....\glue 4.92339 minus 4.50783
 ....\rule(0.0+0.0)x-4.92339
-....\TU/FandolSong-Regular(0)/m/n/9.03374 《中
+....\TU/FandolSong(0)/m/n/9.03374 《中
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 国
+....\TU/FandolSong(0)/m/n/9.03374 国
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 造
+....\TU/FandolSong(0)/m/n/9.03374 造
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 纸
+....\TU/FandolSong(0)/m/n/9.03374 纸
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 年
+....\TU/FandolSong(0)/m/n/9.03374 年
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 鉴
+....\TU/FandolSong(0)/m/n/9.03374 鉴
 ....\glue 2.25844 plus 1.12921 minus 0.7528
 ....\TU/texgyretermes(0)/m/n/9.03374 2002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 》
+....\TU/FandolSong(0)/m/n/9.03374 》
 ....\rule(0.0+0.0)x-4.93242
 ....\glue 4.93242 minus 4.51686
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 及
+....\TU/FandolSong(0)/m/n/9.03374 及
 ....\glue 0.0 plus 0.34721
 ....\glue 4.92339 minus 4.50783
 ....\rule(0.0+0.0)x-4.92339
-....\TU/FandolSong-Regular(0)/m/n/9.03374 《中
+....\TU/FandolSong(0)/m/n/9.03374 《中
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 国
+....\TU/FandolSong(0)/m/n/9.03374 国
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 造
+....\TU/FandolSong(0)/m/n/9.03374 造
 ....\glue(\rightskip) 0.0
 ...\penalty 10250
 ...\glue(\baselineskip) 4.88727
 ...\hbox(7.01018+4.06522)x403.0334, glue set 351.50496fil, shifted 18.06749
-....\TU/FandolSong-Regular(0)/m/n/9.03374 纸
+....\TU/FandolSong(0)/m/n/9.03374 纸
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 年
+....\TU/FandolSong(0)/m/n/9.03374 年
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 鉴
+....\TU/FandolSong(0)/m/n/9.03374 鉴
 ....\glue 2.25844 plus 1.12921 minus 0.7528
 ....\TU/texgyretermes(0)/m/n/9.03374 2006
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 》
+....\TU/FandolSong(0)/m/n/9.03374 》
 ....\rule(0.0+0.0)x-4.93242
 ....\kern 0.0003
 ....\kern -0.0003
@@ -5247,45 +5247,45 @@ Completed box being shipped out [4]
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ....\hbox(8.4+0.0)x0.0
 .....\rule(8.4+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/9.03374 本
+....\TU/FandolSong(0)/m/n/9.03374 本
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 节
+....\TU/FandolSong(0)/m/n/9.03374 节
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 各
+....\TU/FandolSong(0)/m/n/9.03374 各
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 类
+....\TU/FandolSong(0)/m/n/9.03374 类
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 纸
+....\TU/FandolSong(0)/m/n/9.03374 纸
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 浆
+....\TU/FandolSong(0)/m/n/9.03374 浆
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 及
+....\TU/FandolSong(0)/m/n/9.03374 及
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 纸
+....\TU/FandolSong(0)/m/n/9.03374 纸
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 制
+....\TU/FandolSong(0)/m/n/9.03374 制
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 品
+....\TU/FandolSong(0)/m/n/9.03374 品
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 产
+....\TU/FandolSong(0)/m/n/9.03374 产
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 量
+....\TU/FandolSong(0)/m/n/9.03374 量
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 、
+....\TU/FandolSong(0)/m/n/9.03374 、
 ....\rule(0.0+0.0)x-5.89
 ....\glue 5.89 minus 4.51688
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 进
+....\TU/FandolSong(0)/m/n/9.03374 进
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 口
+....\TU/FandolSong(0)/m/n/9.03374 口
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 数
+....\TU/FandolSong(0)/m/n/9.03374 数
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 量
+....\TU/FandolSong(0)/m/n/9.03374 量
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 数
+....\TU/FandolSong(0)/m/n/9.03374 数
 ....\glue 0.0 plus 0.34721
-....\TU/FandolSong-Regular(0)/m/n/9.03374 据
+....\TU/FandolSong(0)/m/n/9.03374 据
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5441,13 +5441,13 @@ C.}
 ...\glue(\baselineskip) 8.58194
 ...\hbox(11.48792+2.5445)x421.10089, glue set 180.43796fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 插
+....\TU/FandolHei(0)/m/n/15.05624 插
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 图
+....\TU/FandolHei(0)/m/n/15.05624 图
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 索
+....\TU/FandolHei(0)/m/n/15.05624 索
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 引
+....\TU/FandolHei(0)/m/n/15.05624 引
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5471,7 +5471,7 @@ C.}
 ....\glue -42.15749
 ....\glue 0.0
 ....\hbox(8.84103+1.73447)x42.15749, glue set 12.045fil
-.....\TU/FandolSong-Regular(0)/m/n/12.045 图
+.....\TU/FandolSong(0)/m/n/12.045 图
 .....\kern -0.00017
 .....\kern 0.00017
 .....\penalty 10000
@@ -5480,31 +5480,31 @@ C.}
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 0.0 plus 1.0fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 冬
+....\TU/FandolSong(0)/m/n/12.045 冬
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 育
+....\TU/FandolSong(0)/m/n/12.045 育
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5676,13 +5676,13 @@ C.}
 ...\glue(\baselineskip) 8.37115
 ...\hbox(11.6987+2.71011)x421.10089, glue set 180.43796fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 表
+....\TU/FandolHei(0)/m/n/15.05624 表
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 格
+....\TU/FandolHei(0)/m/n/15.05624 格
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 索
+....\TU/FandolHei(0)/m/n/15.05624 索
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 引
+....\TU/FandolHei(0)/m/n/15.05624 引
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5706,7 +5706,7 @@ C.}
 ....\glue -42.15749
 ....\glue 0.0
 ....\hbox(9.31079+2.09581)x42.15749, glue set 12.045fil
-.....\TU/FandolSong-Regular(0)/m/n/12.045 表
+.....\TU/FandolSong(0)/m/n/12.045 表
 .....\kern -0.00017
 .....\kern 0.00017
 .....\penalty 10000
@@ -5715,23 +5715,23 @@ C.}
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 0.0 plus 1.0fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 北
+....\TU/FandolSong(0)/m/n/12.045 北
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 京
+....\TU/FandolSong(0)/m/n/12.045 京
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 气
+....\TU/FandolSong(0)/m/n/12.045 气
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 象
+....\TU/FandolSong(0)/m/n/12.045 象
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 站
+....\TU/FandolSong(0)/m/n/12.045 站
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -5919,13 +5919,13 @@ C.}
 ...\glue(\baselineskip) 8.2507
 ...\hbox(11.81915+2.83055)x421.10089, glue set 180.43796fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 参
+....\TU/FandolHei(0)/m/n/15.05624 参
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 考
+....\TU/FandolHei(0)/m/n/15.05624 考
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 文
+....\TU/FandolHei(0)/m/n/15.05624 文
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 献
+....\TU/FandolHei(0)/m/n/15.05624 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5954,49 +5954,49 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辛
+....\TU/FandolSong(0)/m/n/10.53937 辛
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 希
+....\TU/FandolSong(0)/m/n/10.53937 希
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 孟
+....\TU/FandolSong(0)/m/n/10.53937 孟
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 服
+....\TU/FandolSong(0)/m/n/10.53937 服
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 务
+....\TU/FandolSong(0)/m/n/10.53937 务
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 际
+....\TU/FandolSong(0)/m/n/10.53937 际
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讨
+....\TU/FandolSong(0)/m/n/10.53937 讨
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 集
+....\TU/FandolSong(0)/m/n/10.53937 集
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -6005,7 +6005,7 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31609 minus 0.87915
-....\TU/FandolSong-Regular(0)/m/n/10.53937 集
+....\TU/FandolSong(0)/m/n/10.53937 集
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -6014,30 +6014,30 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.0
@@ -6071,11 +6071,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 程
+....\TU/FandolSong(0)/m/n/10.53937 程
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 根
+....\TU/FandolSong(0)/m/n/10.53937 根
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 伟
+....\TU/FandolSong(0)/m/n/10.53937 伟
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -6085,31 +6085,31 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 长
+....\TU/FandolSong(0)/m/n/10.53937 长
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 江
+....\TU/FandolSong(0)/m/n/10.53937 江
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洪
+....\TU/FandolSong(0)/m/n/10.53937 洪
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 水
+....\TU/FandolSong(0)/m/n/10.53937 水
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 成
+....\TU/FandolSong(0)/m/n/10.53937 成
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 因
+....\TU/FandolSong(0)/m/n/10.53937 因
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 减
+....\TU/FandolSong(0)/m/n/10.53937 减
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 灾
+....\TU/FandolSong(0)/m/n/10.53937 灾
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 对
+....\TU/FandolSong(0)/m/n/10.53937 对
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 策
+....\TU/FandolSong(0)/m/n/10.53937 策
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -6117,74 +6117,74 @@ C.}
 ....\kern -0.00024
 ....\kern 0.00024
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 许
+....\TU/FandolSong(0)/m/n/10.53937 许
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 厚
+....\TU/FandolSong(0)/m/n/10.53937 厚
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 泽
+....\TU/FandolSong(0)/m/n/10.53937 泽
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 其
+....\TU/FandolSong(0)/m/n/10.53937 其
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 长
+....\TU/FandolSong(0)/m/n/10.53937 长
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 江
+....\TU/FandolSong(0)/m/n/10.53937 江
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 流
+....\TU/FandolSong(0)/m/n/10.53937 流
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 域
+....\TU/FandolSong(0)/m/n/10.53937 域
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洪
+....\TU/FandolSong(0)/m/n/10.53937 洪
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 涝
+....\TU/FandolSong(0)/m/n/10.53937 涝
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 灾
+....\TU/FandolSong(0)/m/n/10.53937 灾
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 害
+....\TU/FandolSong(0)/m/n/10.53937 害
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 6.92441
 ...\hbox(8.17854+1.86545)x403.99406, glue set 225.71362fil, shifted 17.10683
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 对
+....\TU/FandolSong(0)/m/n/10.53937 对
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 策
+....\TU/FandolSong(0)/m/n/10.53937 策
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -6219,62 +6219,62 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 晓
+....\TU/FandolSong(0)/m/n/10.53937 晓
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 东
+....\TU/FandolSong(0)/m/n/10.53937 东
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 庆
+....\TU/FandolSong(0)/m/n/10.53937 庆
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 红
+....\TU/FandolSong(0)/m/n/10.53937 红
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 叶
+....\TU/FandolSong(0)/m/n/10.53937 叶
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 瑾
+....\TU/FandolSong(0)/m/n/10.53937 瑾
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 琳
+....\TU/FandolSong(0)/m/n/10.53937 琳
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 气
+....\TU/FandolSong(0)/m/n/10.53937 气
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 候
+....\TU/FandolSong(0)/m/n/10.53937 候
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 若
+....\TU/FandolSong(0)/m/n/10.53937 若
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 干
+....\TU/FandolSong(0)/m/n/10.53937 干
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 问
+....\TU/FandolSong(0)/m/n/10.53937 问
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 题
+....\TU/FandolSong(0)/m/n/10.53937 题
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -6283,30 +6283,30 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 然
+....\TU/FandolSong(0)/m/n/10.53937 然
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.0
@@ -6352,61 +6352,61 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 志
+....\TU/FandolSong(0)/m/n/10.53937 志
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 祥
+....\TU/FandolSong(0)/m/n/10.53937 祥
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 间
+....\TU/FandolSong(0)/m/n/10.53937 间
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 断
+....\TU/FandolSong(0)/m/n/10.53937 断
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 动
+....\TU/FandolSong(0)/m/n/10.53937 动
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 力
+....\TU/FandolSong(0)/m/n/10.53937 力
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 统
+....\TU/FandolSong(0)/m/n/10.53937 统
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 随
+....\TU/FandolSong(0)/m/n/10.53937 随
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 机
+....\TU/FandolSong(0)/m/n/10.53937 机
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 扰
+....\TU/FandolSong(0)/m/n/10.53937 扰
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 动
+....\TU/FandolSong(0)/m/n/10.53937 动
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 及
+....\TU/FandolSong(0)/m/n/10.53937 及
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 其
+....\TU/FandolSong(0)/m/n/10.53937 其
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 在
+....\TU/FandolSong(0)/m/n/10.53937 在
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 守
+....\TU/FandolSong(0)/m/n/10.53937 守
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 恒
+....\TU/FandolSong(0)/m/n/10.53937 恒
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 律
+....\TU/FandolSong(0)/m/n/10.53937 律
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 程
+....\TU/FandolSong(0)/m/n/10.53937 程
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 应
+....\TU/FandolSong(0)/m/n/10.53937 应
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 用
+....\TU/FandolSong(0)/m/n/10.53937 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -6415,31 +6415,31 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 数
+....\TU/FandolSong(0)/m/n/10.53937 数
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.55688
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 6.85063
 ...\hbox(8.17854+1.79167)x403.99406, glue set 338.7097fil, shifted 17.10683
-....\TU/FandolSong-Regular(0)/m/n/10.53937 院
+....\TU/FandolSong(0)/m/n/10.53937 院
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -6988,11 +6988,11 @@ Completed box being shipped out [9]
 ...\glue(\baselineskip) 8.41632
 ...\hbox(11.65353+2.75528)x421.10089, glue set 187.96608fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 致
+....\TU/FandolHei(0)/m/n/15.05624 致
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 15.05624
-....\TU/FandolHei-Regular(0)/m/n/15.05624 谢
+....\TU/FandolHei(0)/m/n/15.05624 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -7006,84 +7006,84 @@ Completed box being shipped out [9]
 ...\glue(\baselineskip) 7.88849
 ...\hbox(9.43123+2.32468)x421.10089, glue set - 0.0787
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 致
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 谢
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 象
+....\TU/FandolSong(0)/m/n/12.045 象
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 原
+....\TU/FandolSong(0)/m/n/12.045 原
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 仅
+....\TU/FandolSong(0)/m/n/12.045 仅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 限
+....\TU/FandolSong(0)/m/n/12.045 限
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 术
+....\TU/FandolSong(0)/m/n/12.045 术
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 完
+....\TU/FandolSong(0)/m/n/12.045 完
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 帮
+....\TU/FandolSong(0)/m/n/12.045 帮
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 助
+....\TU/FandolSong(0)/m/n/12.045 助
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
 ...\glue(\baselineskip) 8.6443
 ...\hbox(9.10602+1.97536)x421.10089, glue set 372.9209fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 士
+....\TU/FandolSong(0)/m/n/12.045 士
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -7375,11 +7375,11 @@ Completed box being shipped out [11]
 ...\glue(\baselineskip) 8.38622
 ...\hbox(11.68364+2.69505)x421.10089, glue set 187.96608fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 声
+....\TU/FandolHei(0)/m/n/15.05624 声
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 15.05624
-....\TU/FandolHei-Regular(0)/m/n/15.05624 明
+....\TU/FandolHei(0)/m/n/15.05624 明
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -7393,279 +7393,279 @@ Completed box being shipped out [11]
 ...\glue(\baselineskip) 7.92462
 ...\hbox(9.45532+2.32468)x421.10089, glue set - 0.02623
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 郑
+....\TU/FandolSong(0)/m/n/12.045 郑
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 声
+....\TU/FandolSong(0)/m/n/12.045 声
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\glue 8.39537 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 呈
+....\TU/FandolSong(0)/m/n/12.045 呈
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 师
+....\TU/FandolSong(0)/m/n/12.045 师
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 独
+....\TU/FandolSong(0)/m/n/12.045 独
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x421.10089, glue set - 0.02623
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 尽
+....\TU/FandolSong(0)/m/n/12.045 尽
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 知
+....\TU/FandolSong(0)/m/n/12.045 知
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 除
+....\TU/FandolSong(0)/m/n/12.045 除
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 经
+....\TU/FandolSong(0)/m/n/12.045 经
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 注
+....\TU/FandolSong(0)/m/n/12.045 注
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 外
+....\TU/FandolSong(0)/m/n/12.045 外
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.30058)x421.10089, glue set - 0.0787
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 包
+....\TU/FandolSong(0)/m/n/12.045 包
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 含
+....\TU/FandolSong(0)/m/n/12.045 含
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 何
+....\TU/FandolSong(0)/m/n/12.045 何
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 享
+....\TU/FandolSong(0)/m/n/12.045 享
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 权
+....\TU/FandolSong(0)/m/n/12.045 权
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 涉
+....\TU/FandolSong(0)/m/n/12.045 涉
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 做
+....\TU/FandolSong(0)/m/n/12.045 做
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 贡
+....\TU/FandolSong(0)/m/n/12.045 贡
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 献
+....\TU/FandolSong(0)/m/n/12.045 献
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.40341
 ...\hbox(9.371+2.32468)x421.10089, glue set 175.9129fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 集
+....\TU/FandolSong(0)/m/n/12.045 集
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 确
+....\TU/FandolSong(0)/m/n/12.045 确
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -7681,13 +7681,13 @@ Completed box being shipped out [11]
 ...\hbox(9.32283+3.97446)x421.10089, glue set 150.38715fill
 ....\hbox(0.0+0.0)x24.09
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 签
+....\TU/FandolSong(0)/m/n/12.045 签
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -7705,13 +7705,13 @@ Completed box being shipped out [11]
 .....\rule(0.79489+0.0)x*
 ....\mathoff
 ....\glue 3.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -8017,9 +8017,9 @@ Completed box being shipped out [13]
 ...\glue(\baselineskip) 8.26576
 ...\hbox(11.8041+2.71011)x421.10089, glue set 98.04266fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/15.05624 附
+....\TU/FandolHei(0)/m/n/15.05624 附
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 录
+....\TU/FandolHei(0)/m/n/15.05624 录
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 4.18564 plus 2.09282 minus 1.3952
@@ -8027,27 +8027,27 @@ Completed box being shipped out [13]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\glue 15.05624
-....\TU/FandolHei-Regular(0)/m/n/15.05624 外
+....\TU/FandolHei(0)/m/n/15.05624 外
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 文
+....\TU/FandolHei(0)/m/n/15.05624 文
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 资
+....\TU/FandolHei(0)/m/n/15.05624 资
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 料
+....\TU/FandolHei(0)/m/n/15.05624 料
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 的
+....\TU/FandolHei(0)/m/n/15.05624 的
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 调
+....\TU/FandolHei(0)/m/n/15.05624 调
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 研
+....\TU/FandolHei(0)/m/n/15.05624 研
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 阅
+....\TU/FandolHei(0)/m/n/15.05624 阅
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 读
+....\TU/FandolHei(0)/m/n/15.05624 读
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 报
+....\TU/FandolHei(0)/m/n/15.05624 报
 ....\glue 0.0 plus 1.18555
-....\TU/FandolHei-Regular(0)/m/n/15.05624 告
+....\TU/FandolHei(0)/m/n/15.05624 告
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -8083,21 +8083,21 @@ Completed box being shipped out [13]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 调
+....\TU/FandolSong(0)/m/n/12.045 调
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 阅
+....\TU/FandolSong(0)/m/n/12.045 阅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 读
+....\TU/FandolSong(0)/m/n/12.045 读
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 报
+....\TU/FandolSong(0)/m/n/12.045 报
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 告
+....\TU/FandolSong(0)/m/n/12.045 告
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -8109,68 +8109,68 @@ Completed box being shipped out [13]
 ...\glue(\baselineskip) 8.47568
 ...\hbox(9.40715+2.26445)x421.10089, glue set 0.13647
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 5000
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 外
+....\TU/FandolSong(0)/m/n/12.045 外
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 印
+....\TU/FandolSong(0)/m/n/12.045 印
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 刷
+....\TU/FandolSong(0)/m/n/12.045 刷
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 字
+....\TU/FandolSong(0)/m/n/12.045 字
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 调
+....\TU/FandolSong(0)/m/n/12.045 调
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 阅
+....\TU/FandolSong(0)/m/n/12.045 阅
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 读
+....\TU/FandolSong(0)/m/n/12.045 读
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 报
+....\TU/FandolSong(0)/m/n/12.045 报
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 告
+....\TU/FandolSong(0)/m/n/12.045 告
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 者
+....\TU/FandolSong(0)/m/n/12.045 者
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 书
+....\TU/FandolSong(0)/m/n/12.045 书
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 翻
+....\TU/FandolSong(0)/m/n/12.045 翻
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 译
+....\TU/FandolSong(0)/m/n/12.045 译
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1-2
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 篇
+....\TU/FandolSong(0)/m/n/12.045 篇
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.00021
@@ -8179,20 +8179,20 @@ Completed box being shipped out [13]
 ...\penalty 300
 ...\glue(\baselineskip) 8.4034
 ...\hbox(9.40715+2.26445)x421.10089, glue set 340.53189fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 万
+....\TU/FandolSong(0)/m/n/12.045 万
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 外
+....\TU/FandolSong(0)/m/n/12.045 外
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 印
+....\TU/FandolSong(0)/m/n/12.045 印
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 刷
+....\TU/FandolSong(0)/m/n/12.045 刷
 ....\glue 0.0 plus 0.73799
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\TU/texgyretermes(0)/m/n/12.045 )
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047

--- a/testfiles/07-main-bachelor.tlg
+++ b/testfiles/07-main-bachelor.tlg
@@ -4726,8 +4726,8 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 6.825
-...\hbox(10.92532+2.32468)x421.10089, glue set 0.07953
+...\glue(\baselineskip) 5.02727
+...\hbox(12.72305+2.32468)x421.10089, glue set - 0.07465
 ....\TU/FandolSong(0)/m/n/12.045 费
 ....\glue 0.0 plus 0.73799
 ....\TU/FandolSong(0)/m/n/12.045 量
@@ -4762,10 +4762,10 @@ Completed box being shipped out [4]
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
 ....\penalty 10000
-....\hbox(10.92532+0.0)x6.6791
+....\hbox(12.72305+0.0)x9.53375
 .....\mathon
-.....\hbox(6.10681+0.12646)x6.6791, shifted -4.81851
-......\TU/XITS-Regular.otf(0)/m/n/9.03375 ①
+.....\hbox(7.90454+1.52669)x9.53375, shifted -4.81851
+......\TU/FandolSong(0)/m/n/9.03375 ①
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -4814,8 +4814,8 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 6.825
-...\hbox(10.92532+2.20422)x421.10089, glue set 342.15181fil
+...\glue(\baselineskip) 5.02727
+...\hbox(12.72305+2.20422)x421.10089, glue set 339.29715fil
 ....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.73799
 ....\TU/FandolSong(0)/m/n/12.045 快
@@ -4834,10 +4834,10 @@ Completed box being shipped out [4]
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
 ....\penalty 10000
-....\hbox(10.92532+0.0)x6.6791
+....\hbox(12.72305+0.0)x9.53375
 .....\mathon
-.....\hbox(6.10681+0.12646)x6.6791, shifted -4.81851
-......\TU/XITS-Regular.otf(0)/m/n/9.03375 ②
+.....\hbox(7.90454+1.52669)x9.53375, shifted -4.81851
+......\TU/FandolSong(0)/m/n/9.03375 ②
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -5111,12 +5111,12 @@ Completed box being shipped out [4]
 ...\glue 2.6
 ...\hbox(8.4+1.65315)x403.0334, glue set 0.23544, shifted 18.06749
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.12645)x0.0, glue set - 18.06749fil
+....\hbox(7.90453+1.52669)x0.0, glue set - 18.06749fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.12645)x18.06749
-......\hbox(6.10681+0.12645)x18.06749, glue set 11.88841fil
-.......\hbox(6.10681+0.12645)x6.17908
-........\TU/XITS-Regular.otf(0)/m/n/9.03374 ①
+.....\hbox(7.90453+1.52669)x18.06749
+......\hbox(7.90453+1.52669)x18.06749, glue set 9.03375fil
+.......\hbox(7.90453+1.52669)x9.03374
+........\TU/FandolSong(0)/m/n/9.03374 ①
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5236,12 +5236,12 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\hbox(8.4+4.06522)x403.0334, glue set 231.3924fil, shifted 18.06749
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.12645)x0.0, glue set - 18.06749fil
+....\hbox(7.90453+1.52669)x0.0, glue set - 18.06749fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.12645)x18.06749
-......\hbox(6.10681+0.12645)x18.06749, glue set 11.88841fil
-.......\hbox(6.10681+0.12645)x6.17908
-........\TU/XITS-Regular.otf(0)/m/n/9.03374 ②
+.....\hbox(7.90453+1.52669)x18.06749
+......\hbox(7.90453+1.52669)x18.06749, glue set 9.03375fil
+.......\hbox(7.90453+1.52669)x9.03374
+........\TU/FandolSong(0)/m/n/9.03374 ②
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil

--- a/testfiles/07-main.tlg
+++ b/testfiles/07-main.tlg
@@ -130,7 +130,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
-..\vbox(674.33032+0.0)x426.79135, glue set 16.4673fill
+..\vbox(674.33032+0.0)x426.79135, glue set 16.57571fill
 ...\write-{}
 ...\special{color push gray 0}
 ...\write1{\protect \providecommand {\protect \FN@pp@footnotehinttrue }{}}
@@ -456,7 +456,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
-...\hbox(9.636+2.40898)x426.79135, glue set - 0.37794
+...\hbox(9.636+2.40898)x426.79135, glue set 0.3217
 ....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 解
@@ -530,11 +530,11 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 系
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.2068
+....\TU/FandolSong(0)/m/n/12.045 统
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 数
@@ -604,11 +604,11 @@ Completed box being shipped out [1]
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.28853)x426.79135, glue set 0.3217
+....\TU/FandolSong(0)/m/n/12.045 统
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 索
@@ -682,12 +682,11 @@ Completed box being shipped out [1]
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 后
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue(\rightskip) 0.0
-...\penalty 150
-...\glue(\baselineskip) 6.86115
-...\hbox(10.92532+2.28853)x426.79135, glue set - 0.24287
+...\glue(\baselineskip) 8.28296
+...\hbox(9.50351+2.28853)x426.79135, glue set 0.06274
+....\TU/FandolSong(0)/m/n/12.045 面
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 四
@@ -761,13 +760,15 @@ Completed box being shipped out [1]
 ....\kern 0.00047
 ....\kern -0.00047
 ....\kern -0.18753
-....\kern 0.18753
-....\glue 7.75697 minus 6.02249
-....\penalty 10000
-....\hbox(10.92532+0.0)x6.6791
+....\kern 0.0
+....\glue(\rightskip) 0.0
+...\penalty 150
+...\glue(\baselineskip) 5.06342
+...\hbox(12.72305+0.0)x426.79135, glue set 417.2576fil
+....\hbox(12.72305+0.0)x9.53375
 .....\mathon
-.....\hbox(6.10681+0.12646)x6.6791, shifted -4.81851
-......\TU/XITS-Regular.otf(0)/m/n/9.03375 ①
+.....\hbox(7.90454+1.52669)x9.53375, shifted -4.81851
+......\TU/FandolSong(0)/m/n/9.03375 ①
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -776,7 +777,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
-...\glue(\baselineskip) 8.4275
+...\glue(\baselineskip) 10.71603
 ...\hbox(9.35896+2.32468)x426.79135, glue set 0.29543
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 从
@@ -2089,82 +2090,6 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 [42-
 ....\discretionary
 ....\glue(\rightskip) 0.0
-...\penalty 100
-...\glue(\baselineskip) 8.45158
-...\hbox(9.40715+2.32468)x426.79135, glue set 0.0323
-....\TU/texgyretermes(0)/m/n/12.045 54,106]
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\glue 7.75697 minus 6.02249
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 其
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 中
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 最
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 为
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 重
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 要
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 手
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 段
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 就
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 是
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 主
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 动
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 扩
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 散
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 据
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 索
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 引
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 即
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 结
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 点
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 只
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 存
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 储
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 自
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 身
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 据
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fill
 ...\glue 10.8 plus 4.0 minus 2.0
 ...\special{color push gray 0}
@@ -2173,12 +2098,12 @@ Completed box being shipped out [1]
 ...\glue 2.6
 ...\hbox(8.4+1.7435)x408.72386, glue set - 0.06303, shifted 18.06749
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.12645)x0.0, glue set - 18.06749fil
+....\hbox(7.90453+1.52669)x0.0, glue set - 18.06749fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.12645)x18.06749
-......\hbox(6.10681+0.12645)x18.06749, glue set 11.88841fil
-.......\hbox(6.10681+0.12645)x6.17908
-........\TU/XITS-Regular.otf(0)/m/n/9.03374 ①
+.....\hbox(7.90453+1.52669)x18.06749
+......\hbox(7.90453+1.52669)x18.06749, glue set 9.03375fil
+.......\hbox(7.90453+1.52669)x9.03374
+........\TU/FandolSong(0)/m/n/9.03374 ①
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2628,7 +2553,82 @@ Completed box being shipped out [2]
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
 ..\vbox(674.33032+0.0)x426.79135, glue set >20000.0fil
-...\glue(\topskip) 2.364
+...\glue(\topskip) 2.59285
+...\hbox(9.40715+2.32468)x426.79135, glue set 0.0323
+....\TU/texgyretermes(0)/m/n/12.045 54,106]
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\glue 7.75697 minus 6.02249
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 其
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 中
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 最
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 为
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 重
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 要
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 手
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 段
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 就
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 是
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 主
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 动
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 扩
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 散
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 据
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 索
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 引
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 即
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 结
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 点
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 不
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 只
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 存
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 储
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 自
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 身
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 据
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.31483
 ....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
@@ -4878,81 +4878,6 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue(\parskip) 0.0 plus 1.0
-...\glue(\baselineskip) 8.24681
-...\hbox(9.50351+2.32468)x426.79135, glue set - 0.06168
-....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 虽
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 然
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 在
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 特
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 定
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 应
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 用
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 中
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 使
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 用
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 一
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 定
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 是
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 严
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 格
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
-....\glue 7.04633 minus 6.0225
-....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong(0)/m/n/12.045 “一
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 般
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 性
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 搜
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 索
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ”
-....\penalty 10000
-....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 其
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 据
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 与
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 结
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 点
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 之
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 间
-....\glue(\rightskip) 0.0
 ...\glue -2.32468
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 7.14894
@@ -5132,7 +5057,82 @@ Completed box being shipped out [3]
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
 ..\vbox(674.33032+0.0)x426.79135, glue set >20000.0fil
-...\glue(\topskip) 2.6049
+...\glue(\topskip) 2.49649
+...\hbox(9.50351+2.32468)x426.79135, glue set - 0.06168
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 虽
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 然
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 在
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 特
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 定
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 应
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 用
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 中
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 使
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 用
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 不
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 一
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 定
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 是
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 严
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 格
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.52307
+....\glue 7.04633 minus 6.0225
+....\rule(0.0+0.0)x-7.04633
+....\TU/FandolSong(0)/m/n/12.045 “一
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 般
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 性
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 搜
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 索
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ”
+....\penalty 10000
+....\glue -6.0225 plus 6.0225 minus 1.02382
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 其
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 据
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 与
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 结
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 点
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 之
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 间
+....\glue(\rightskip) 0.0
+...\penalty 150
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.31165
 ....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
@@ -7205,85 +7205,6 @@ Completed box being shipped out [3]
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 8.03001
-...\hbox(9.636+2.40898)x426.79135, glue set - 0.30394
-....\TU/FandolSong(0)/m/n/12.045 这
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 种
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 分
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 布
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 一
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 般
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 用
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 指
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 分
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 布
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 来
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 刻
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 画
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\glue 7.75697 minus 6.02249
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 具
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 体
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 来
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 说
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 设
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 结
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 点
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 平
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 均
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 在
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 线
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 服
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 务
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 时
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 间
-....\glue 0.0 plus 0.52307
-....\glue 7.63654 minus 6.0225
-....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong(0)/m/n/12.045 （
-....\penalty 10000
-....\glue 0.0
-....\TU/texgyretermes(0)/m/n/12.045 session
-....\kern -0.00021
-....\kern 0.0
-....\glue(\rightskip) 0.0
 ...\glue -2.40898
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 7.14894
@@ -7477,6 +7398,85 @@ Completed box being shipped out [4]
 ..\glue(\lineskip) 0.0
 ..\vbox(674.33032+0.0)x426.79135, glue set >20000.0fil
 ...\glue(\topskip) 2.364
+...\hbox(9.636+2.40898)x426.79135, glue set - 0.30394
+....\TU/FandolSong(0)/m/n/12.045 这
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 种
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 分
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 布
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 一
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 般
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 用
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 指
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 分
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 布
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 来
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 刻
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 画
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\glue 7.75697 minus 6.02249
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 具
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 体
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 来
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 说
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 设
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 结
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 点
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 平
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 均
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 在
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 线
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 服
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 务
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 时
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 间
+....\glue 0.0 plus 0.52307
+....\glue 7.63654 minus 6.0225
+....\rule(0.0+0.0)x-7.63654
+....\TU/FandolSong(0)/m/n/12.045 （
+....\penalty 10000
+....\glue 0.0
+....\TU/texgyretermes(0)/m/n/12.045 session
+....\kern -0.00021
+....\kern 0.0
+....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+3.10188)x426.79135, glue set - 0.09775
 ....\TU/texgyretermes(0)/m/n/12.045 time
 ....\penalty 10000
@@ -9380,90 +9380,6 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 索
-....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 8.25887
-...\hbox(9.49146+2.32468)x426.79135, glue set - 0.22678
-....\TU/FandolSong(0)/m/n/12.045 引
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 则
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 搜
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 索
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 过
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 程
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 结
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 束
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 成
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 功
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 返
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 回
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ；
-....\rule(0.0+0.0)x-8.32309
-....\glue 8.32309 minus 6.02249
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 否
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 则
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 搜
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 索
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 继
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 续
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 寻
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 求
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 尚
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 未
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 遍
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 历
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 新
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 结
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 点
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\glue 7.75697 minus 6.02249
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 于
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 是
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue(\rightskip) 0.0
 ...\glue -2.32468
 ...\glue 0.0 plus 0.0001fil
@@ -11579,7 +11495,91 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue -6.02249
 ...\glue 6.02249
-...\glue(\topskip) 2.59285
+...\glue(\topskip) 2.50854
+...\hbox(9.49146+2.32468)x426.79135, glue set - 0.22678
+....\TU/FandolSong(0)/m/n/12.045 引
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 则
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 搜
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 索
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 过
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 程
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 结
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 束
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 成
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 功
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 返
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 回
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ；
+....\rule(0.0+0.0)x-8.32309
+....\glue 8.32309 minus 6.02249
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 否
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 则
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 搜
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 索
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 继
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 续
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 寻
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 求
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 尚
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 未
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 遍
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 历
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 新
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 结
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 点
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\glue 7.75697 minus 6.02249
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 于
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 是
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 搜
+....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+4.70088)x426.79135, glue set - 0.27238
 ....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
@@ -12624,87 +12624,7 @@ Completed box being shipped out [5]
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 否
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 8.295
-...\hbox(9.45532+3.10188)x426.79135, glue set 0.26299
-....\TU/FandolSong(0)/m/n/12.045 则
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 就
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 有
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 效
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 据
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 索
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 引
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 个
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 就
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 会
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 断
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 减
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 少
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 直
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 至
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 为
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 零
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\glue 7.75697 minus 6.02249
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 因
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 此
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 系
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 统
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 总
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 带
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 宽
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 开
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 销
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\mathon
-....\hbox(7.86539+0.21681)x17.39297
-.....\TU/texgyretermes(1)/m/it/12.045 glyph#35
-.....\TU/texgyretermes(1)/m/it/12.045 glyph#114
-....\hbox(6.17006+0.09032)x16.56201, shifted 3.01157
-.....\TU/texgyretermes(0)/m/n/9.03375 total
-.....\kern -0.0002
-.....\kern 0.0002
-....\mathoff
-....\glue(\rightskip) 0.0
-...\glue -3.10188
+...\glue -2.32468
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 7.14894
 ..\hbox(15.61334+4.1104)x426.79135
@@ -12882,8 +12802,89 @@ Completed box being shipped out [6]
 ....\special{color pop}
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
-..\vbox(674.33032+0.0)x426.79135, glue set 273.13348fil
-...\glue(\topskip) 2.64104
+..\vbox(674.33032+0.0)x426.79135, glue set 253.06064fil
+...\glue(\topskip) 2.54468
+...\hbox(9.45532+3.10188)x426.79135, glue set 0.26299
+....\TU/FandolSong(0)/m/n/12.045 则
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 就
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 有
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 效
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 据
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 索
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 引
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 个
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 就
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 会
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 不
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 断
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 减
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 少
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 直
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 至
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 为
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 零
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\glue 7.75697 minus 6.02249
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 因
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 此
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 系
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 统
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 总
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 带
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 宽
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 开
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 销
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\mathon
+....\hbox(7.86539+0.21681)x17.39297
+.....\TU/texgyretermes(1)/m/it/12.045 glyph#35
+.....\TU/texgyretermes(1)/m/it/12.045 glyph#114
+....\hbox(6.17006+0.09032)x16.56201, shifted 3.01157
+.....\TU/texgyretermes(0)/m/n/9.03375 total
+.....\kern -0.0002
+.....\kern 0.0002
+....\mathoff
+....\glue(\rightskip) 0.0
+...\penalty 50
+...\glue(\baselineskip) 7.61415
 ...\hbox(9.35896+3.10188)x426.79135, glue set 19.63101fil
 ....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307

--- a/testfiles/07-main.tlg
+++ b/testfiles/07-main.tlg
@@ -61,53 +61,53 @@ Completed box being shipped out [1]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 86.92326fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 3
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 等
+..........\TU/FandolSong(0)/m/n/10.53937 等
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 网
+..........\TU/FandolSong(0)/m/n/10.53937 网
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 络
+..........\TU/FandolSong(0)/m/n/10.53937 络
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 中
+..........\TU/FandolSong(0)/m/n/10.53937 中
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+..........\TU/FandolSong(0)/m/n/10.53937 宽
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 松
+..........\TU/FandolSong(0)/m/n/10.53937 松
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 约
+..........\TU/FandolSong(0)/m/n/10.53937 约
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 束
+..........\TU/FandolSong(0)/m/n/10.53937 束
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 一
+..........\TU/FandolSong(0)/m/n/10.53937 一
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 般
+..........\TU/FandolSong(0)/m/n/10.53937 般
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 性
+..........\TU/FandolSong(0)/m/n/10.53937 性
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+..........\TU/FandolSong(0)/m/n/10.53937 搜
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 索
+..........\TU/FandolSong(0)/m/n/10.53937 索
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 模
+..........\TU/FandolSong(0)/m/n/10.53937 模
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 型
+..........\TU/FandolSong(0)/m/n/10.53937 型
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -152,53 +152,53 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 3.43684
 ...\hbox(12.62315+2.8426)x426.79135, glue set 19.77635fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 第
+....\TU/FandolHei(0)/m/n/16.06 第
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 3
 ....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/FandolHei-Regular(0)/m/n/16.06 章
+....\TU/FandolHei(0)/m/n/16.06 章
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 对
+....\TU/FandolHei(0)/m/n/16.06 对
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 等
+....\TU/FandolHei(0)/m/n/16.06 等
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 网
+....\TU/FandolHei(0)/m/n/16.06 网
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 络
+....\TU/FandolHei(0)/m/n/16.06 络
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 中
+....\TU/FandolHei(0)/m/n/16.06 中
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 宽
+....\TU/FandolHei(0)/m/n/16.06 宽
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 松
+....\TU/FandolHei(0)/m/n/16.06 松
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 约
+....\TU/FandolHei(0)/m/n/16.06 约
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 束
+....\TU/FandolHei(0)/m/n/16.06 束
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 的
+....\TU/FandolHei(0)/m/n/16.06 的
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 一
+....\TU/FandolHei(0)/m/n/16.06 一
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 般
+....\TU/FandolHei(0)/m/n/16.06 般
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 性
+....\TU/FandolHei(0)/m/n/16.06 性
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 搜
+....\TU/FandolHei(0)/m/n/16.06 搜
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 索
+....\TU/FandolHei(0)/m/n/16.06 索
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 的
+....\TU/FandolHei(0)/m/n/16.06 的
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 理
+....\TU/FandolHei(0)/m/n/16.06 理
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 论
+....\TU/FandolHei(0)/m/n/16.06 论
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 模
+....\TU/FandolHei(0)/m/n/16.06 模
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 型
+....\TU/FandolHei(0)/m/n/16.06 型
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -214,13 +214,13 @@ Completed box being shipped out [1]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 14.05249
-....\TU/FandolHei-Regular(0)/m/n/14.05249 本
+....\TU/FandolHei(0)/m/n/14.05249 本
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 章
+....\TU/FandolHei(0)/m/n/14.05249 章
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 引
+....\TU/FandolHei(0)/m/n/14.05249 引
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 论
+....\TU/FandolHei(0)/m/n/14.05249 论
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -236,148 +236,148 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.1043
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.21907
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.28853)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 根
+....\TU/FandolSong(0)/m/n/12.045 根
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 测
+....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.33115
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.29672
@@ -385,378 +385,378 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.37794
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 瓶
+....\TU/FandolSong(0)/m/n/12.045 瓶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 颈
+....\TU/FandolSong(0)/m/n/12.045 颈
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （即
+....\TU/FandolSong(0)/m/n/12.045 （即
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 限
+....\TU/FandolSong(0)/m/n/12.045 限
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.2068
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 达
+....\TU/FandolSong(0)/m/n/12.045 达
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.28853)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 比
+....\TU/FandolSong(0)/m/n/12.045 比
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 析
+....\TU/FandolSong(0)/m/n/12.045 析
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 供
+....\TU/FandolSong(0)/m/n/12.045 供
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 6.86115
 ...\hbox(10.92532+2.28853)x426.79135, glue set - 0.24287
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 四
+....\TU/FandolSong(0)/m/n/12.045 四
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 似
+....\TU/FandolSong(0)/m/n/12.045 似
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 接
+....\TU/FandolSong(0)/m/n/12.045 接
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -779,624 +779,624 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.4275
 ...\hbox(9.35896+2.32468)x426.79135, glue set 0.29543
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 讨
+....\TU/FandolSong(0)/m/n/12.045 讨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 知
+....\TU/FandolSong(0)/m/n/12.045 知
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 途
+....\TU/FandolSong(0)/m/n/12.045 途
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 域
+....\TU/FandolSong(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x426.79135, glue set - 0.22678
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 功
+....\TU/FandolSong(0)/m/n/12.045 功
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 确
+....\TU/FandolSong(0)/m/n/12.045 确
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 起
+....\TU/FandolSong(0)/m/n/12.045 起
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 里
+....\TU/FandolSong(0)/m/n/12.045 里
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\glue 8.39537 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谓
+....\TU/FandolSong(0)/m/n/12.045 谓
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “宽
+....\TU/FandolSong(0)/m/n/12.045 “宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 返
+....\TU/FandolSong(0)/m/n/12.045 返
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 返
+....\TU/FandolSong(0)/m/n/12.045 返
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 若
+....\TU/FandolSong(0)/m/n/12.045 若
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 干
+....\TU/FandolSong(0)/m/n/12.045 干
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （根
+....\TU/FandolSong(0)/m/n/12.045 （根
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 户
+....\TU/FandolSong(0)/m/n/12.045 户
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.22678
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 即
+....\TU/FandolSong(0)/m/n/12.045 即
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谓
+....\TU/FandolSong(0)/m/n/12.045 谓
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “一
+....\TU/FandolSong(0)/m/n/12.045 “一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 必
+....\TU/FandolSong(0)/m/n/12.045 必
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 须
+....\TU/FandolSong(0)/m/n/12.045 须
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 说
+....\TU/FandolSong(0)/m/n/12.045 说
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 置
+....\TU/FandolSong(0)/m/n/12.045 置
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 尚
+....\TU/FandolSong(0)/m/n/12.045 尚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 临
+....\TU/FandolSong(0)/m/n/12.045 临
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 易
+....\TU/FandolSong(0)/m/n/12.045 易
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 超
+....\TU/FandolSong(0)/m/n/12.045 超
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 承
+....\TU/FandolSong(0)/m/n/12.045 承
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 受
+....\TU/FandolSong(0)/m/n/12.045 受
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 造
+....\TU/FandolSong(0)/m/n/12.045 造
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 严
+....\TU/FandolSong(0)/m/n/12.045 严
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.21391
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 non-scalable
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 精
+....\TU/FandolSong(0)/m/n/12.045 精
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 确
+....\TU/FandolSong(0)/m/n/12.045 确
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 匹
+....\TU/FandolSong(0)/m/n/12.045 匹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 配
+....\TU/FandolSong(0)/m/n/12.045 配
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 识
+....\TU/FandolSong(0)/m/n/12.045 识
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 支
+....\TU/FandolSong(0)/m/n/12.045 支
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 精
+....\TU/FandolSong(0)/m/n/12.045 精
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 确
+....\TU/FandolSong(0)/m/n/12.045 确
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 匹
+....\TU/FandolSong(0)/m/n/12.045 匹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 配
+....\TU/FandolSong(0)/m/n/12.045 配
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （如
+....\TU/FandolSong(0)/m/n/12.045 （如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 串
+....\TU/FandolSong(0)/m/n/12.045 串
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 匹
+....\TU/FandolSong(0)/m/n/12.045 匹
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 配
+....\TU/FandolSong(0)/m/n/12.045 配
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.06482
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1407,450 +1407,450 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 依
+....\TU/FandolSong(0)/m/n/12.045 依
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 靠
+....\TU/FandolSong(0)/m/n/12.045 靠
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 转
+....\TU/FandolSong(0)/m/n/12.045 转
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 虽
+....\TU/FandolSong(0)/m/n/12.045 虽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.17456
 ...\hbox(9.49146+2.32468)x426.79135, glue set 0.21907
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 但
+....\TU/FandolSong(0)/m/n/12.045 但
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 严
+....\TU/FandolSong(0)/m/n/12.045 严
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 巨
+....\TU/FandolSong(0)/m/n/12.045 巨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 临
+....\TU/FandolSong(0)/m/n/12.045 临
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “大
+....\TU/FandolSong(0)/m/n/12.045 “大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 海
+....\TU/FandolSong(0)/m/n/12.045 海
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 捞
+....\TU/FandolSong(0)/m/n/12.045 捞
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 针
+....\TU/FandolSong(0)/m/n/12.045 针
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 困
+....\TU/FandolSong(0)/m/n/12.045 困
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 境
+....\TU/FandolSong(0)/m/n/12.045 境
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 游
+....\TU/FandolSong(0)/m/n/12.045 游
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.19965
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 冗
+....\TU/FandolSong(0)/m/n/12.045 冗
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 余
+....\TU/FandolSong(0)/m/n/12.045 余
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 才
+....\TU/FandolSong(0)/m/n/12.045 才
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 找
+....\TU/FandolSong(0)/m/n/12.045 找
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 洪
+....\TU/FandolSong(0)/m/n/12.045 洪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [2]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 稍
+....\TU/FandolSong(0)/m/n/12.045 稍
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.25717
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 走
+....\TU/FandolSong(0)/m/n/12.045 走
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [45]
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遍
+....\TU/FandolSong(0)/m/n/12.045 遍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 Gnutella
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [47]
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 当
+....\TU/FandolSong(0)/m/n/12.045 当
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.19217)x426.79135, glue set 0.2068
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 造
+....\TU/FandolSong(0)/m/n/12.045 造
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 严
+....\TU/FandolSong(0)/m/n/12.045 严
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 瓶
+....\TU/FandolSong(0)/m/n/12.045 瓶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 颈
+....\TU/FandolSong(0)/m/n/12.045 颈
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.54796
 ...\hbox(9.33487+1.98741)x426.79135, glue set 362.27834fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1863,228 +1863,228 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.69249
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.3217
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 尝
+....\TU/FandolSong(0)/m/n/12.045 尝
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 试
+....\TU/FandolSong(0)/m/n/12.045 试
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 措
+....\TU/FandolSong(0)/m/n/12.045 措
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 施
+....\TU/FandolSong(0)/m/n/12.045 施
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 改
+....\TU/FandolSong(0)/m/n/12.045 改
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 施
+....\TU/FandolSong(0)/m/n/12.045 施
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 包
+....\TU/FandolSong(0)/m/n/12.045 包
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 括
+....\TU/FandolSong(0)/m/n/12.045 括
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 冗
+....\TU/FandolSong(0)/m/n/12.045 冗
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 余
+....\TU/FandolSong(0)/m/n/12.045 余
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “温
+....\TU/FandolSong(0)/m/n/12.045 “温
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 转
+....\TU/FandolSong(0)/m/n/12.045 转
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 采
+....\TU/FandolSong(0)/m/n/12.045 采
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.21626)x426.79135, glue set - 0.44577
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 混
+....\TU/FandolSong(0)/m/n/12.045 混
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 构
+....\TU/FandolSong(0)/m/n/12.045 构
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 超
+....\TU/FandolSong(0)/m/n/12.045 超
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 缓
+....\TU/FandolSong(0)/m/n/12.045 缓
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [42-
 ....\discretionary
@@ -2094,75 +2094,75 @@ Completed box being shipped out [1]
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.0323
 ....\TU/texgyretermes(0)/m/n/12.045 54,106]
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 手
+....\TU/FandolSong(0)/m/n/12.045 手
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 即
+....\TU/FandolSong(0)/m/n/12.045 即
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 储
+....\TU/FandolSong(0)/m/n/12.045 储
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 身
+....\TU/FandolSong(0)/m/n/12.045 身
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fill
@@ -2184,244 +2184,244 @@ Completed box being shipped out [1]
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ....\hbox(8.4+0.0)x0.0
 .....\rule(8.4+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/9.03374 脚
+....\TU/FandolSong(0)/m/n/9.03374 脚
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 注
+....\TU/FandolSong(0)/m/n/9.03374 注
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 处
+....\TU/FandolSong(0)/m/n/9.03374 处
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 序
+....\TU/FandolSong(0)/m/n/9.03374 序
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 号
+....\TU/FandolSong(0)/m/n/9.03374 号
 ....\glue 0.0 plus 0.26138
 ....\glue 5.28473 minus 4.51686
 ....\rule(0.0+0.0)x-5.28473
-....\TU/FandolSong-Regular(0)/m/n/9.03374 “
+....\TU/FandolSong(0)/m/n/9.03374 “
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/9.03374 ①
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 6.0526
-....\TU/FandolSong-Regular(0)/m/n/9.03374 …
+....\TU/FandolSong(0)/m/n/9.03374 …
 ....\penalty 10000
 ....\glue 0.0
-....\TU/FandolSong-Regular(0)/m/n/9.03374 …
+....\TU/FandolSong(0)/m/n/9.03374 …
 ....\rule(0.0+0.0)x-1.53574
 ....\glue 1.53574 minus 1.53574
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\TU/texgyretermes(0)/m/n/9.03374 ⑩
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ”
+....\TU/FandolSong(0)/m/n/9.03374 ”
 ....\rule(0.0+0.0)x-5.28473
 ....\glue 5.28473 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 的
+....\TU/FandolSong(0)/m/n/9.03374 的
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 字
+....\TU/FandolSong(0)/m/n/9.03374 字
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 体
+....\TU/FandolSong(0)/m/n/9.03374 体
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 是
+....\TU/FandolSong(0)/m/n/9.03374 是
 ....\glue 0.0 plus 0.26138
 ....\glue 5.28473 minus 4.51686
 ....\rule(0.0+0.0)x-5.28473
-....\TU/FandolSong-Regular(0)/m/n/9.03374 “正
+....\TU/FandolSong(0)/m/n/9.03374 “正
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 文
+....\TU/FandolSong(0)/m/n/9.03374 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ”
+....\TU/FandolSong(0)/m/n/9.03374 ”
 ....\penalty 10000
 ....\glue -4.51688 plus 4.51688 minus 0.76785
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 不
+....\TU/FandolSong(0)/m/n/9.03374 不
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 是
+....\TU/FandolSong(0)/m/n/9.03374 是
 ....\glue 0.0 plus 0.26138
 ....\glue 5.28473 minus 4.51686
 ....\rule(0.0+0.0)x-5.28473
-....\TU/FandolSong-Regular(0)/m/n/9.03374 “上
+....\TU/FandolSong(0)/m/n/9.03374 “上
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 标
+....\TU/FandolSong(0)/m/n/9.03374 标
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ”
+....\TU/FandolSong(0)/m/n/9.03374 ”
 ....\penalty 10000
 ....\glue -4.51688 plus 4.51688 minus 0.76785
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 序
+....\TU/FandolSong(0)/m/n/9.03374 序
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 号
+....\TU/FandolSong(0)/m/n/9.03374 号
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 与
+....\TU/FandolSong(0)/m/n/9.03374 与
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 脚
+....\TU/FandolSong(0)/m/n/9.03374 脚
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 注
+....\TU/FandolSong(0)/m/n/9.03374 注
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 内
+....\TU/FandolSong(0)/m/n/9.03374 内
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 容
+....\TU/FandolSong(0)/m/n/9.03374 容
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 文
+....\TU/FandolSong(0)/m/n/9.03374 文
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 字
+....\TU/FandolSong(0)/m/n/9.03374 字
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 之
+....\TU/FandolSong(0)/m/n/9.03374 之
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 间
+....\TU/FandolSong(0)/m/n/9.03374 间
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 空
+....\TU/FandolSong(0)/m/n/9.03374 空
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 半
+....\TU/FandolSong(0)/m/n/9.03374 半
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 个
+....\TU/FandolSong(0)/m/n/9.03374 个
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 汉
+....\TU/FandolSong(0)/m/n/9.03374 汉
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 字
+....\TU/FandolSong(0)/m/n/9.03374 字
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 符
+....\TU/FandolSong(0)/m/n/9.03374 符
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 脚
+....\TU/FandolSong(0)/m/n/9.03374 脚
 ....\glue(\rightskip) 0.0
 ...\penalty 10100
 ...\glue(\baselineskip) 4.69754
 ...\hbox(7.10956+1.7435)x408.72386, glue set - 0.14453, shifted 18.06749
-....\TU/FandolSong-Regular(0)/m/n/9.03374 注
+....\TU/FandolSong(0)/m/n/9.03374 注
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 的
+....\TU/FandolSong(0)/m/n/9.03374 的
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 段
+....\TU/FandolSong(0)/m/n/9.03374 段
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 落
+....\TU/FandolSong(0)/m/n/9.03374 落
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 格
+....\TU/FandolSong(0)/m/n/9.03374 格
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 式
+....\TU/FandolSong(0)/m/n/9.03374 式
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 为
+....\TU/FandolSong(0)/m/n/9.03374 为
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ：
+....\TU/FandolSong(0)/m/n/9.03374 ：
 ....\rule(0.0+0.0)x-6.29651
 ....\glue 6.29651 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 单
+....\TU/FandolSong(0)/m/n/9.03374 单
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 倍
+....\TU/FandolSong(0)/m/n/9.03374 倍
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 行
+....\TU/FandolSong(0)/m/n/9.03374 行
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 距
+....\TU/FandolSong(0)/m/n/9.03374 距
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 段
+....\TU/FandolSong(0)/m/n/9.03374 段
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 前
+....\TU/FandolSong(0)/m/n/9.03374 前
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 空
+....\TU/FandolSong(0)/m/n/9.03374 空
 ....\glue 2.25844 plus 1.12921 minus 0.7528
 ....\TU/texgyretermes(0)/m/n/9.03374 0
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.25844 plus 1.12921 minus 0.7528
-....\TU/FandolSong-Regular(0)/m/n/9.03374 磅
+....\TU/FandolSong(0)/m/n/9.03374 磅
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 段
+....\TU/FandolSong(0)/m/n/9.03374 段
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 后
+....\TU/FandolSong(0)/m/n/9.03374 后
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 空
+....\TU/FandolSong(0)/m/n/9.03374 空
 ....\glue 2.25844 plus 1.12921 minus 0.7528
 ....\TU/texgyretermes(0)/m/n/9.03374 0
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.25844 plus 1.12921 minus 0.7528
-....\TU/FandolSong-Regular(0)/m/n/9.03374 磅
+....\TU/FandolSong(0)/m/n/9.03374 磅
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 悬
+....\TU/FandolSong(0)/m/n/9.03374 悬
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 挂
+....\TU/FandolSong(0)/m/n/9.03374 挂
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 缩
+....\TU/FandolSong(0)/m/n/9.03374 缩
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 进
+....\TU/FandolSong(0)/m/n/9.03374 进
 ....\glue 2.25844 plus 1.12921 minus 0.7528
 ....\TU/texgyretermes(0)/m/n/9.03374 1.5
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.25844 plus 1.12921 minus 0.7528
-....\TU/FandolSong-Regular(0)/m/n/9.03374 字
+....\TU/FandolSong(0)/m/n/9.03374 字
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 符
+....\TU/FandolSong(0)/m/n/9.03374 符
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ；
+....\TU/FandolSong(0)/m/n/9.03374 ；
 ....\rule(0.0+0.0)x-6.24231
 ....\glue 6.24231 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 字
+....\TU/FandolSong(0)/m/n/9.03374 字
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 号
+....\TU/FandolSong(0)/m/n/9.03374 号
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 为
+....\TU/FandolSong(0)/m/n/9.03374 为
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 小
+....\TU/FandolSong(0)/m/n/9.03374 小
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 五
+....\TU/FandolSong(0)/m/n/9.03374 五
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 号
+....\TU/FandolSong(0)/m/n/9.03374 号
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 字
+....\TU/FandolSong(0)/m/n/9.03374 字
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 汉
+....\TU/FandolSong(0)/m/n/9.03374 汉
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 字
+....\TU/FandolSong(0)/m/n/9.03374 字
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 用
+....\TU/FandolSong(0)/m/n/9.03374 用
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 宋
+....\TU/FandolSong(0)/m/n/9.03374 宋
 ....\glue(\rightskip) 0.0
 ...\penalty 250
 ...\glue(\baselineskip) 4.82402
 ...\hbox(6.98308+4.06522)x408.72386, glue set 277.43654fil, shifted 18.06749
-....\TU/FandolSong-Regular(0)/m/n/9.03374 体
+....\TU/FandolSong(0)/m/n/9.03374 体
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 ，
+....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 外
+....\TU/FandolSong(0)/m/n/9.03374 外
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 文
+....\TU/FandolSong(0)/m/n/9.03374 文
 ....\glue 0.0 plus 0.26138
-....\TU/FandolSong-Regular(0)/m/n/9.03374 用
+....\TU/FandolSong(0)/m/n/9.03374 用
 ....\glue 2.25844 plus 1.12807 minus 0.75356
 ....\TU/texgyretermes(0)/m/n/9.03374 Times
 ....\kern -0.00021
@@ -2435,9 +2435,9 @@ Completed box being shipped out [1]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.25844 plus 1.12921 minus 0.7528
-....\TU/FandolSong-Regular(0)/m/n/9.03374 体
+....\TU/FandolSong(0)/m/n/9.03374 体
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/9.03374 。
+....\TU/FandolSong(0)/m/n/9.03374 。
 ....\rule(0.0+0.0)x-5.81773
 ....\kern 0.00035
 ....\kern -0.00035
@@ -2559,53 +2559,53 @@ Completed box being shipped out [2]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 86.92326fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 3
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 等
+..........\TU/FandolSong(0)/m/n/10.53937 等
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 网
+..........\TU/FandolSong(0)/m/n/10.53937 网
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 络
+..........\TU/FandolSong(0)/m/n/10.53937 络
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 中
+..........\TU/FandolSong(0)/m/n/10.53937 中
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+..........\TU/FandolSong(0)/m/n/10.53937 宽
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 松
+..........\TU/FandolSong(0)/m/n/10.53937 松
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 约
+..........\TU/FandolSong(0)/m/n/10.53937 约
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 束
+..........\TU/FandolSong(0)/m/n/10.53937 束
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 一
+..........\TU/FandolSong(0)/m/n/10.53937 一
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 般
+..........\TU/FandolSong(0)/m/n/10.53937 般
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 性
+..........\TU/FandolSong(0)/m/n/10.53937 性
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+..........\TU/FandolSong(0)/m/n/10.53937 搜
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 索
+..........\TU/FandolSong(0)/m/n/10.53937 索
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 模
+..........\TU/FandolSong(0)/m/n/10.53937 模
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 型
+..........\TU/FandolSong(0)/m/n/10.53937 型
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -2630,288 +2630,288 @@ Completed box being shipped out [2]
 ..\vbox(674.33032+0.0)x426.79135, glue set >20000.0fil
 ...\glue(\topskip) 2.364
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.31483
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 缓
+....\TU/FandolSong(0)/m/n/12.045 缓
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （参
+....\TU/FandolSong(0)/m/n/12.045 （参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 2.3.1
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.25887
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 避
+....\TU/FandolSong(0)/m/n/12.045 避
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 免
+....\TU/FandolSong(0)/m/n/12.045 免
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 盲
+....\TU/FandolSong(0)/m/n/12.045 盲
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 跳
+....\TU/FandolSong(0)/m/n/12.045 跳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 依
+....\TU/FandolSong(0)/m/n/12.045 依
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 赖
+....\TU/FandolSong(0)/m/n/12.045 赖
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “知
+....\TU/FandolSong(0)/m/n/12.045 “知
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 道
+....\TU/FandolSong(0)/m/n/12.045 道
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.09312
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 难
+....\TU/FandolSong(0)/m/n/12.045 难
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （详
+....\TU/FandolSong(0)/m/n/12.045 （详
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 3.2
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 析
+....\TU/FandolSong(0)/m/n/12.045 析
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.27092
 ...\hbox(9.3951+2.19217)x426.79135, glue set 145.46837fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 知
+....\TU/FandolSong(0)/m/n/12.045 知
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 途
+....\TU/FandolSong(0)/m/n/12.045 途
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 径
+....\TU/FandolSong(0)/m/n/12.045 径
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2924,850 +2924,850 @@ Completed box being shipped out [2]
 ...\glue(\baselineskip) 8.4275
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.34389
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 它
+....\TU/FandolSong(0)/m/n/12.045 它
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 也
+....\TU/FandolSong(0)/m/n/12.045 也
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.21907
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 快
+....\TU/FandolSong(0)/m/n/12.045 快
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 返
+....\TU/FandolSong(0)/m/n/12.045 返
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 减
+....\TU/FandolSong(0)/m/n/12.045 减
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 另
+....\TU/FandolSong(0)/m/n/12.045 另
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 处
+....\TU/FandolSong(0)/m/n/12.045 处
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 断
+....\TU/FandolSong(0)/m/n/12.045 断
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 当
+....\TU/FandolSong(0)/m/n/12.045 当
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 失
+....\TU/FandolSong(0)/m/n/12.045 失
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （如
+....\TU/FandolSong(0)/m/n/12.045 （如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 离
+....\TU/FandolSong(0)/m/n/12.045 离
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 删
+....\TU/FandolSong(0)/m/n/12.045 删
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 除
+....\TU/FandolSong(0)/m/n/12.045 除
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.03136
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 也
+....\TU/FandolSong(0)/m/n/12.045 也
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 失
+....\TU/FandolSong(0)/m/n/12.045 失
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 必
+....\TU/FandolSong(0)/m/n/12.045 必
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 须
+....\TU/FandolSong(0)/m/n/12.045 须
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.29501
 ...\hbox(9.371+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 味
+....\TU/FandolSong(0)/m/n/12.045 味
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 着
+....\TU/FandolSong(0)/m/n/12.045 着
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.292
-....\TU/FandolSong-Regular(0)/m/n/12.045 着
+....\TU/FandolSong(0)/m/n/12.045 着
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 折
+....\TU/FandolSong(0)/m/n/12.045 折
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衷
+....\TU/FandolSong(0)/m/n/12.045 衷
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 trade-off
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 往
+....\TU/FandolSong(0)/m/n/12.045 往
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仅
+....\TU/FandolSong(0)/m/n/12.045 仅
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 虑
+....\TU/FandolSong(0)/m/n/12.045 虑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 虑
+....\TU/FandolSong(0)/m/n/12.045 虑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 两
+....\TU/FandolSong(0)/m/n/12.045 两
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 给
+....\TU/FandolSong(0)/m/n/12.045 给
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 影
+....\TU/FandolSong(0)/m/n/12.045 影
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.2283)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.43954
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 素
+....\TU/FandolSong(0)/m/n/12.045 素
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 采
+....\TU/FandolSong(0)/m/n/12.045 采
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 降
+....\TU/FandolSong(0)/m/n/12.045 降
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 低
+....\TU/FandolSong(0)/m/n/12.045 低
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.20673
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 难
+....\TU/FandolSong(0)/m/n/12.045 难
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 non-scalable
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 恰
+....\TU/FandolSong(0)/m/n/12.045 恰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 恰
+....\TU/FandolSong(0)/m/n/12.045 恰
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 反
+....\TU/FandolSong(0)/m/n/12.045 反
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 示
+....\TU/FandolSong(0)/m/n/12.045 示
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.25887
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 策
+....\TU/FandolSong(0)/m/n/12.045 策
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 略
+....\TU/FandolSong(0)/m/n/12.045 略
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 备
+....\TU/FandolSong(0)/m/n/12.045 备
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 负
+....\TU/FandolSong(0)/m/n/12.045 负
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 4.71161
 ...\hbox(13.03871+2.5957)x426.79135, glue set - 0.31139
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2489
@@ -3775,23 +3775,23 @@ Completed box being shipped out [2]
 ....\mathoff
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （结
+....\TU/FandolSong(0)/m/n/12.045 （结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2490
@@ -3810,72 +3810,72 @@ Completed box being shipped out [2]
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#42
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 增
+....\TU/FandolSong(0)/m/n/12.045 增
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 根
+....\TU/FandolSong(0)/m/n/12.045 根
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 保
+....\TU/FandolSong(0)/m/n/12.045 保
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.12033
 ...\hbox(9.35896+2.2283)x426.79135, glue set 276.61432fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -3888,35 +3888,35 @@ Completed box being shipped out [2]
 ...\glue(\baselineskip) 8.39137
 ...\hbox(9.45532+2.2283)x426.79135, glue set 0.32425
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 剩
+....\TU/FandolSong(0)/m/n/12.045 剩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 余
+....\TU/FandolSong(0)/m/n/12.045 余
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 按
+....\TU/FandolSong(0)/m/n/12.045 按
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 照
+....\TU/FandolSong(0)/m/n/12.045 照
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 织
+....\TU/FandolSong(0)/m/n/12.045 织
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -3927,21 +3927,21 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 给
+....\TU/FandolSong(0)/m/n/12.045 给
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\kern 0.0005
 ....\kern -0.0005
@@ -3952,62 +3952,62 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 推
+....\TU/FandolSong(0)/m/n/12.045 推
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.34319
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.06177
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 公
+....\TU/FandolSong(0)/m/n/12.045 公
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 给
+....\TU/FandolSong(0)/m/n/12.045 给
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\kern 0.0005
 ....\kern -0.0005
@@ -4018,104 +4018,104 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.4034
 ...\hbox(9.34692+2.32468)x426.79135, glue set 0.23524
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 扩
+....\TU/FandolSong(0)/m/n/12.045 扩
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “平
+....\TU/FandolSong(0)/m/n/12.045 “平
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 根
+....\TU/FandolSong(0)/m/n/12.045 根
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\kern 0.0005
 ....\kern -0.0005
@@ -4126,37 +4126,37 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x426.79135, glue set - 0.06177
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\kern 0.0005
 ....\kern -0.0005
@@ -4167,66 +4167,66 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 讨
+....\TU/FandolSong(0)/m/n/12.045 讨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 比
+....\TU/FandolSong(0)/m/n/12.045 比
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.39136
 ...\hbox(9.35896+2.21626)x426.79135, glue set 350.23334fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -4245,17 +4245,17 @@ Completed box being shipped out [2]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 14.05249
-....\TU/FandolHei-Regular(0)/m/n/14.05249 模
+....\TU/FandolHei(0)/m/n/14.05249 模
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 型
+....\TU/FandolHei(0)/m/n/14.05249 型
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 基
+....\TU/FandolHei(0)/m/n/14.05249 基
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 本
+....\TU/FandolHei(0)/m/n/14.05249 本
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 假
+....\TU/FandolHei(0)/m/n/14.05249 假
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 设
+....\TU/FandolHei(0)/m/n/14.05249 设
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -4269,257 +4269,257 @@ Completed box being shipped out [2]
 ...\glue(\baselineskip) 8.16452
 ...\hbox(9.3951+2.21626)x426.79135, glue set 0.05547
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 查
+....\TU/FandolSong(0)/m/n/12.045 查
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 询
+....\TU/FandolSong(0)/m/n/12.045 询
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.45158
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 味
+....\TU/FandolSong(0)/m/n/12.045 味
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 着
+....\TU/FandolSong(0)/m/n/12.045 着
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 何
+....\TU/FandolSong(0)/m/n/12.045 何
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x426.79135, glue set - 0.56693
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 利
+....\TU/FandolSong(0)/m/n/12.045 利
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 似
+....\TU/FandolSong(0)/m/n/12.045 似
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 兴
+....\TU/FandolSong(0)/m/n/12.045 兴
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 趣
+....\TU/FandolSong(0)/m/n/12.045 趣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 转
+....\TU/FandolSong(0)/m/n/12.045 转
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.049
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 盲
+....\TU/FandolSong(0)/m/n/12.045 盲
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 blind
@@ -4528,348 +4528,348 @@ Completed box being shipped out [2]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 search
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 查
+....\TU/FandolSong(0)/m/n/12.045 查
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 询
+....\TU/FandolSong(0)/m/n/12.045 询
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 味
+....\TU/FandolSong(0)/m/n/12.045 味
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 着
+....\TU/FandolSong(0)/m/n/12.045 着
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 获
+....\TU/FandolSong(0)/m/n/12.045 获
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 完
+....\TU/FandolSong(0)/m/n/12.045 完
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （数
+....\TU/FandolSong(0)/m/n/12.045 （数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 查
+....\TU/FandolSong(0)/m/n/12.045 查
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 询
+....\TU/FandolSong(0)/m/n/12.045 询
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 才
+....\TU/FandolSong(0)/m/n/12.045 才
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 判
+....\TU/FandolSong(0)/m/n/12.045 判
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 断
+....\TU/FandolSong(0)/m/n/12.045 断
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 否
+....\TU/FandolSong(0)/m/n/12.045 否
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 查
+....\TU/FandolSong(0)/m/n/12.045 查
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 询
+....\TU/FandolSong(0)/m/n/12.045 询
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.17456
 ...\hbox(9.49146+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 靠
+....\TU/FandolSong(0)/m/n/12.045 靠
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 查
+....\TU/FandolSong(0)/m/n/12.045 查
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 询
+....\TU/FandolSong(0)/m/n/12.045 询
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 往
+....\TU/FandolSong(0)/m/n/12.045 往
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 针
+....\TU/FandolSong(0)/m/n/12.045 针
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.05725
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 倒
+....\TU/FandolSong(0)/m/n/12.045 倒
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 排
+....\TU/FandolSong(0)/m/n/12.045 排
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （如
+....\TU/FandolSong(0)/m/n/12.045 （如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 词
+....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 倒
+....\TU/FandolSong(0)/m/n/12.045 倒
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 排
+....\TU/FandolSong(0)/m/n/12.045 排
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 挥
+....\TU/FandolSong(0)/m/n/12.045 挥
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 排
+....\TU/FandolSong(0)/m/n/12.045 排
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.1625
 ...\hbox(9.50351+2.32468)x426.79135, glue set 37.06339fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 限
+....\TU/FandolSong(0)/m/n/12.045 限
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 采
+....\TU/FandolSong(0)/m/n/12.045 采
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 措
+....\TU/FandolSong(0)/m/n/12.045 措
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 施
+....\TU/FandolSong(0)/m/n/12.045 施
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 限
+....\TU/FandolSong(0)/m/n/12.045 限
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -4882,76 +4882,76 @@ Completed box being shipped out [2]
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.06168
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 虽
+....\TU/FandolSong(0)/m/n/12.045 虽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 严
+....\TU/FandolSong(0)/m/n/12.045 严
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 格
+....\TU/FandolSong(0)/m/n/12.045 格
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “一
+....\TU/FandolSong(0)/m/n/12.045 “一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue(\rightskip) 0.0
 ...\glue -2.32468
 ...\glue 0.0 plus 0.0001fil
@@ -5062,53 +5062,53 @@ Completed box being shipped out [3]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 86.92326fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 3
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 等
+..........\TU/FandolSong(0)/m/n/10.53937 等
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 网
+..........\TU/FandolSong(0)/m/n/10.53937 网
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 络
+..........\TU/FandolSong(0)/m/n/10.53937 络
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 中
+..........\TU/FandolSong(0)/m/n/10.53937 中
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+..........\TU/FandolSong(0)/m/n/10.53937 宽
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 松
+..........\TU/FandolSong(0)/m/n/10.53937 松
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 约
+..........\TU/FandolSong(0)/m/n/10.53937 约
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 束
+..........\TU/FandolSong(0)/m/n/10.53937 束
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 一
+..........\TU/FandolSong(0)/m/n/10.53937 一
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 般
+..........\TU/FandolSong(0)/m/n/10.53937 般
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 性
+..........\TU/FandolSong(0)/m/n/10.53937 性
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+..........\TU/FandolSong(0)/m/n/10.53937 搜
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 索
+..........\TU/FandolSong(0)/m/n/10.53937 索
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 模
+..........\TU/FandolSong(0)/m/n/10.53937 模
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 型
+..........\TU/FandolSong(0)/m/n/10.53937 型
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -5134,284 +5134,284 @@ Completed box being shipped out [3]
 ..\vbox(674.33032+0.0)x426.79135, glue set >20000.0fil
 ...\glue(\topskip) 2.6049
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 且
+....\TU/FandolSong(0)/m/n/12.045 且
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 借
+....\TU/FandolSong(0)/m/n/12.045 借
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 助
+....\TU/FandolSong(0)/m/n/12.045 助
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 但
+....\TU/FandolSong(0)/m/n/12.045 但
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 讨
+....\TU/FandolSong(0)/m/n/12.045 讨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 况
+....\TU/FandolSong(0)/m/n/12.045 况
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 寻
+....\TU/FandolSong(0)/m/n/12.045 寻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 找
+....\TU/FandolSong(0)/m/n/12.045 找
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 绝
+....\TU/FandolSong(0)/m/n/12.045 绝
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 针
+....\TU/FandolSong(0)/m/n/12.045 针
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 五
+....\TU/FandolSong(0)/m/n/12.045 五
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 利
+....\TU/FandolSong(0)/m/n/12.045 利
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.21626)x426.79135, glue set 133.42337fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 语
+....\TU/FandolSong(0)/m/n/12.045 语
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 六
+....\TU/FandolSong(0)/m/n/12.045 六
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -5424,184 +5424,184 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.40341
 ...\hbox(9.45532+2.32468)x426.79135, glue set - 0.58185
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 针
+....\TU/FandolSong(0)/m/n/12.045 针
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 给
+....\TU/FandolSong(0)/m/n/12.045 给
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 包
+....\TU/FandolSong(0)/m/n/12.045 包
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 括
+....\TU/FandolSong(0)/m/n/12.045 括
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “无
+....\TU/FandolSong(0)/m/n/12.045 “无
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set - 0.04222
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 短
+....\TU/FandolSong(0)/m/n/12.045 短
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 稳
+....\TU/FandolSong(0)/m/n/12.045 稳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 首
+....\TU/FandolSong(0)/m/n/12.045 首
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 先
+....\TU/FandolSong(0)/m/n/12.045 先
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 讨
+....\TU/FandolSong(0)/m/n/12.045 讨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.2283)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 给
+....\TU/FandolSong(0)/m/n/12.045 给
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 叙
+....\TU/FandolSong(0)/m/n/12.045 叙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -5620,17 +5620,17 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 13.04874
-....\TU/FandolHei-Regular(0)/m/n/13.04874 无
+....\TU/FandolHei(0)/m/n/13.04874 无
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 偏
+....\TU/FandolHei(0)/m/n/13.04874 偏
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 向
+....\TU/FandolHei(0)/m/n/13.04874 向
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 性
+....\TU/FandolHei(0)/m/n/13.04874 性
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 搜
+....\TU/FandolHei(0)/m/n/13.04874 搜
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 索
+....\TU/FandolHei(0)/m/n/13.04874 索
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5643,100 +5643,100 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.37833
 ...\hbox(9.49146+2.32468)x426.79135, glue set 0.21907
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 都
+....\TU/FandolSong(0)/m/n/12.045 都
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 接
+....\TU/FandolSong(0)/m/n/12.045 接
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 那
+....\TU/FandolSong(0)/m/n/12.045 那
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 么
+....\TU/FandolSong(0)/m/n/12.045 么
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.0403
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “无
+....\TU/FandolSong(0)/m/n/12.045 “无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 unbiased
@@ -5745,828 +5745,828 @@ Completed box being shipped out [3]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 search
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 看
+....\TU/FandolSong(0)/m/n/12.045 看
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24683
 ...\hbox(9.41919+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 也
+....\TU/FandolSong(0)/m/n/12.045 也
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 弱
+....\TU/FandolSong(0)/m/n/12.045 弱
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 让
+....\TU/FandolSong(0)/m/n/12.045 让
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 摊
+....\TU/FandolSong(0)/m/n/12.045 摊
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 巨
+....\TU/FandolSong(0)/m/n/12.045 巨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 负
+....\TU/FandolSong(0)/m/n/12.045 负
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 才
+....\TU/FandolSong(0)/m/n/12.045 才
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 支
+....\TU/FandolSong(0)/m/n/12.045 支
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 撑
+....\TU/FandolSong(0)/m/n/12.045 撑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 起
+....\TU/FandolSong(0)/m/n/12.045 起
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 强
+....\TU/FandolSong(0)/m/n/12.045 强
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 似
+....\TU/FandolSong(0)/m/n/12.045 似
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 匀
+....\TU/FandolSong(0)/m/n/12.045 匀
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 散
+....\TU/FandolSong(0)/m/n/12.045 散
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 落
+....\TU/FandolSong(0)/m/n/12.045 落
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 那
+....\TU/FandolSong(0)/m/n/12.045 那
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 么
+....\TU/FandolSong(0)/m/n/12.045 么
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 负
+....\TU/FandolSong(0)/m/n/12.045 负
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 易
+....\TU/FandolSong(0)/m/n/12.045 易
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衡
+....\TU/FandolSong(0)/m/n/12.045 衡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 负
+....\TU/FandolSong(0)/m/n/12.045 负
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.04826
-....\TU/FandolSong-Regular(0)/m/n/12.045 载
+....\TU/FandolSong(0)/m/n/12.045 载
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 思
+....\TU/FandolSong(0)/m/n/12.045 思
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 展
+....\TU/FandolSong(0)/m/n/12.045 展
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 础
+....\TU/FandolSong(0)/m/n/12.045 础
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 即
+....\TU/FandolSong(0)/m/n/12.045 即
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 集
+....\TU/FandolSong(0)/m/n/12.045 集
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 众
+....\TU/FandolSong(0)/m/n/12.045 众
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 微
+....\TU/FandolSong(0)/m/n/12.045 微
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （大
+....\TU/FandolSong(0)/m/n/12.045 （大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 弱
+....\TU/FandolSong(0)/m/n/12.045 弱
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.1625
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 形
+....\TU/FandolSong(0)/m/n/12.045 形
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 巨
+....\TU/FandolSong(0)/m/n/12.045 巨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 际
+....\TU/FandolSong(0)/m/n/12.045 际
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 选
+....\TU/FandolSong(0)/m/n/12.045 选
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 择
+....\TU/FandolSong(0)/m/n/12.045 择
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 邻
+....\TU/FandolSong(0)/m/n/12.045 邻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 居
+....\TU/FandolSong(0)/m/n/12.045 居
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 转
+....\TU/FandolSong(0)/m/n/12.045 转
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.22273
 ...\hbox(9.52759+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 没
+....\TU/FandolSong(0)/m/n/12.045 没
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 殊
+....\TU/FandolSong(0)/m/n/12.045 殊
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 那
+....\TU/FandolSong(0)/m/n/12.045 那
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 么
+....\TU/FandolSong(0)/m/n/12.045 么
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 似
+....\TU/FandolSong(0)/m/n/12.045 似
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 譬
+....\TU/FandolSong(0)/m/n/12.045 譬
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 洪
+....\TU/FandolSong(0)/m/n/12.045 洪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.28853)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 走
+....\TU/FandolSong(0)/m/n/12.045 走
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.37932
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 超
+....\TU/FandolSong(0)/m/n/12.045 超
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 级
+....\TU/FandolSong(0)/m/n/12.045 级
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 划
+....\TU/FandolSong(0)/m/n/12.045 划
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 别
+....\TU/FandolSong(0)/m/n/12.045 别
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 别
+....\TU/FandolSong(0)/m/n/12.045 别
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 运
+....\TU/FandolSong(0)/m/n/12.045 运
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 协
+....\TU/FandolSong(0)/m/n/12.045 协
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 议
+....\TU/FandolSong(0)/m/n/12.045 议
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 别
+....\TU/FandolSong(0)/m/n/12.045 别
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仍
+....\TU/FandolSong(0)/m/n/12.045 仍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.37794
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 针
+....\TU/FandolSong(0)/m/n/12.045 针
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 每
+....\TU/FandolSong(0)/m/n/12.045 每
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 类
+....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 别
+....\TU/FandolSong(0)/m/n/12.045 别
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 群
+....\TU/FandolSong(0)/m/n/12.045 群
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 别
+....\TU/FandolSong(0)/m/n/12.045 别
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （详
+....\TU/FandolSong(0)/m/n/12.045 （详
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set 371.3121fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 3.5
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -6579,365 +6579,365 @@ Completed box being shipped out [3]
 ...\glue(\baselineskip) 8.22273
 ...\hbox(9.44328+2.32468)x426.79135, glue set 0.33243
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 且
+....\TU/FandolSong(0)/m/n/12.045 且
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 彼
+....\TU/FandolSong(0)/m/n/12.045 彼
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.30704
 ...\hbox(9.44328+2.26445)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 功
+....\TU/FandolSong(0)/m/n/12.045 功
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 盲
+....\TU/FandolSong(0)/m/n/12.045 盲
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 虽
+....\TU/FandolSong(0)/m/n/12.045 虽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 途
+....\TU/FandolSong(0)/m/n/12.045 途
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遇
+....\TU/FandolSong(0)/m/n/12.045 遇
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.4034
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 史
+....\TU/FandolSong(0)/m/n/12.045 史
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 续
+....\TU/FandolSong(0)/m/n/12.045 续
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遍
+....\TU/FandolSong(0)/m/n/12.045 遍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 但
+....\TU/FandolSong(0)/m/n/12.045 但
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 巨
+....\TU/FandolSong(0)/m/n/12.045 巨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 史
+....\TU/FandolSong(0)/m/n/12.045 史
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 信
+....\TU/FandolSong(0)/m/n/12.045 信
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 限
+....\TU/FandolSong(0)/m/n/12.045 限
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 且
+....\TU/FandolSong(0)/m/n/12.045 且
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.36726
 ...\hbox(9.38306+2.32468)x426.79135, glue set 85.24338fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 虑
+....\TU/FandolSong(0)/m/n/12.045 虑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仍
+....\TU/FandolSong(0)/m/n/12.045 仍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 盲
+....\TU/FandolSong(0)/m/n/12.045 盲
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -6956,13 +6956,13 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 13.04874
-....\TU/FandolHei-Regular(0)/m/n/13.04874 结
+....\TU/FandolHei(0)/m/n/13.04874 结
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 点
+....\TU/FandolHei(0)/m/n/13.04874 点
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 特
+....\TU/FandolHei(0)/m/n/13.04874 特
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 性
+....\TU/FandolHei(0)/m/n/13.04874 性
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -6979,305 +6979,305 @@ Completed box being shipped out [3]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 处
+....\TU/FandolSong(0)/m/n/12.045 处
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 断
+....\TU/FandolSong(0)/m/n/12.045 断
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 加
+....\TU/FandolSong(0)/m/n/12.045 加
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 入
+....\TU/FandolSong(0)/m/n/12.045 入
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 离
+....\TU/FandolSong(0)/m/n/12.045 离
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.40732
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 影
+....\TU/FandolSong(0)/m/n/12.045 影
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 按
+....\TU/FandolSong(0)/m/n/12.045 按
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 照
+....\TU/FandolSong(0)/m/n/12.045 照
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （在
+....\TU/FandolSong(0)/m/n/12.045 （在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.09001
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 离
+....\TU/FandolSong(0)/m/n/12.045 离
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 独
+....\TU/FandolSong(0)/m/n/12.045 独
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 且
+....\TU/FandolSong(0)/m/n/12.045 且
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+2.40898)x426.79135, glue set - 0.30394
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 刻
+....\TU/FandolSong(0)/m/n/12.045 刻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 画
+....\TU/FandolSong(0)/m/n/12.045 画
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 说
+....\TU/FandolSong(0)/m/n/12.045 说
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 session
@@ -7407,53 +7407,53 @@ Completed box being shipped out [4]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 86.92326fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 3
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 等
+..........\TU/FandolSong(0)/m/n/10.53937 等
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 网
+..........\TU/FandolSong(0)/m/n/10.53937 网
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 络
+..........\TU/FandolSong(0)/m/n/10.53937 络
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 中
+..........\TU/FandolSong(0)/m/n/10.53937 中
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+..........\TU/FandolSong(0)/m/n/10.53937 宽
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 松
+..........\TU/FandolSong(0)/m/n/10.53937 松
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 约
+..........\TU/FandolSong(0)/m/n/10.53937 约
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 束
+..........\TU/FandolSong(0)/m/n/10.53937 束
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 一
+..........\TU/FandolSong(0)/m/n/10.53937 一
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 般
+..........\TU/FandolSong(0)/m/n/10.53937 般
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 性
+..........\TU/FandolSong(0)/m/n/10.53937 性
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+..........\TU/FandolSong(0)/m/n/10.53937 搜
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 索
+..........\TU/FandolSong(0)/m/n/10.53937 索
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 模
+..........\TU/FandolSong(0)/m/n/10.53937 模
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 型
+..........\TU/FandolSong(0)/m/n/10.53937 型
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -7480,11 +7480,11 @@ Completed box being shipped out [4]
 ...\hbox(9.636+3.10188)x426.79135, glue set - 0.09775
 ....\TU/texgyretermes(0)/m/n/12.045 time
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2495
@@ -7494,39 +7494,39 @@ Completed box being shipped out [4]
 .....\kern 0.0002
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#3172
@@ -7543,127 +7543,127 @@ Completed box being shipped out [4]
 .....\kern 0.0002
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 7.56596
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.08728
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 彼
+....\TU/FandolSong(0)/m/n/12.045 彼
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 独
+....\TU/FandolSong(0)/m/n/12.045 独
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泊
+....\TU/FandolSong(0)/m/n/12.045 泊
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.18013)x426.79135, glue set 277.96335fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 致
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -7682,15 +7682,15 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 13.04874
-....\TU/FandolHei-Regular(0)/m/n/13.04874 短
+....\TU/FandolHei(0)/m/n/13.04874 短
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 时
+....\TU/FandolHei(0)/m/n/13.04874 时
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 稳
+....\TU/FandolHei(0)/m/n/13.04874 稳
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 态
+....\TU/FandolHei(0)/m/n/13.04874 态
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 性
+....\TU/FandolHei(0)/m/n/13.04874 性
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -7703,92 +7703,92 @@ Completed box being shipped out [4]
 ...\glue(\baselineskip) 8.23378
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.22575
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 短
+....\TU/FandolSong(0)/m/n/12.045 短
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 稳
+....\TU/FandolSong(0)/m/n/12.045 稳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 即
+....\TU/FandolSong(0)/m/n/12.045 即
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （如
+....\TU/FandolSong(0)/m/n/12.045 （如
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.03001
 ...\hbox(9.636+3.10188)x426.79135, glue set - 0.2761
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2495
@@ -7798,61 +7798,61 @@ Completed box being shipped out [4]
 .....\kern 0.0002
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 访
+....\TU/FandolSong(0)/m/n/12.045 访
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 频
+....\TU/FandolSong(0)/m/n/12.045 频
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （结
+....\TU/FandolSong(0)/m/n/12.045 （结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 7.33711
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.36552
@@ -7860,157 +7860,157 @@ Completed box being shipped out [4]
 ....\kern1.08405
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 尽
+....\TU/FandolSong(0)/m/n/12.045 尽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 质
+....\TU/FandolSong(0)/m/n/12.045 质
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 但
+....\TU/FandolSong(0)/m/n/12.045 但
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.21907
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 靠
+....\TU/FandolSong(0)/m/n/12.045 靠
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 缓
+....\TU/FandolSong(0)/m/n/12.045 缓
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 慢
+....\TU/FandolSong(0)/m/n/12.045 慢
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 积
+....\TU/FandolSong(0)/m/n/12.045 积
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 累
+....\TU/FandolSong(0)/m/n/12.045 累
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 稳
+....\TU/FandolSong(0)/m/n/12.045 稳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 描
+....\TU/FandolSong(0)/m/n/12.045 描
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.30704
@@ -8019,63 +8019,63 @@ Completed box being shipped out [4]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 稳
+....\TU/FandolSong(0)/m/n/12.045 稳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 刻
+....\TU/FandolSong(0)/m/n/12.045 刻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 画
+....\TU/FandolSong(0)/m/n/12.045 画
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -8094,23 +8094,23 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 13.04874
-....\TU/FandolHei-Regular(0)/m/n/13.04874 模
+....\TU/FandolHei(0)/m/n/13.04874 模
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 型
+....\TU/FandolHei(0)/m/n/13.04874 型
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 假
+....\TU/FandolHei(0)/m/n/13.04874 假
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 设
+....\TU/FandolHei(0)/m/n/13.04874 设
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 的
+....\TU/FandolHei(0)/m/n/13.04874 的
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 总
+....\TU/FandolHei(0)/m/n/13.04874 总
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 体
+....\TU/FandolHei(0)/m/n/13.04874 体
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 叙
+....\TU/FandolHei(0)/m/n/13.04874 叙
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 述
+....\TU/FandolHei(0)/m/n/13.04874 述
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -8123,71 +8123,71 @@ Completed box being shipped out [4]
 ...\glue(\baselineskip) 8.34921
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.42593
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 综
+....\TU/FandolSong(0)/m/n/12.045 综
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 三
+....\TU/FandolSong(0)/m/n/12.045 三
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 言
+....\TU/FandolSong(0)/m/n/12.045 言
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
@@ -8196,379 +8196,379 @@ Completed box being shipped out [4]
 ...\penalty 10000
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\glue 8.39537 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.25887
 ...\hbox(9.49146+2.26445)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 或
+....\TU/FandolSong(0)/m/n/12.045 或
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 近
+....\TU/FandolSong(0)/m/n/12.045 近
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 线
+....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 独
+....\TU/FandolSong(0)/m/n/12.045 独
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34319
 ...\hbox(9.46736+2.32468)x426.79135, glue set - 0.3959
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 描
+....\TU/FandolSong(0)/m/n/12.045 描
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 较
+....\TU/FandolSong(0)/m/n/12.045 较
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 短
+....\TU/FandolSong(0)/m/n/12.045 短
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 看
+....\TU/FandolSong(0)/m/n/12.045 看
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 稳
+....\TU/FandolSong(0)/m/n/12.045 稳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 态
+....\TU/FandolSong(0)/m/n/12.045 态
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 保
+....\TU/FandolSong(0)/m/n/12.045 保
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.00867
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 针
+....\TU/FandolSong(0)/m/n/12.045 针
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 做
+....\TU/FandolSong(0)/m/n/12.045 做
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.2283)x426.79135, glue set 0.0447
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 松
+....\TU/FandolSong(0)/m/n/12.045 松
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 约
+....\TU/FandolSong(0)/m/n/12.045 约
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 适
+....\TU/FandolSong(0)/m/n/12.045 适
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 3.6.1
 ....\kern -0.00021
@@ -8577,21 +8577,21 @@ Completed box being shipped out [4]
 ...\penalty 150
 ...\glue(\baselineskip) 8.4516
 ...\hbox(9.3951+2.144)x426.79135, glue set 338.18834fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 做
+....\TU/FandolSong(0)/m/n/12.045 做
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 讨
+....\TU/FandolSong(0)/m/n/12.045 讨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -8610,37 +8610,37 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 14.05249
-....\TU/FandolHei-Regular(0)/m/n/14.05249 宽
+....\TU/FandolHei(0)/m/n/14.05249 宽
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 松
+....\TU/FandolHei(0)/m/n/14.05249 松
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 约
+....\TU/FandolHei(0)/m/n/14.05249 约
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 束
+....\TU/FandolHei(0)/m/n/14.05249 束
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 的
+....\TU/FandolHei(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 一
+....\TU/FandolHei(0)/m/n/14.05249 一
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 般
+....\TU/FandolHei(0)/m/n/14.05249 般
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 性
+....\TU/FandolHei(0)/m/n/14.05249 性
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 搜
+....\TU/FandolHei(0)/m/n/14.05249 搜
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 索
+....\TU/FandolHei(0)/m/n/14.05249 索
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 性
+....\TU/FandolHei(0)/m/n/14.05249 性
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 能
+....\TU/FandolHei(0)/m/n/14.05249 能
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 理
+....\TU/FandolHei(0)/m/n/14.05249 理
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 论
+....\TU/FandolHei(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 模
+....\TU/FandolHei(0)/m/n/14.05249 模
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 型
+....\TU/FandolHei(0)/m/n/14.05249 型
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -8654,171 +8654,171 @@ Completed box being shipped out [4]
 ...\glue(\baselineskip) 8.24683
 ...\hbox(9.38306+2.32468)x426.79135, glue set 0.3217
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 建
+....\TU/FandolSong(0)/m/n/12.045 建
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 解
+....\TU/FandolSong(0)/m/n/12.045 解
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 决
+....\TU/FandolSong(0)/m/n/12.045 决
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.28853)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 限
+....\TU/FandolSong(0)/m/n/12.045 限
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 、
+....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 优
+....\TU/FandolSong(0)/m/n/12.045 优
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.37932
 ...\hbox(9.40715+2.26445)x426.79135, glue set 311.0871fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 符
+....\TU/FandolSong(0)/m/n/12.045 符
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 说
+....\TU/FandolSong(0)/m/n/12.045 说
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 参
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -8828,7 +8828,7 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -8849,41 +8849,41 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 13.04874
-....\TU/FandolHei-Regular(0)/m/n/13.04874 单
+....\TU/FandolHei(0)/m/n/13.04874 单
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 次
+....\TU/FandolHei(0)/m/n/13.04874 次
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 搜
+....\TU/FandolHei(0)/m/n/13.04874 搜
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 索
+....\TU/FandolHei(0)/m/n/13.04874 索
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 的
+....\TU/FandolHei(0)/m/n/13.04874 的
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 带
+....\TU/FandolHei(0)/m/n/13.04874 带
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 宽
+....\TU/FandolHei(0)/m/n/13.04874 宽
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 开
+....\TU/FandolHei(0)/m/n/13.04874 开
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 销
+....\TU/FandolHei(0)/m/n/13.04874 销
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 以
+....\TU/FandolHei(0)/m/n/13.04874 以
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 及
+....\TU/FandolHei(0)/m/n/13.04874 及
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 系
+....\TU/FandolHei(0)/m/n/13.04874 系
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 统
+....\TU/FandolHei(0)/m/n/13.04874 统
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 总
+....\TU/FandolHei(0)/m/n/13.04874 总
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 带
+....\TU/FandolHei(0)/m/n/13.04874 带
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 宽
+....\TU/FandolHei(0)/m/n/13.04874 宽
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 开
+....\TU/FandolHei(0)/m/n/13.04874 开
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 销
+....\TU/FandolHei(0)/m/n/13.04874 销
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -8896,115 +8896,115 @@ Completed box being shipped out [4]
 ...\glue(\baselineskip) 8.29199
 ...\hbox(9.3951+2.32468)x426.79135, glue set - 0.56693
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 之
+....\TU/FandolSong(0)/m/n/12.045 之
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+4.70088)x426.79135, glue set 0.09041
-....\TU/FandolSong-Regular(0)/m/n/12.045 虑
+....\TU/FandolSong(0)/m/n/12.045 虑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2489
 ....\kern1.08405
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2478
@@ -9013,42 +9013,42 @@ Completed box being shipped out [4]
 .....\kern1.08405
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 放
+....\TU/FandolSong(0)/m/n/12.045 放
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （存
+....\TU/FandolSong(0)/m/n/12.045 （存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 储
+....\TU/FandolSong(0)/m/n/12.045 储
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
@@ -9057,413 +9057,413 @@ Completed box being shipped out [4]
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 5.73811
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.0316
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 身
+....\TU/FandolSong(0)/m/n/12.045 身
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 那
+....\TU/FandolSong(0)/m/n/12.045 那
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 些
+....\TU/FandolSong(0)/m/n/12.045 些
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 也
+....\TU/FandolSong(0)/m/n/12.045 也
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 包
+....\TU/FandolSong(0)/m/n/12.045 包
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 含
+....\TU/FandolSong(0)/m/n/12.045 含
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 称
+....\TU/FandolSong(0)/m/n/12.045 称
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 些
+....\TU/FandolSong(0)/m/n/12.045 些
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “应
+....\TU/FandolSong(0)/m/n/12.045 “应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 答
+....\TU/FandolSong(0)/m/n/12.045 答
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.02382
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.17456
 ...\hbox(9.49146+2.32468)x426.79135, glue set 0.04842
-....\TU/FandolSong-Regular(0)/m/n/12.045 它
+....\TU/FandolSong(0)/m/n/12.045 它
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 够
+....\TU/FandolSong(0)/m/n/12.045 够
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 答
+....\TU/FandolSong(0)/m/n/12.045 答
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 目
+....\TU/FandolSong(0)/m/n/12.045 目
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 虑
+....\TU/FandolSong(0)/m/n/12.045 虑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 某
+....\TU/FandolSong(0)/m/n/12.045 某
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 起
+....\TU/FandolSong(0)/m/n/12.045 起
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.25887
 ...\hbox(9.49146+2.32468)x426.79135, glue set 0.1662
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 当
+....\TU/FandolSong(0)/m/n/12.045 当
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 且
+....\TU/FandolSong(0)/m/n/12.045 且
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仅
+....\TU/FandolSong(0)/m/n/12.045 仅
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 当
+....\TU/FandolSong(0)/m/n/12.045 当
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 转
+....\TU/FandolSong(0)/m/n/12.045 转
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 答
+....\TU/FandolSong(0)/m/n/12.045 答
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 才
+....\TU/FandolSong(0)/m/n/12.045 才
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 够
+....\TU/FandolSong(0)/m/n/12.045 够
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 0.1662
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 每
+....\TU/FandolSong(0)/m/n/12.045 每
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 当
+....\TU/FandolSong(0)/m/n/12.045 当
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 送
+....\TU/FandolSong(0)/m/n/12.045 送
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 尚
+....\TU/FandolSong(0)/m/n/12.045 尚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 未
+....\TU/FandolSong(0)/m/n/12.045 未
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遍
+....\TU/FandolSong(0)/m/n/12.045 遍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.25887
 ...\hbox(9.49146+2.32468)x426.79135, glue set - 0.22678
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 功
+....\TU/FandolSong(0)/m/n/12.045 功
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 返
+....\TU/FandolSong(0)/m/n/12.045 返
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ；
+....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 否
+....\TU/FandolSong(0)/m/n/12.045 否
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 继
+....\TU/FandolSong(0)/m/n/12.045 继
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 续
+....\TU/FandolSong(0)/m/n/12.045 续
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 寻
+....\TU/FandolSong(0)/m/n/12.045 寻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 尚
+....\TU/FandolSong(0)/m/n/12.045 尚
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 未
+....\TU/FandolSong(0)/m/n/12.045 未
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遍
+....\TU/FandolSong(0)/m/n/12.045 遍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue(\rightskip) 0.0
 ...\glue -2.32468
 ...\glue 0.0 plus 0.0001fil
@@ -9574,53 +9574,53 @@ Completed box being shipped out [5]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 86.92326fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 3
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 等
+..........\TU/FandolSong(0)/m/n/10.53937 等
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 网
+..........\TU/FandolSong(0)/m/n/10.53937 网
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 络
+..........\TU/FandolSong(0)/m/n/10.53937 络
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 中
+..........\TU/FandolSong(0)/m/n/10.53937 中
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+..........\TU/FandolSong(0)/m/n/10.53937 宽
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 松
+..........\TU/FandolSong(0)/m/n/10.53937 松
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 约
+..........\TU/FandolSong(0)/m/n/10.53937 约
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 束
+..........\TU/FandolSong(0)/m/n/10.53937 束
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 一
+..........\TU/FandolSong(0)/m/n/10.53937 一
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 般
+..........\TU/FandolSong(0)/m/n/10.53937 般
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 性
+..........\TU/FandolSong(0)/m/n/10.53937 性
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+..........\TU/FandolSong(0)/m/n/10.53937 搜
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 索
+..........\TU/FandolSong(0)/m/n/10.53937 索
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 模
+..........\TU/FandolSong(0)/m/n/10.53937 模
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 型
+..........\TU/FandolSong(0)/m/n/10.53937 型
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -9658,7 +9658,7 @@ Completed box being shipped out [5]
 .......\hbox(10.0475+4.30612)x426.79135, glue set 133.34665fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
-........\TU/FandolSong-Regular(0)/m/n/11.04124 表
+........\TU/FandolSong(0)/m/n/11.04124 表
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
@@ -9670,27 +9670,27 @@ Completed box being shipped out [5]
 ........\rule(10.0475+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
-........\TU/FandolSong-Regular(0)/m/n/11.04124 无
+........\TU/FandolSong(0)/m/n/11.04124 无
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 偏
+........\TU/FandolSong(0)/m/n/11.04124 偏
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 向
+........\TU/FandolSong(0)/m/n/11.04124 向
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 搜
+........\TU/FandolSong(0)/m/n/11.04124 搜
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 索
+........\TU/FandolSong(0)/m/n/11.04124 索
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 模
+........\TU/FandolSong(0)/m/n/11.04124 模
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 型
+........\TU/FandolSong(0)/m/n/11.04124 型
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 的
+........\TU/FandolSong(0)/m/n/11.04124 的
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 符
+........\TU/FandolSong(0)/m/n/11.04124 符
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 号
+........\TU/FandolSong(0)/m/n/11.04124 号
 ........\glue 0.0 plus 0.50737
-........\TU/FandolSong-Regular(0)/m/n/11.04124 表
+........\TU/FandolSong(0)/m/n/11.04124 表
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
@@ -9723,9 +9723,9 @@ Completed box being shipped out [5]
 ..........\glue 6.0
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 0.00002
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 符
+..........\TU/FandolSong(0)/m/n/10.53937 符
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 号
+..........\TU/FandolSong(0)/m/n/10.53937 号
 ..........\kern -0.00018
 ..........\kern 0.00018
 ..........\glue 0.0 plus 1.0fil
@@ -9737,15 +9737,15 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 246.0558fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 意
+............\TU/FandolSong(0)/m/n/10.53937 意
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 义
+............\TU/FandolSong(0)/m/n/10.53937 义
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 及
+............\TU/FandolSong(0)/m/n/10.53937 及
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 说
+............\TU/FandolSong(0)/m/n/10.53937 说
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 明
+............\TU/FandolSong(0)/m/n/10.53937 明
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -9779,31 +9779,31 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 172.28023fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 结
+............\TU/FandolSong(0)/m/n/10.53937 结
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 点
+............\TU/FandolSong(0)/m/n/10.53937 点
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 总
+............\TU/FandolSong(0)/m/n/10.53937 总
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 代
+............\TU/FandolSong(0)/m/n/10.53937 代
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 表
+............\TU/FandolSong(0)/m/n/10.53937 表
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 了
+............\TU/FandolSong(0)/m/n/10.53937 了
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 系
+............\TU/FandolSong(0)/m/n/10.53937 系
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 统
+............\TU/FandolSong(0)/m/n/10.53937 统
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 规
+............\TU/FandolSong(0)/m/n/10.53937 规
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 模
+............\TU/FandolSong(0)/m/n/10.53937 模
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -9835,54 +9835,54 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 60.61562fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 彼
+............\TU/FandolSong(0)/m/n/10.53937 彼
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 此
+............\TU/FandolSong(0)/m/n/10.53937 此
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 不
+............\TU/FandolSong(0)/m/n/10.53937 不
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 同
+............\TU/FandolSong(0)/m/n/10.53937 同
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 个
+............\TU/FandolSong(0)/m/n/10.53937 个
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 注
+............\TU/FandolSong(0)/m/n/10.53937 注
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 意
+............\TU/FandolSong(0)/m/n/10.53937 意
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 副
+............\TU/FandolSong(0)/m/n/10.53937 副
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 本
+............\TU/FandolSong(0)/m/n/10.53937 本
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 不
+............\TU/FandolSong(0)/m/n/10.53937 不
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 计
+............\TU/FandolSong(0)/m/n/10.53937 计
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 入
+............\TU/FandolSong(0)/m/n/10.53937 入
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2488
 ............\kern0.94855
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 中
+............\TU/FandolSong(0)/m/n/10.53937 中
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -9930,32 +9930,32 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 166.0093fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 系
+............\TU/FandolSong(0)/m/n/10.53937 系
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 统
+............\TU/FandolSong(0)/m/n/10.53937 统
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 中
+............\TU/FandolSong(0)/m/n/10.53937 中
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2488
 ............\kern0.94855
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 个
+............\TU/FandolSong(0)/m/n/10.53937 个
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 彼
+............\TU/FandolSong(0)/m/n/10.53937 彼
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 此
+............\TU/FandolSong(0)/m/n/10.53937 此
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 不
+............\TU/FandolSong(0)/m/n/10.53937 不
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 同
+............\TU/FandolSong(0)/m/n/10.53937 同
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10003,27 +10003,27 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 182.8196fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 访
+............\TU/FandolSong(0)/m/n/10.53937 访
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 问
+............\TU/FandolSong(0)/m/n/10.53937 问
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 频
+............\TU/FandolSong(0)/m/n/10.53937 频
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 度
+............\TU/FandolSong(0)/m/n/10.53937 度
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 分
+............\TU/FandolSong(0)/m/n/10.53937 分
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 布
+............\TU/FandolSong(0)/m/n/10.53937 布
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 向
+............\TU/FandolSong(0)/m/n/10.53937 向
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 量
+............\TU/FandolSong(0)/m/n/10.53937 量
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10056,9 +10056,9 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 81.45195fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2507
@@ -10066,23 +10066,23 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 个
+............\TU/FandolSong(0)/m/n/10.53937 个
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 亦
+............\TU/FandolSong(0)/m/n/10.53937 亦
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 即
+............\TU/FandolSong(0)/m/n/10.53937 即
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2507
@@ -10090,21 +10090,21 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 应
+............\TU/FandolSong(0)/m/n/10.53937 应
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 答
+............\TU/FandolSong(0)/m/n/10.53937 答
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 结
+............\TU/FandolSong(0)/m/n/10.53937 结
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 点
+............\TU/FandolSong(0)/m/n/10.53937 点
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 个
+............\TU/FandolSong(0)/m/n/10.53937 个
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10140,9 +10140,9 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+2.71211)x298.75264, glue set 0.2513
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2507
@@ -10150,37 +10150,37 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 失
+............\TU/FandolSong(0)/m/n/10.53937 失
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 效
+............\TU/FandolSong(0)/m/n/10.53937 效
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 率
+............\TU/FandolSong(0)/m/n/10.53937 率
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 每
+............\TU/FandolSong(0)/m/n/10.53937 每
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\TU/texgyretermes(0)/m/n/10.53937 1
 ............\kern -0.00021
 ............\kern 0.00021
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 秒
+............\TU/FandolSong(0)/m/n/10.53937 秒
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 内
+............\TU/FandolSong(0)/m/n/10.53937 内
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 失
+............\TU/FandolSong(0)/m/n/10.53937 失
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 效
+............\TU/FandolSong(0)/m/n/10.53937 效
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2507
@@ -10188,15 +10188,15 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 占
+............\TU/FandolSong(0)/m/n/10.53937 占
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 全
+............\TU/FandolSong(0)/m/n/10.53937 全
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 部
+............\TU/FandolSong(0)/m/n/10.53937 部
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2507
@@ -10204,18 +10204,18 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue(\rightskip) 0.0
 ...........\penalty 10150
 ...........\glue(\baselineskip) 1.8409
 ...........\hbox(8.09424+3.7942)x298.75264, glue set 277.6739fil
-............\TU/FandolSong-Regular(0)/m/n/10.53937 比
+............\TU/FandolSong(0)/m/n/10.53937 比
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 例
+............\TU/FandolSong(0)/m/n/10.53937 例
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10249,53 +10249,53 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 13.01984fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 当
+............\TU/FandolSong(0)/m/n/10.53937 当
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 具
+............\TU/FandolSong(0)/m/n/10.53937 具
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 有
+............\TU/FandolSong(0)/m/n/10.53937 有
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 相
+............\TU/FandolSong(0)/m/n/10.53937 相
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 近
+............\TU/FandolSong(0)/m/n/10.53937 近
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 更
+............\TU/FandolSong(0)/m/n/10.53937 更
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 新
+............\TU/FandolSong(0)/m/n/10.53937 新
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 频
+............\TU/FandolSong(0)/m/n/10.53937 频
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 度
+............\TU/FandolSong(0)/m/n/10.53937 度
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 时
+............\TU/FandolSong(0)/m/n/10.53937 时
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 ，
+............\TU/FandolSong(0)/m/n/10.53937 ，
 ............\rule(0.0+0.0)x-7.29324
 ............\glue 7.29324 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 失
+............\TU/FandolSong(0)/m/n/10.53937 失
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 效
+............\TU/FandolSong(0)/m/n/10.53937 效
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 率
+............\TU/FandolSong(0)/m/n/10.53937 率
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 用
+............\TU/FandolSong(0)/m/n/10.53937 用
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 统
+............\TU/FandolSong(0)/m/n/10.53937 统
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 一
+............\TU/FandolSong(0)/m/n/10.53937 一
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\hbox(6.8822+0.18971)x16.97893
@@ -10304,9 +10304,9 @@ Completed box being shipped out [5]
 .............\TU/texgyretermes(1)/m/it/10.53937 glyph#112
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 表
+............\TU/FandolSong(0)/m/n/10.53937 表
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 示
+............\TU/FandolSong(0)/m/n/10.53937 示
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10382,74 +10382,74 @@ Completed box being shipped out [5]
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#126
 ............\mathoff
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 ，
+............\TU/FandolSong(0)/m/n/10.53937 ，
 ............\rule(0.0+0.0)x-7.29324
 ............\glue 7.29324 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 即
+............\TU/FandolSong(0)/m/n/10.53937 即
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 所
+............\TU/FandolSong(0)/m/n/10.53937 所
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 有
+............\TU/FandolSong(0)/m/n/10.53937 有
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 失
+............\TU/FandolSong(0)/m/n/10.53937 失
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 效
+............\TU/FandolSong(0)/m/n/10.53937 效
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 率
+............\TU/FandolSong(0)/m/n/10.53937 率
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 最
+............\TU/FandolSong(0)/m/n/10.53937 最
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 大
+............\TU/FandolSong(0)/m/n/10.53937 大
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 值
+............\TU/FandolSong(0)/m/n/10.53937 值
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 如
+............\TU/FandolSong(0)/m/n/10.53937 如
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 果
+............\TU/FandolSong(0)/m/n/10.53937 果
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 不
+............\TU/FandolSong(0)/m/n/10.53937 不
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 考
+............\TU/FandolSong(0)/m/n/10.53937 考
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 虑
+............\TU/FandolSong(0)/m/n/10.53937 虑
 ............\glue(\rightskip) 0.0
 ...........\penalty 10150
 ...........\glue(\baselineskip) 1.71443
 ...........\hbox(8.2207+3.7942)x298.75264, glue set 66.78787fil
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 之
+............\TU/FandolSong(0)/m/n/10.53937 之
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 间
+............\TU/FandolSong(0)/m/n/10.53937 间
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 更
+............\TU/FandolSong(0)/m/n/10.53937 更
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 新
+............\TU/FandolSong(0)/m/n/10.53937 新
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 频
+............\TU/FandolSong(0)/m/n/10.53937 频
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 度
+............\TU/FandolSong(0)/m/n/10.53937 度
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 差
+............\TU/FandolSong(0)/m/n/10.53937 差
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 异
+............\TU/FandolSong(0)/m/n/10.53937 异
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 ，
+............\TU/FandolSong(0)/m/n/10.53937 ，
 ............\rule(0.0+0.0)x-7.29324
 ............\glue 7.29324 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 则
+............\TU/FandolSong(0)/m/n/10.53937 则
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\hbox(6.8822+0.18971)x16.97893
@@ -10522,63 +10522,63 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 3.65034fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 消
+............\TU/FandolSong(0)/m/n/10.53937 消
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 息
+............\TU/FandolSong(0)/m/n/10.53937 息
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 冗
+............\TU/FandolSong(0)/m/n/10.53937 冗
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 余
+............\TU/FandolSong(0)/m/n/10.53937 余
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 和
+............\TU/FandolSong(0)/m/n/10.53937 和
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 消
+............\TU/FandolSong(0)/m/n/10.53937 消
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 息
+............\TU/FandolSong(0)/m/n/10.53937 息
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 比
+............\TU/FandolSong(0)/m/n/10.53937 比
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 特
+............\TU/FandolSong(0)/m/n/10.53937 特
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 刻
+............\TU/FandolSong(0)/m/n/10.53937 刻
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 画
+............\TU/FandolSong(0)/m/n/10.53937 画
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 消
+............\TU/FandolSong(0)/m/n/10.53937 消
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 息
+............\TU/FandolSong(0)/m/n/10.53937 息
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 转
+............\TU/FandolSong(0)/m/n/10.53937 转
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 发
+............\TU/FandolSong(0)/m/n/10.53937 发
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10624,63 +10624,63 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 3.65034fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 维
+............\TU/FandolSong(0)/m/n/10.53937 维
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 护
+............\TU/FandolSong(0)/m/n/10.53937 护
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 消
+............\TU/FandolSong(0)/m/n/10.53937 消
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 息
+............\TU/FandolSong(0)/m/n/10.53937 息
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 冗
+............\TU/FandolSong(0)/m/n/10.53937 冗
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 余
+............\TU/FandolSong(0)/m/n/10.53937 余
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 和
+............\TU/FandolSong(0)/m/n/10.53937 和
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 维
+............\TU/FandolSong(0)/m/n/10.53937 维
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 护
+............\TU/FandolSong(0)/m/n/10.53937 护
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 消
+............\TU/FandolSong(0)/m/n/10.53937 消
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 息
+............\TU/FandolSong(0)/m/n/10.53937 息
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 比
+............\TU/FandolSong(0)/m/n/10.53937 比
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 特
+............\TU/FandolSong(0)/m/n/10.53937 特
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 刻
+............\TU/FandolSong(0)/m/n/10.53937 刻
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 画
+............\TU/FandolSong(0)/m/n/10.53937 画
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 维
+............\TU/FandolSong(0)/m/n/10.53937 维
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 护
+............\TU/FandolSong(0)/m/n/10.53937 护
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 消
+............\TU/FandolSong(0)/m/n/10.53937 消
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 息
+............\TU/FandolSong(0)/m/n/10.53937 息
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10730,53 +10730,53 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 45.80782fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 系
+............\TU/FandolSong(0)/m/n/10.53937 系
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 统
+............\TU/FandolSong(0)/m/n/10.53937 统
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 中
+............\TU/FandolSong(0)/m/n/10.53937 中
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 使
+............\TU/FandolSong(0)/m/n/10.53937 使
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 用
+............\TU/FandolSong(0)/m/n/10.53937 用
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 总
+............\TU/FandolSong(0)/m/n/10.53937 总
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 和
+............\TU/FandolSong(0)/m/n/10.53937 和
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 维
+............\TU/FandolSong(0)/m/n/10.53937 维
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 护
+............\TU/FandolSong(0)/m/n/10.53937 护
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 使
+............\TU/FandolSong(0)/m/n/10.53937 使
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 用
+............\TU/FandolSong(0)/m/n/10.53937 用
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 总
+............\TU/FandolSong(0)/m/n/10.53937 总
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10826,68 +10826,68 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+1.91815)x298.75264, glue set 0.33861
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 系
+............\TU/FandolSong(0)/m/n/10.53937 系
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 统
+............\TU/FandolSong(0)/m/n/10.53937 统
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 总
+............\TU/FandolSong(0)/m/n/10.53937 总
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 与
+............\TU/FandolSong(0)/m/n/10.53937 与
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 单
+............\TU/FandolSong(0)/m/n/10.53937 单
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 个
+............\TU/FandolSong(0)/m/n/10.53937 个
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 结
+............\TU/FandolSong(0)/m/n/10.53937 结
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 点
+............\TU/FandolSong(0)/m/n/10.53937 点
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 上
+............\TU/FandolSong(0)/m/n/10.53937 上
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 是
+............\TU/FandolSong(0)/m/n/10.53937 是
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 与
+............\TU/FandolSong(0)/m/n/10.53937 与
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 维
+............\TU/FandolSong(0)/m/n/10.53937 维
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 护
+............\TU/FandolSong(0)/m/n/10.53937 护
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 之
+............\TU/FandolSong(0)/m/n/10.53937 之
 ............\glue(\rightskip) 0.0
 ...........\penalty 10150
 ...........\glue(\baselineskip) 2.76134
 ...........\hbox(7.96776+3.7942)x298.75264, glue set 288.21327fil
-............\TU/FandolSong-Regular(0)/m/n/10.53937 和
+............\TU/FandolSong(0)/m/n/10.53937 和
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -10924,39 +10924,39 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 70.31184fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 使
+............\TU/FandolSong(0)/m/n/10.53937 使
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 开
+............\TU/FandolSong(0)/m/n/10.53937 开
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 销
+............\TU/FandolSong(0)/m/n/10.53937 销
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 最
+............\TU/FandolSong(0)/m/n/10.53937 最
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 小
+............\TU/FandolSong(0)/m/n/10.53937 小
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 化
+............\TU/FandolSong(0)/m/n/10.53937 化
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 量
+............\TU/FandolSong(0)/m/n/10.53937 量
 ............\glue 0.0 plus 0.41463
 ............\glue 6.68196 minus 5.26968
 ............\rule(0.0+0.0)x-6.68196
-............\TU/FandolSong-Regular(0)/m/n/10.53937 （指
+............\TU/FandolSong(0)/m/n/10.53937 （指
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 据
+............\TU/FandolSong(0)/m/n/10.53937 据
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2507
@@ -10964,13 +10964,13 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 ）
+............\TU/FandolSong(0)/m/n/10.53937 ）
 ............\rule(0.0+0.0)x-6.68196
 ............\kern 0.00041
 ............\kern -0.00041
@@ -11014,33 +11014,33 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+2.9552)x298.75264, glue set 0.29526
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 结
+............\TU/FandolSong(0)/m/n/10.53937 结
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 点
+............\TU/FandolSong(0)/m/n/10.53937 点
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 理
+............\TU/FandolSong(0)/m/n/10.53937 理
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 论
+............\TU/FandolSong(0)/m/n/10.53937 论
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 下
+............\TU/FandolSong(0)/m/n/10.53937 下
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 限
+............\TU/FandolSong(0)/m/n/10.53937 限
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 当
+............\TU/FandolSong(0)/m/n/10.53937 当
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 所
+............\TU/FandolSong(0)/m/n/10.53937 所
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 有
+............\TU/FandolSong(0)/m/n/10.53937 有
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2507
@@ -11048,25 +11048,25 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 都
+............\TU/FandolSong(0)/m/n/10.53937 都
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 等
+............\TU/FandolSong(0)/m/n/10.53937 等
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 于
+............\TU/FandolSong(0)/m/n/10.53937 于
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 对
+............\TU/FandolSong(0)/m/n/10.53937 对
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 应
+............\TU/FandolSong(0)/m/n/10.53937 应
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2478
@@ -11078,14 +11078,14 @@ Completed box being shipped out [5]
 ..............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 时
+............\TU/FandolSong(0)/m/n/10.53937 时
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 取
+............\TU/FandolSong(0)/m/n/10.53937 取
 ............\glue(\rightskip) 0.0
 ...........\penalty 10150
 ...........\glue(\baselineskip) 1.5662
 ...........\hbox(8.12585+3.7942)x298.75264, glue set 288.21327fil
-............\TU/FandolSong-Regular(0)/m/n/10.53937 到
+............\TU/FandolSong(0)/m/n/10.53937 到
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -11118,25 +11118,25 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+4.1541)x298.75264, glue set 97.66689fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 结
+............\TU/FandolSong(0)/m/n/10.53937 结
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 点
+............\TU/FandolSong(0)/m/n/10.53937 点
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 可
+............\TU/FandolSong(0)/m/n/10.53937 可
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 用
+............\TU/FandolSong(0)/m/n/10.53937 用
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 约
+............\TU/FandolSong(0)/m/n/10.53937 约
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 束
+............\TU/FandolSong(0)/m/n/10.53937 束
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\kern 0.00041
 ............\kern -0.00041
@@ -11149,15 +11149,15 @@ Completed box being shipped out [5]
 .............\TU/texgyretermes(1)/m/it/10.53937 glyph#28
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 必
+............\TU/FandolSong(0)/m/n/10.53937 必
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 须
+............\TU/FandolSong(0)/m/n/10.53937 须
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 不
+............\TU/FandolSong(0)/m/n/10.53937 不
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 小
+............\TU/FandolSong(0)/m/n/10.53937 小
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 于
+............\TU/FandolSong(0)/m/n/10.53937 于
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\hbox(7.1984+0.18971)x12.29944
@@ -11204,59 +11204,59 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+3.7942)x298.75264, glue set 24.72908fil
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 单
+............\TU/FandolSong(0)/m/n/10.53937 单
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 次
+............\TU/FandolSong(0)/m/n/10.53937 次
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 所
+............\TU/FandolSong(0)/m/n/10.53937 所
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 需
+............\TU/FandolSong(0)/m/n/10.53937 需
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 遍
+............\TU/FandolSong(0)/m/n/10.53937 遍
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 历
+............\TU/FandolSong(0)/m/n/10.53937 历
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 不
+............\TU/FandolSong(0)/m/n/10.53937 不
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 同
+............\TU/FandolSong(0)/m/n/10.53937 同
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 结
+............\TU/FandolSong(0)/m/n/10.53937 结
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 点
+............\TU/FandolSong(0)/m/n/10.53937 点
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 期
+............\TU/FandolSong(0)/m/n/10.53937 期
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 望
+............\TU/FandolSong(0)/m/n/10.53937 望
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 刻
+............\TU/FandolSong(0)/m/n/10.53937 刻
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 画
+............\TU/FandolSong(0)/m/n/10.53937 画
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 等
+............\TU/FandolSong(0)/m/n/10.53937 等
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 待
+............\TU/FandolSong(0)/m/n/10.53937 待
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 时
+............\TU/FandolSong(0)/m/n/10.53937 时
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 间
+............\TU/FandolSong(0)/m/n/10.53937 间
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -11288,43 +11288,43 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+2.71211)x298.75264, glue set - 0.11797
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 放
+............\TU/FandolSong(0)/m/n/10.53937 放
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 大
+............\TU/FandolSong(0)/m/n/10.53937 大
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 系
+............\TU/FandolSong(0)/m/n/10.53937 系
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 ，
+............\TU/FandolSong(0)/m/n/10.53937 ，
 ............\rule(0.0+0.0)x-7.29324
 ............\glue 7.29324 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 即
+............\TU/FandolSong(0)/m/n/10.53937 即
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 约
+............\TU/FandolSong(0)/m/n/10.53937 约
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 束
+............\TU/FandolSong(0)/m/n/10.53937 束
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 下
+............\TU/FandolSong(0)/m/n/10.53937 下
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 最
+............\TU/FandolSong(0)/m/n/10.53937 最
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 优
+............\TU/FandolSong(0)/m/n/10.53937 优
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2478
@@ -11332,28 +11332,28 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 与
+............\TU/FandolSong(0)/m/n/10.53937 与
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 最
+............\TU/FandolSong(0)/m/n/10.53937 最
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 小
+............\TU/FandolSong(0)/m/n/10.53937 小
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 化
+............\TU/FandolSong(0)/m/n/10.53937 化
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue(\rightskip) 0.0
 ...........\penalty 10150
 ...........\glue(\baselineskip) 1.67227
 ...........\hbox(8.26286+4.1541)x298.75264, glue set 14.62926fil
-............\TU/FandolSong-Regular(0)/m/n/10.53937 数
+............\TU/FandolSong(0)/m/n/10.53937 数
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2478
@@ -11365,13 +11365,13 @@ Completed box being shipped out [5]
 ..............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 比
+............\TU/FandolSong(0)/m/n/10.53937 比
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 值
+............\TU/FandolSong(0)/m/n/10.53937 值
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\kern 0.00041
 ............\kern -0.00041
@@ -11383,15 +11383,15 @@ Completed box being shipped out [5]
 ............\kern0.52696
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 由
+............\TU/FandolSong(0)/m/n/10.53937 由
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 约
+............\TU/FandolSong(0)/m/n/10.53937 约
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 束
+............\TU/FandolSong(0)/m/n/10.53937 束
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\hbox(7.0403+0.0)x12.87912
@@ -11399,15 +11399,15 @@ Completed box being shipped out [5]
 .............\TU/texgyretermes(1)/m/it/10.53937 glyph#28
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 与
+............\TU/FandolSong(0)/m/n/10.53937 与
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 带
+............\TU/FandolSong(0)/m/n/10.53937 带
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+............\TU/FandolSong(0)/m/n/10.53937 宽
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 下
+............\TU/FandolSong(0)/m/n/10.53937 下
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 限
+............\TU/FandolSong(0)/m/n/10.53937 限
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\hbox(7.1984+0.18971)x12.29944
@@ -11423,15 +11423,15 @@ Completed box being shipped out [5]
 ..............\kern 0.0002
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 比
+............\TU/FandolSong(0)/m/n/10.53937 比
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 值
+............\TU/FandolSong(0)/m/n/10.53937 值
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 决
+............\TU/FandolSong(0)/m/n/10.53937 决
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 定
+............\TU/FandolSong(0)/m/n/10.53937 定
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -11463,66 +11463,66 @@ Completed box being shipped out [5]
 ...........\hbox(8.85303+2.03409)x298.75264, glue set 0.10588
 ............\hbox(0.0+0.0)x0.0
 ............\rule(8.85303+*)x0.0
-............\TU/FandolSong-Regular(0)/m/n/10.53937 与
+............\TU/FandolSong(0)/m/n/10.53937 与
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2489
 ............\kern0.94855
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 无
+............\TU/FandolSong(0)/m/n/10.53937 无
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 关
+............\TU/FandolSong(0)/m/n/10.53937 关
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 系
+............\TU/FandolSong(0)/m/n/10.53937 系
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 统
+............\TU/FandolSong(0)/m/n/10.53937 统
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 常
+............\TU/FandolSong(0)/m/n/10.53937 常
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 量
+............\TU/FandolSong(0)/m/n/10.53937 量
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 ，
+............\TU/FandolSong(0)/m/n/10.53937 ，
 ............\rule(0.0+0.0)x-7.29324
 ............\glue 7.29324 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 刻
+............\TU/FandolSong(0)/m/n/10.53937 刻
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 画
+............\TU/FandolSong(0)/m/n/10.53937 画
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 了
+............\TU/FandolSong(0)/m/n/10.53937 了
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+............\TU/FandolSong(0)/m/n/10.53937 搜
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 与
+............\TU/FandolSong(0)/m/n/10.53937 与
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 维
+............\TU/FandolSong(0)/m/n/10.53937 维
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 护
+............\TU/FandolSong(0)/m/n/10.53937 护
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 之
+............\TU/FandolSong(0)/m/n/10.53937 之
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 间
+............\TU/FandolSong(0)/m/n/10.53937 间
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 折
+............\TU/FandolSong(0)/m/n/10.53937 折
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 衷
+............\TU/FandolSong(0)/m/n/10.53937 衷
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 关
+............\TU/FandolSong(0)/m/n/10.53937 关
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 系
+............\TU/FandolSong(0)/m/n/10.53937 系
 ............\penalty 10000
-............\TU/FandolSong-Regular(0)/m/n/10.53937 。
+............\TU/FandolSong(0)/m/n/10.53937 。
 ............\rule(0.0+0.0)x-6.78735
 ............\glue 6.78735 minus 5.26968
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 用
+............\TU/FandolSong(0)/m/n/10.53937 用
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#3169
@@ -11532,19 +11532,19 @@ Completed box being shipped out [5]
 ...........\penalty 10150
 ...........\glue(\baselineskip) 2.40298
 ...........\hbox(8.21017+3.7942)x298.75264, glue set 179.69994fil
-............\TU/FandolSong-Regular(0)/m/n/10.53937 可
+............\TU/FandolSong(0)/m/n/10.53937 可
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 简
+............\TU/FandolSong(0)/m/n/10.53937 简
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 化
+............\TU/FandolSong(0)/m/n/10.53937 化
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 索
+............\TU/FandolSong(0)/m/n/10.53937 索
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 引
+............\TU/FandolSong(0)/m/n/10.53937 引
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 比
+............\TU/FandolSong(0)/m/n/10.53937 比
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 例
+............\TU/FandolSong(0)/m/n/10.53937 例
 ............\glue 2.63484 plus 1.31741 minus 0.87828
 ............\mathon
 ............\TU/XITSMath-Regular(1)/m/n/10.53937 glyph#2511
@@ -11552,11 +11552,11 @@ Completed box being shipped out [5]
 .............\TU/XITSMath-Regular(1)/m/n/7 glyph#2509
 ............\mathoff
 ............\glue 2.63484 plus 1.31741 minus 0.87828
-............\TU/FandolSong-Regular(0)/m/n/10.53937 的
+............\TU/FandolSong(0)/m/n/10.53937 的
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 表
+............\TU/FandolSong(0)/m/n/10.53937 表
 ............\glue 0.0 plus 0.41463
-............\TU/FandolSong-Regular(0)/m/n/10.53937 示
+............\TU/FandolSong(0)/m/n/10.53937 示
 ............\kern -0.00018
 ............\kern 0.00018
 ............\penalty 10000
@@ -11581,82 +11581,82 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\topskip) 2.59285
 ...\hbox(9.40715+4.70088)x426.79135, glue set - 0.27238
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 贝
+....\TU/FandolSong(0)/m/n/12.045 贝
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 努
+....\TU/FandolSong(0)/m/n/12.045 努
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 利
+....\TU/FandolSong(0)/m/n/12.045 利
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 刻
+....\TU/FandolSong(0)/m/n/12.045 刻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 画
+....\TU/FandolSong(0)/m/n/12.045 画
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 共
+....\TU/FandolSong(0)/m/n/12.045 共
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2489
 ....\kern1.08405
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2478
@@ -11667,69 +11667,69 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 5.8706
 ...\hbox(9.50351+4.70088)x426.79135, glue set - 0.23509
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 答
+....\TU/FandolSong(0)/m/n/12.045 答
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 偏
+....\TU/FandolSong(0)/m/n/12.045 偏
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 新
+....\TU/FandolSong(0)/m/n/12.045 新
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遍
+....\TU/FandolSong(0)/m/n/12.045 遍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 束
+....\TU/FandolSong(0)/m/n/12.045 束
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2478
@@ -11741,73 +11741,73 @@ Completed box being shipped out [5]
 ....\kern1.08405
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue(\rightskip) 0.0
 ...\penalty 50
 ...\glue(\baselineskip) 5.96696
 ...\hbox(9.40715+2.32468)x426.79135, glue set 107.8639fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 贝
+....\TU/FandolSong(0)/m/n/12.045 贝
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 努
+....\TU/FandolSong(0)/m/n/12.045 努
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 利
+....\TU/FandolSong(0)/m/n/12.045 利
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 知
+....\TU/FandolSong(0)/m/n/12.045 知
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遍
+....\TU/FandolSong(0)/m/n/12.045 遍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 望
+....\TU/FandolSong(0)/m/n/12.045 望
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 满
+....\TU/FandolSong(0)/m/n/12.045 满
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 足
+....\TU/FandolSong(0)/m/n/12.045 足
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -11826,36 +11826,36 @@ Completed box being shipped out [5]
 .....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#124
 .....\hbox(9.40715+2.25241)x170.73784
 ......\hbox(9.40715+2.25241)x170.73784
-.......\TU/FandolSong-Regular(0)/m/n/12.045 搜
+.......\TU/FandolSong(0)/m/n/12.045 搜
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 索
+.......\TU/FandolSong(0)/m/n/12.045 索
 .......\glue 3.01125 plus 1.50562 minus 1.00374
 .......\mathon
 .......\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 .......\kern1.4454
 .......\mathoff
 .......\glue 3.01125 plus 1.50562 minus 1.00374
-.......\TU/FandolSong-Regular(0)/m/n/12.045 所
+.......\TU/FandolSong(0)/m/n/12.045 所
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 遍
+.......\TU/FandolSong(0)/m/n/12.045 遍
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 历
+.......\TU/FandolSong(0)/m/n/12.045 历
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 的
+.......\TU/FandolSong(0)/m/n/12.045 的
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 不
+.......\TU/FandolSong(0)/m/n/12.045 不
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 同
+.......\TU/FandolSong(0)/m/n/12.045 同
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 结
+.......\TU/FandolSong(0)/m/n/12.045 结
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 点
+.......\TU/FandolSong(0)/m/n/12.045 点
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 的
+.......\TU/FandolSong(0)/m/n/12.045 的
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 个
+.......\TU/FandolSong(0)/m/n/12.045 个
 .......\glue 0.0 plus 0.52307
-.......\TU/FandolSong-Regular(0)/m/n/12.045 数
+.......\TU/FandolSong(0)/m/n/12.045 数
 .......\kern -0.00017
 .......\kern 0.00017
 .....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#126
@@ -11925,61 +11925,61 @@ Completed box being shipped out [5]
 ...\glue(\lineskip) 1.0
 ...\hbox(9.50351+3.10188)x426.79135, glue set - 0.12634
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 占
+....\TU/FandolSong(0)/m/n/12.045 占
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 网
+....\TU/FandolSong(0)/m/n/12.045 网
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 络
+....\TU/FandolSong(0)/m/n/12.045 络
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 定
+....\TU/FandolSong(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\glue 0.0 plus 0.52307
 ....\glue 7.04633 minus 6.0225
 ....\rule(0.0+0.0)x-7.04633
-....\TU/FandolSong-Regular(0)/m/n/12.045 “搜
+....\TU/FandolSong(0)/m/n/12.045 “搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 冗
+....\TU/FandolSong(0)/m/n/12.045 冗
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 余
+....\TU/FandolSong(0)/m/n/12.045 余
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ”
+....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\kern 0.00043
 ....\kern -0.00043
@@ -11994,284 +11994,284 @@ Completed box being shipped out [5]
 .....\kern 0.0002
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 示
+....\TU/FandolSong(0)/m/n/12.045 示
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.48166
 ...\hbox(9.49146+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 每
+....\TU/FandolSong(0)/m/n/12.045 每
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 求
+....\TU/FandolSong(0)/m/n/12.045 求
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 复
+....\TU/FandolSong(0)/m/n/12.045 复
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 显
+....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 转
+....\TU/FandolSong(0)/m/n/12.045 转
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 没
+....\TU/FandolSong(0)/m/n/12.045 没
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 义
+....\TU/FandolSong(0)/m/n/12.045 义
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 只
+....\TU/FandolSong(0)/m/n/12.045 只
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 来
+....\TU/FandolSong(0)/m/n/12.045 来
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 浪
+....\TU/FandolSong(0)/m/n/12.045 浪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 费
+....\TU/FandolSong(0)/m/n/12.045 费
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 但
+....\TU/FandolSong(0)/m/n/12.045 但
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.22273
 ...\hbox(9.52759+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 非
+....\TU/FandolSong(0)/m/n/12.045 非
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 都
+....\TU/FandolSong(0)/m/n/12.045 都
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 冗
+....\TU/FandolSong(0)/m/n/12.045 冗
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 余
+....\TU/FandolSong(0)/m/n/12.045 余
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 譬
+....\TU/FandolSong(0)/m/n/12.045 譬
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 洪
+....\TU/FandolSong(0)/m/n/12.045 洪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泛
+....\TU/FandolSong(0)/m/n/12.045 泛
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 播
+....\TU/FandolSong(0)/m/n/12.045 播
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+3.10188)x426.79135, glue set 0.1687
-....\TU/FandolSong-Regular(0)/m/n/12.045 沿
+....\TU/FandolSong(0)/m/n/12.045 沿
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 着
+....\TU/FandolSong(0)/m/n/12.045 着
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 径
+....\TU/FandolSong(0)/m/n/12.045 径
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 抵
+....\TU/FandolSong(0)/m/n/12.045 抵
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 达
+....\TU/FandolSong(0)/m/n/12.045 达
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2493
@@ -12281,88 +12281,88 @@ Completed box being shipped out [5]
 .....\kern 0.0002
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 值
+....\TU/FandolSong(0)/m/n/12.045 值
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 当
+....\TU/FandolSong(0)/m/n/12.045 当
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 随
+....\TU/FandolSong(0)/m/n/12.045 随
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 走
+....\TU/FandolSong(0)/m/n/12.045 走
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 步
+....\TU/FandolSong(0)/m/n/12.045 步
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 通
+....\TU/FandolSong(0)/m/n/12.045 通
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.56596
 ...\hbox(9.40715+3.10188)x426.79135, glue set 77.09645fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 记
+....\TU/FandolSong(0)/m/n/12.045 记
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 遍
+....\TU/FandolSong(0)/m/n/12.045 遍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 历
+....\TU/FandolSong(0)/m/n/12.045 历
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 无
+....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 冗
+....\TU/FandolSong(0)/m/n/12.045 冗
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 余
+....\TU/FandolSong(0)/m/n/12.045 余
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 息
+....\TU/FandolSong(0)/m/n/12.045 息
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 转
+....\TU/FandolSong(0)/m/n/12.045 转
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2493
@@ -12377,7 +12377,7 @@ Completed box being shipped out [5]
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#50
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -12390,96 +12390,96 @@ Completed box being shipped out [5]
 ...\glue(\baselineskip) 7.51779
 ...\hbox(9.45532+2.32468)x426.79135, glue set - 0.56693
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 述
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 析
+....\TU/FandolSong(0)/m/n/12.045 析
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 看
+....\TU/FandolSong(0)/m/n/12.045 看
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 耗
+....\TU/FandolSong(0)/m/n/12.045 耗
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 影
+....\TU/FandolSong(0)/m/n/12.045 影
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+4.70088)x426.79135, glue set - 0.07869
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 越
+....\TU/FandolSong(0)/m/n/12.045 越
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 广
+....\TU/FandolSong(0)/m/n/12.045 广
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （即
+....\TU/FandolSong(0)/m/n/12.045 （即
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2478
@@ -12488,211 +12488,211 @@ Completed box being shipped out [5]
 .....\kern1.08405
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 越
+....\TU/FandolSong(0)/m/n/12.045 越
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 该
+....\TU/FandolSong(0)/m/n/12.045 该
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 越
+....\TU/FandolSong(0)/m/n/12.045 越
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 易
+....\TU/FandolSong(0)/m/n/12.045 易
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 也
+....\TU/FandolSong(0)/m/n/12.045 也
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 越
+....\TU/FandolSong(0)/m/n/12.045 越
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 5.9188
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.31165
-....\TU/FandolSong-Regular(0)/m/n/12.045 另
+....\TU/FandolSong(0)/m/n/12.045 另
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 际
+....\TU/FandolSong(0)/m/n/12.045 际
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 变
+....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 动
+....\TU/FandolSong(0)/m/n/12.045 动
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 失
+....\TU/FandolSong(0)/m/n/12.045 失
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 续
+....\TU/FandolSong(0)/m/n/12.045 续
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 断
+....\TU/FandolSong(0)/m/n/12.045 断
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 地
+....\TU/FandolSong(0)/m/n/12.045 地
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 否
+....\TU/FandolSong(0)/m/n/12.045 否
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+3.10188)x426.79135, glue set 0.26299
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 就
+....\TU/FandolSong(0)/m/n/12.045 就
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 会
+....\TU/FandolSong(0)/m/n/12.045 会
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 断
+....\TU/FandolSong(0)/m/n/12.045 断
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 减
+....\TU/FandolSong(0)/m/n/12.045 减
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 少
+....\TU/FandolSong(0)/m/n/12.045 少
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 零
+....\TU/FandolSong(0)/m/n/12.045 零
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\hbox(7.86539+0.21681)x17.39297
@@ -12814,53 +12814,53 @@ Completed box being shipped out [6]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 86.92326fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 3
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 等
+..........\TU/FandolSong(0)/m/n/10.53937 等
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 网
+..........\TU/FandolSong(0)/m/n/10.53937 网
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 络
+..........\TU/FandolSong(0)/m/n/10.53937 络
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 中
+..........\TU/FandolSong(0)/m/n/10.53937 中
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+..........\TU/FandolSong(0)/m/n/10.53937 宽
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 松
+..........\TU/FandolSong(0)/m/n/10.53937 松
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 约
+..........\TU/FandolSong(0)/m/n/10.53937 约
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 束
+..........\TU/FandolSong(0)/m/n/10.53937 束
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 一
+..........\TU/FandolSong(0)/m/n/10.53937 一
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 般
+..........\TU/FandolSong(0)/m/n/10.53937 般
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 性
+..........\TU/FandolSong(0)/m/n/10.53937 性
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+..........\TU/FandolSong(0)/m/n/10.53937 搜
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 索
+..........\TU/FandolSong(0)/m/n/10.53937 索
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 模
+..........\TU/FandolSong(0)/m/n/10.53937 模
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 型
+..........\TU/FandolSong(0)/m/n/10.53937 型
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -12885,19 +12885,19 @@ Completed box being shipped out [6]
 ..\vbox(674.33032+0.0)x426.79135, glue set 273.13348fil
 ...\glue(\topskip) 2.64104
 ...\hbox(9.35896+3.10188)x426.79135, glue set 19.63101fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\hbox(7.86539+0.21681)x17.39297
@@ -12909,25 +12909,25 @@ Completed box being shipped out [6]
 .....\kern 0.0002
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 维
+....\TU/FandolSong(0)/m/n/12.045 维
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 护
+....\TU/FandolSong(0)/m/n/12.045 护
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\hbox(7.86539+0.21681)x17.39297
@@ -12939,25 +12939,25 @@ Completed box being shipped out [6]
 .....\kern 0.0002
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 两
+....\TU/FandolSong(0)/m/n/12.045 两
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 组
+....\TU/FandolSong(0)/m/n/12.045 组
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 即
+....\TU/FandolSong(0)/m/n/12.045 即
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -13014,17 +13014,17 @@ Completed box being shipped out [6]
 ...\glue(\baselineskip) 7.4696
 ...\hbox(9.50351+3.10188)x426.79135, glue set 106.31885fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 别
+....\TU/FandolSong(0)/m/n/12.045 别
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\hbox(7.86539+0.21681)x17.39297
@@ -13036,7 +13036,7 @@ Completed box being shipped out [6]
 .....\kern 0.0002
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\hbox(7.86539+0.21681)x17.39297
@@ -13048,27 +13048,27 @@ Completed box being shipped out [6]
 .....\kern 0.0002
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 从
+....\TU/FandolSong(0)/m/n/12.045 从
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 性
+....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 能
+....\TU/FandolSong(0)/m/n/12.045 能
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 模
+....\TU/FandolSong(0)/m/n/12.045 模
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 型
+....\TU/FandolSong(0)/m/n/12.045 型
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -13087,29 +13087,29 @@ Completed box being shipped out [6]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 13.04874
-....\TU/FandolHei-Regular(0)/m/n/13.04874 索
+....\TU/FandolHei(0)/m/n/13.04874 索
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 引
+....\TU/FandolHei(0)/m/n/13.04874 引
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 分
+....\TU/FandolHei(0)/m/n/13.04874 分
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 布
+....\TU/FandolHei(0)/m/n/13.04874 布
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 与
+....\TU/FandolHei(0)/m/n/13.04874 与
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 搜
+....\TU/FandolHei(0)/m/n/13.04874 搜
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 索
+....\TU/FandolHei(0)/m/n/13.04874 索
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 开
+....\TU/FandolHei(0)/m/n/13.04874 开
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 销
+....\TU/FandolHei(0)/m/n/13.04874 销
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 的
+....\TU/FandolHei(0)/m/n/13.04874 的
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 关
+....\TU/FandolHei(0)/m/n/13.04874 关
 ....\glue 0.0 plus 0.74269
-....\TU/FandolHei-Regular(0)/m/n/13.04874 系
+....\TU/FandolHei(0)/m/n/13.04874 系
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -13122,90 +13122,90 @@ Completed box being shipped out [6]
 ...\glue(\baselineskip) 8.34016
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.16719
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 首
+....\TU/FandolSong(0)/m/n/12.045 首
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 先
+....\TU/FandolSong(0)/m/n/12.045 先
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 虑
+....\TU/FandolSong(0)/m/n/12.045 虑
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2489
 ....\kern1.08405
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 共
+....\TU/FandolSong(0)/m/n/12.045 共
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 享
+....\TU/FandolSong(0)/m/n/12.045 享
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 了
+....\TU/FandolSong(0)/m/n/12.045 了
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2488
 ....\kern1.08405
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 彼
+....\TU/FandolSong(0)/m/n/12.045 彼
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+3.01157)x426.79135, glue set 0.15118
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
@@ -13228,218 +13228,218 @@ Completed box being shipped out [6]
 .....\kern0.81303
 ....\mathoff
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 注
+....\TU/FandolSong(0)/m/n/12.045 注
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 意
+....\TU/FandolSong(0)/m/n/12.045 意
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
 ....\kern1.4454
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 副
+....\TU/FandolSong(0)/m/n/12.045 副
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 replicas
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 存
+....\TU/FandolSong(0)/m/n/12.045 存
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 储
+....\TU/FandolSong(0)/m/n/12.045 储
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 7.53584
 ...\hbox(9.52759+2.32468)x426.79135, glue set - 0.07417
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 结
+....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 种
+....\TU/FandolSong(0)/m/n/12.045 种
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 况
+....\TU/FandolSong(0)/m/n/12.045 况
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 很
+....\TU/FandolSong(0)/m/n/12.045 很
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 常
+....\TU/FandolSong(0)/m/n/12.045 常
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 譬
+....\TU/FandolSong(0)/m/n/12.045 譬
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 共
+....\TU/FandolSong(0)/m/n/12.045 共
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 享
+....\TU/FandolSong(0)/m/n/12.045 享
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 副
+....\TU/FandolSong(0)/m/n/12.045 副
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.2283)x426.79135, glue set 5.80663fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 联
+....\TU/FandolSong(0)/m/n/12.045 联
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 由
+....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 提
+....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 供
+....\TU/FandolSong(0)/m/n/12.045 供
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 服
+....\TU/FandolSong(0)/m/n/12.045 服
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 里
+....\TU/FandolSong(0)/m/n/12.045 里
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 副
+....\TU/FandolSong(0)/m/n/12.045 副
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 入
+....\TU/FandolSong(0)/m/n/12.045 入
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2488
 ....\kern1.08405
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -13452,35 +13452,35 @@ Completed box being shipped out [6]
 ...\glue(\baselineskip) 8.34319
 ...\hbox(9.50351+3.11093)x426.79135, glue set - 0.18678
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 察
+....\TU/FandolSong(0)/m/n/12.045 察
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 况
+....\TU/FandolSong(0)/m/n/12.045 况
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
@@ -13488,7 +13488,7 @@ Completed box being shipped out [6]
 .....\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#2509
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2478
@@ -13496,286 +13496,286 @@ Completed box being shipped out [6]
 .....\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#2509
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 计
+....\TU/FandolSong(0)/m/n/12.045 计
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 算
+....\TU/FandolSong(0)/m/n/12.045 算
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 消
+....\TU/FandolSong(0)/m/n/12.045 消
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 耗
+....\TU/FandolSong(0)/m/n/12.045 耗
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 7.50874
 ...\hbox(9.45532+2.20422)x426.79135, glue set 0.09528
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 察
+....\TU/FandolSong(0)/m/n/12.045 察
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 务
+....\TU/FandolSong(0)/m/n/12.045 务
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 配
+....\TU/FandolSong(0)/m/n/12.045 配
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 假
+....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 设
+....\TU/FandolSong(0)/m/n/12.045 设
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 单
+....\TU/FandolSong(0)/m/n/12.045 单
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 时
+....\TU/FandolSong(0)/m/n/12.045 时
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 共
+....\TU/FandolSong(0)/m/n/12.045 共
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 产
+....\TU/FandolSong(0)/m/n/12.045 产
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2492
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.23477
 ...\hbox(9.636+2.6258)x426.79135, glue set - 0.09274
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 每
+....\TU/FandolSong(0)/m/n/12.045 每
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 根
+....\TU/FandolSong(0)/m/n/12.045 根
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 身
+....\TU/FandolSong(0)/m/n/12.045 身
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 况
+....\TU/FandolSong(0)/m/n/12.045 况
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 具
+....\TU/FandolSong(0)/m/n/12.045 具
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 访
+....\TU/FandolSong(0)/m/n/12.045 访
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 频
+....\TU/FandolSong(0)/m/n/12.045 频
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （
+....\TU/FandolSong(0)/m/n/12.045 （
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/12.045 popularity
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\penalty 10000
 ....\glue -6.0225 plus 6.0225 minus 1.61403
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 访
+....\TU/FandolSong(0)/m/n/12.045 访
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 频
+....\TU/FandolSong(0)/m/n/12.045 频
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 高
+....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 7.8132
 ...\hbox(9.636+2.40898)x426.79135, glue set 0.10374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
-....\TU/FandolSong-Regular(0)/m/n/12.045 （即
+....\TU/FandolSong(0)/m/n/12.045 （即
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 热
+....\TU/FandolSong(0)/m/n/12.045 热
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 门
+....\TU/FandolSong(0)/m/n/12.045 门
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ）
+....\TU/FandolSong(0)/m/n/12.045 ）
 ....\rule(0.0+0.0)x-7.63654
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 因
+....\TU/FandolSong(0)/m/n/12.045 因
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2492
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 占
+....\TU/FandolSong(0)/m/n/12.045 占
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 多
+....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 份
+....\TU/FandolSong(0)/m/n/12.045 份
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 额
+....\TU/FandolSong(0)/m/n/12.045 额
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
 ...\hbox(9.3951+3.11093)x426.79135, glue set - 0.18811
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 布
+....\TU/FandolSong(0)/m/n/12.045 布
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 量
+....\TU/FandolSong(0)/m/n/12.045 量
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2517
@@ -13806,33 +13806,33 @@ Completed box being shipped out [6]
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#1818
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 示
+....\TU/FandolSong(0)/m/n/12.045 示
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 各
+....\TU/FandolSong(0)/m/n/12.045 各
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 访
+....\TU/FandolSong(0)/m/n/12.045 访
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 问
+....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 频
+....\TU/FandolSong(0)/m/n/12.045 频
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 度
+....\TU/FandolSong(0)/m/n/12.045 度
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2517
@@ -13840,53 +13840,53 @@ Completed box being shipped out [6]
 .....\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#2509
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 示
+....\TU/FandolSong(0)/m/n/12.045 示
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 7.52078
 ...\hbox(9.44328+3.11093)x426.79135, glue set 0.06873
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 统
+....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 现
+....\TU/FandolSong(0)/m/n/12.045 现
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 数
+....\TU/FandolSong(0)/m/n/12.045 数
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2507
@@ -13894,33 +13894,33 @@ Completed box being shipped out [6]
 .....\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#2509
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 满
+....\TU/FandolSong(0)/m/n/12.045 满
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 足
+....\TU/FandolSong(0)/m/n/12.045 足
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 条
+....\TU/FandolSong(0)/m/n/12.045 条
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 概
+....\TU/FandolSong(0)/m/n/12.045 概
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 而
+....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 部
+....\TU/FandolSong(0)/m/n/12.045 部
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2517
@@ -13928,56 +13928,56 @@ Completed box being shipped out [6]
 .....\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#2509
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 这
+....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue(\rightskip) 0.0
 ...\penalty 50
 ...\glue(\baselineskip) 7.6051
 ...\hbox(9.35896+3.10188)x426.79135, glue set 177.5471fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 根
+....\TU/FandolSong(0)/m/n/12.045 根
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 3.2.2
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 小
+....\TU/FandolSong(0)/m/n/12.045 小
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 可
+....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 到
+....\TU/FandolSong(0)/m/n/12.045 到
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 搜
+....\TU/FandolSong(0)/m/n/12.045 搜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 带
+....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宽
+....\TU/FandolSong(0)/m/n/12.045 宽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 销
+....\TU/FandolSong(0)/m/n/12.045 销
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\mathon
 ....\hbox(7.86539+0.21681)x17.39297
@@ -13989,9 +13989,9 @@ Completed box being shipped out [6]
 .....\kern 0.0002
 ....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 为
+....\TU/FandolSong(0)/m/n/12.045 为
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -14203,53 +14203,53 @@ Completed box being shipped out [7]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 86.92326fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 4
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 对
+..........\TU/FandolSong(0)/m/n/10.53937 对
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 等
+..........\TU/FandolSong(0)/m/n/10.53937 等
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 网
+..........\TU/FandolSong(0)/m/n/10.53937 网
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 络
+..........\TU/FandolSong(0)/m/n/10.53937 络
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 中
+..........\TU/FandolSong(0)/m/n/10.53937 中
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 宽
+..........\TU/FandolSong(0)/m/n/10.53937 宽
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 松
+..........\TU/FandolSong(0)/m/n/10.53937 松
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 约
+..........\TU/FandolSong(0)/m/n/10.53937 约
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 束
+..........\TU/FandolSong(0)/m/n/10.53937 束
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 一
+..........\TU/FandolSong(0)/m/n/10.53937 一
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 般
+..........\TU/FandolSong(0)/m/n/10.53937 般
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 性
+..........\TU/FandolSong(0)/m/n/10.53937 性
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 搜
+..........\TU/FandolSong(0)/m/n/10.53937 搜
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 索
+..........\TU/FandolSong(0)/m/n/10.53937 索
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 模
+..........\TU/FandolSong(0)/m/n/10.53937 模
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 型
+..........\TU/FandolSong(0)/m/n/10.53937 型
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -14285,53 +14285,53 @@ Completed box being shipped out [7]
 ...\glue(\baselineskip) 3.43684
 ...\hbox(12.62315+2.8426)x426.79135, glue set 19.77635fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 第
+....\TU/FandolHei(0)/m/n/16.06 第
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 4
 ....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/FandolHei-Regular(0)/m/n/16.06 章
+....\TU/FandolHei(0)/m/n/16.06 章
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 对
+....\TU/FandolHei(0)/m/n/16.06 对
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 等
+....\TU/FandolHei(0)/m/n/16.06 等
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 网
+....\TU/FandolHei(0)/m/n/16.06 网
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 络
+....\TU/FandolHei(0)/m/n/16.06 络
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 中
+....\TU/FandolHei(0)/m/n/16.06 中
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 宽
+....\TU/FandolHei(0)/m/n/16.06 宽
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 松
+....\TU/FandolHei(0)/m/n/16.06 松
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 约
+....\TU/FandolHei(0)/m/n/16.06 约
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 束
+....\TU/FandolHei(0)/m/n/16.06 束
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 的
+....\TU/FandolHei(0)/m/n/16.06 的
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 一
+....\TU/FandolHei(0)/m/n/16.06 一
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 般
+....\TU/FandolHei(0)/m/n/16.06 般
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 性
+....\TU/FandolHei(0)/m/n/16.06 性
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 搜
+....\TU/FandolHei(0)/m/n/16.06 搜
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 索
+....\TU/FandolHei(0)/m/n/16.06 索
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 的
+....\TU/FandolHei(0)/m/n/16.06 的
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 理
+....\TU/FandolHei(0)/m/n/16.06 理
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 论
+....\TU/FandolHei(0)/m/n/16.06 论
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 模
+....\TU/FandolHei(0)/m/n/16.06 模
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 型
+....\TU/FandolHei(0)/m/n/16.06 型
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -14343,148 +14343,148 @@ Completed box being shipped out [7]
 ...\glue(\baselineskip) 7.86139
 ...\hbox(9.371+2.32468)x426.79135, glue set - 0.0365
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 如
+....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 章
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 过
+....\TU/FandolSong(0)/m/n/12.045 过
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 长
+....\TU/FandolSong(0)/m/n/12.045 长
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 需
+....\TU/FandolSong(0)/m/n/12.045 需
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 要
+....\TU/FandolSong(0)/m/n/12.045 要
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 分
+....\TU/FandolSong(0)/m/n/12.045 分
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 书
+....\TU/FandolSong(0)/m/n/12.045 书
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 话
+....\TU/FandolSong(0)/m/n/12.045 话
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 空
+....\TU/FandolSong(0)/m/n/12.045 空
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 24
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 磅
+....\TU/FandolSong(0)/m/n/12.045 磅
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 空
+....\TU/FandolSong(0)/m/n/12.045 空
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 0
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 磅
+....\TU/FandolSong(0)/m/n/12.045 磅
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x426.79135, glue set 103.31088fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 车
+....\TU/FandolSong(0)/m/n/12.045 车
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 第
+....\TU/FandolSong(0)/m/n/12.045 第
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 二
+....\TU/FandolSong(0)/m/n/12.045 二
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 前
+....\TU/FandolSong(0)/m/n/12.045 前
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 空
+....\TU/FandolSong(0)/m/n/12.045 空
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 0
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 磅
+....\TU/FandolSong(0)/m/n/12.045 磅
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 后
+....\TU/FandolSong(0)/m/n/12.045 后
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 空
+....\TU/FandolSong(0)/m/n/12.045 空
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 24
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 磅
+....\TU/FandolSong(0)/m/n/12.045 磅
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 见
+....\TU/FandolSong(0)/m/n/12.045 见
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 上
+....\TU/FandolSong(0)/m/n/12.045 上
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 面
+....\TU/FandolSong(0)/m/n/12.045 面
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 例
+....\TU/FandolSong(0)/m/n/12.045 例
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 子
+....\TU/FandolSong(0)/m/n/12.045 子
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047

--- a/testfiles/08-bib/08-bib-author-year.tlg
+++ b/testfiles/08-bib/08-bib-author-year.tlg
@@ -57,13 +57,13 @@ Completed box being shipped out [1]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -112,13 +112,13 @@ C.}
 ...\glue(\baselineskip) 3.4529
 ...\hbox(12.6071+3.01927)x426.79135, glue set 181.27568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 参
+....\TU/FandolHei(0)/m/n/16.06 参
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 考
+....\TU/FandolHei(0)/m/n/16.06 考
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 文
+....\TU/FandolHei(0)/m/n/16.06 文
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 献
+....\TU/FandolHei(0)/m/n/16.06 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -144,11 +144,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 白
+....\TU/FandolSong(0)/m/n/10.53937 白
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 农
+....\TU/FandolSong(0)/m/n/10.53937 农
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -158,68 +158,68 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 植
+....\TU/FandolSong(0)/m/n/10.53937 植
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 开
+....\TU/FandolSong(0)/m/n/10.53937 开
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 花
+....\TU/FandolSong(0)/m/n/10.53937 花
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 //
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 承
+....\TU/FandolSong(0)/m/n/10.53937 承
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 森
+....\TU/FandolSong(0)/m/n/10.53937 森
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 植
+....\TU/FandolSong(0)/m/n/10.53937 植
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 进
+....\TU/FandolSong(0)/m/n/10.53937 进
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 展
+....\TU/FandolSong(0)/m/n/10.53937 展
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 高
+....\TU/FandolSong(0)/m/n/10.53937 高
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -247,25 +247,25 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 傅
+....\TU/FandolSong(0)/m/n/10.53937 傅
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刚
+....\TU/FandolSong(0)/m/n/10.53937 刚
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 承
+....\TU/FandolSong(0)/m/n/10.53937 承
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 佳
+....\TU/FandolSong(0)/m/n/10.53937 佳
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 路
+....\TU/FandolSong(0)/m/n/10.53937 路
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -275,36 +275,36 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 风
+....\TU/FandolSong(0)/m/n/10.53937 风
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 沙
+....\TU/FandolSong(0)/m/n/10.53937 沙
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 过
+....\TU/FandolSong(0)/m/n/10.53937 过
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 后
+....\TU/FandolSong(0)/m/n/10.53937 后
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 思
+....\TU/FandolSong(0)/m/n/10.53937 思
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [N/OL].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 青
+....\TU/FandolSong(0)/m/n/10.53937 青
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -497,25 +497,25 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 广
+....\TU/FandolSong(0)/m/n/10.53937 广
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 西
+....\TU/FandolSong(0)/m/n/10.53937 西
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 壮
+....\TU/FandolSong(0)/m/n/10.53937 壮
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 族
+....\TU/FandolSong(0)/m/n/10.53937 族
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 治
+....\TU/FandolSong(0)/m/n/10.53937 治
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 区
+....\TU/FandolSong(0)/m/n/10.53937 区
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 林
+....\TU/FandolSong(0)/m/n/10.53937 林
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 厅
+....\TU/FandolSong(0)/m/n/10.53937 厅
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -525,44 +525,44 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 广
+....\TU/FandolSong(0)/m/n/10.53937 广
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 西
+....\TU/FandolSong(0)/m/n/10.53937 西
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 然
+....\TU/FandolSong(0)/m/n/10.53937 然
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 保
+....\TU/FandolSong(0)/m/n/10.53937 保
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 护
+....\TU/FandolSong(0)/m/n/10.53937 护
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 区
+....\TU/FandolSong(0)/m/n/10.53937 区
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 林
+....\TU/FandolSong(0)/m/n/10.53937 林
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -586,11 +586,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 韩
+....\TU/FandolSong(0)/m/n/10.53937 韩
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 吉
+....\TU/FandolSong(0)/m/n/10.53937 吉
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -600,93 +600,93 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 特
+....\TU/FandolSong(0)/m/n/10.53937 特
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 点
+....\TU/FandolSong(0)/m/n/10.53937 点
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 //
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 集
+....\TU/FandolSong(0)/m/n/10.53937 集
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.77559
 ...\hbox(8.11531+1.78114)x402.70135, glue set 326.87762fil, shifted 24.09
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -714,11 +714,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 霍
+....\TU/FandolSong(0)/m/n/10.53937 霍
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 斯
+....\TU/FandolSong(0)/m/n/10.53937 斯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 尼
+....\TU/FandolSong(0)/m/n/10.53937 尼
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -728,40 +728,40 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 谷
+....\TU/FandolSong(0)/m/n/10.53937 谷
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 艺
+....\TU/FandolSong(0)/m/n/10.53937 艺
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 原
+....\TU/FandolSong(0)/m/n/10.53937 原
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 庆
+....\TU/FandolSong(0)/m/n/10.53937 庆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 龙
+....\TU/FandolSong(0)/m/n/10.53937 龙
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 译
+....\TU/FandolSong(0)/m/n/10.53937 译
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -770,32 +770,32 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 食
+....\TU/FandolSong(0)/m/n/10.53937 食
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 品
+....\TU/FandolSong(0)/m/n/10.53937 品
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -823,11 +823,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 姜
+....\TU/FandolSong(0)/m/n/10.53937 姜
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 锡
+....\TU/FandolSong(0)/m/n/10.53937 锡
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洲
+....\TU/FandolSong(0)/m/n/10.53937 洲
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -837,34 +837,34 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 一
+....\TU/FandolSong(0)/m/n/10.53937 一
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 种
+....\TU/FandolSong(0)/m/n/10.53937 种
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 温
+....\TU/FandolSong(0)/m/n/10.53937 温
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 热
+....\TU/FandolSong(0)/m/n/10.53937 热
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 外
+....\TU/FandolSong(0)/m/n/10.53937 外
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 敷
+....\TU/FandolSong(0)/m/n/10.53937 敷
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 药
+....\TU/FandolSong(0)/m/n/10.53937 药
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 制
+....\TU/FandolSong(0)/m/n/10.53937 制
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 备
+....\TU/FandolSong(0)/m/n/10.53937 备
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 案
+....\TU/FandolSong(0)/m/n/10.53937 案
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -901,30 +901,30 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 马
+....\TU/FandolSong(0)/m/n/10.53937 马
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辉
+....\TU/FandolSong(0)/m/n/10.53937 辉
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 俭
+....\TU/FandolSong(0)/m/n/10.53937 俭
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刘
+....\TU/FandolSong(0)/m/n/10.53937 刘
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 耀
+....\TU/FandolSong(0)/m/n/10.53937 耀
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 明
+....\TU/FandolSong(0)/m/n/10.53937 明
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -934,57 +934,57 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 利
+....\TU/FandolSong(0)/m/n/10.53937 利
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 用
+....\TU/FandolSong(0)/m/n/10.53937 用
 ....\glue 2.63484 plus 1.31609 minus 0.87915
 ....\TU/texgyretermes(0)/m/n/10.53937 REMPI
 ....\kern -0.0002
 ....\kern 0.0002
 ....\glue 2.63484 plus 1.31609 minus 0.87915
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 法
+....\TU/FandolSong(0)/m/n/10.53937 法
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 测
+....\TU/FandolSong(0)/m/n/10.53937 测
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 量
+....\TU/FandolSong(0)/m/n/10.53937 量
 ....\glue 2.63484 plus 1.31609 minus 0.87915
 ....\TU/texgyretermes(0)/m/n/10.53937 BaF
 ....\kern -0.0002
 ....\kern 0.0002
 ....\glue 2.63484 plus 1.31609 minus 0.87915
-....\TU/FandolSong-Regular(0)/m/n/10.53937 高
+....\TU/FandolSong(0)/m/n/10.53937 高
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 里
+....\TU/FandolSong(0)/m/n/10.53937 里
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 德
+....\TU/FandolSong(0)/m/n/10.53937 德
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 堡
+....\TU/FandolSong(0)/m/n/10.53937 堡
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 列
+....\TU/FandolSong(0)/m/n/10.53937 列
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 光
+....\TU/FandolSong(0)/m/n/10.53937 光
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 谱
+....\TU/FandolSong(0)/m/n/10.53937 谱
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1020,35 +1020,35 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 资
+....\TU/FandolSong(0)/m/n/10.53937 资
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 试
+....\TU/FandolSong(0)/m/n/10.53937 试
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 办
+....\TU/FandolSong(0)/m/n/10.53937 办
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 公
+....\TU/FandolSong(0)/m/n/10.53937 公
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 室
+....\TU/FandolSong(0)/m/n/10.53937 室
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1058,67 +1058,67 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 资
+....\TU/FandolSong(0)/m/n/10.53937 资
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 试
+....\TU/FandolSong(0)/m/n/10.53937 试
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辅
+....\TU/FandolSong(0)/m/n/10.53937 辅
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 导
+....\TU/FandolSong(0)/m/n/10.53937 导
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 材
+....\TU/FandolSong(0)/m/n/10.53937 材
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.67018
 ...\hbox(8.21017+1.89706)x402.70135, glue set 137.8927fil, shifted 24.09
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 实
+....\TU/FandolSong(0)/m/n/10.53937 实
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 务
+....\TU/FandolSong(0)/m/n/10.53937 务
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 •
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 级
+....\TU/FandolSong(0)/m/n/10.53937 级
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1128,32 +1128,32 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 上
+....\TU/FandolSong(0)/m/n/10.53937 上
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 上
+....\TU/FandolSong(0)/m/n/10.53937 上
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辞
+....\TU/FandolSong(0)/m/n/10.53937 辞
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1181,57 +1181,57 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 献
+....\TU/FandolSong(0)/m/n/10.53937 献
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 作
+....\TU/FandolSong(0)/m/n/10.53937 作
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 委
+....\TU/FandolSong(0)/m/n/10.53937 委
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 员
+....\TU/FandolSong(0)/m/n/10.53937 员
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 式
+....\TU/FandolSong(0)/m/n/10.53937 式
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 分
+....\TU/FandolSong(0)/m/n/10.53937 分
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 委
+....\TU/FandolSong(0)/m/n/10.53937 委
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 员
+....\TU/FandolSong(0)/m/n/10.53937 员
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1249,43 +1249,43 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.7545
 ...\hbox(8.19963+1.86545)x402.70135, glue set 271.26138fil, shifted 24.09
-....\TU/FandolSong-Regular(0)/m/n/10.53937 名
+....\TU/FandolSong(0)/m/n/10.53937 名
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 页
+....\TU/FandolSong(0)/m/n/10.53937 页
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1309,11 +1309,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 王
+....\TU/FandolSong(0)/m/n/10.53937 王
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 夫
+....\TU/FandolSong(0)/m/n/10.53937 夫
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 之
+....\TU/FandolSong(0)/m/n/10.53937 之
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1321,17 +1321,17 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 1865
 ....\glue 6.68196 minus 5.26968
 ....\rule(0.0+0.0)x-6.68196
-....\TU/FandolSong-Regular(0)/m/n/10.53937 （清
+....\TU/FandolSong(0)/m/n/10.53937 （清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 同
+....\TU/FandolSong(0)/m/n/10.53937 同
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 治
+....\TU/FandolSong(0)/m/n/10.53937 治
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 四
+....\TU/FandolSong(0)/m/n/10.53937 四
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/10.53937 ）
+....\TU/FandolSong(0)/m/n/10.53937 ）
 ....\rule(0.0+0.0)x-6.68196
 ....\glue 6.68196 minus 5.26968
 ....\TU/texgyretermes(0)/m/n/10.53937 .
@@ -1339,32 +1339,32 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 宋
+....\TU/FandolSong(0)/m/n/10.53937 宋
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刻
+....\TU/FandolSong(0)/m/n/10.53937 刻
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 本
+....\TU/FandolSong(0)/m/n/10.53937 本
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 金
+....\TU/FandolSong(0)/m/n/10.53937 金
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 陵
+....\TU/FandolSong(0)/m/n/10.53937 陵
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 曾
+....\TU/FandolSong(0)/m/n/10.53937 曾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 氏
+....\TU/FandolSong(0)/m/n/10.53937 氏
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1388,9 +1388,9 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 萧
+....\TU/FandolSong(0)/m/n/10.53937 萧
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 钰
+....\TU/FandolSong(0)/m/n/10.53937 钰
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1400,27 +1400,27 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 迈
+....\TU/FandolSong(0)/m/n/10.53937 迈
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 入
+....\TU/FandolSong(0)/m/n/10.53937 入
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 快
+....\TU/FandolSong(0)/m/n/10.53937 快
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 车
+....\TU/FandolSong(0)/m/n/10.53937 车
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 道
+....\TU/FandolSong(0)/m/n/10.53937 道
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [EB/OL].
 ....\kern -0.00021
@@ -1593,32 +1593,32 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 昆
+....\TU/FandolSong(0)/m/n/10.53937 昆
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 冯
+....\TU/FandolSong(0)/m/n/10.53937 冯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 立
+....\TU/FandolSong(0)/m/n/10.53937 立
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 群
+....\TU/FandolSong(0)/m/n/10.53937 群
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 余
+....\TU/FandolSong(0)/m/n/10.53937 余
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 昌
+....\TU/FandolSong(0)/m/n/10.53937 昌
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 钰
+....\TU/FandolSong(0)/m/n/10.53937 钰
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1628,69 +1628,69 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 机
+....\TU/FandolSong(0)/m/n/10.53937 机
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 器
+....\TU/FandolSong(0)/m/n/10.53937 器
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 柔
+....\TU/FandolSong(0)/m/n/10.53937 柔
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 性
+....\TU/FandolSong(0)/m/n/10.53937 性
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 手
+....\TU/FandolSong(0)/m/n/10.53937 手
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 腕
+....\TU/FandolSong(0)/m/n/10.53937 腕
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 球
+....\TU/FandolSong(0)/m/n/10.53937 球
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 面
+....\TU/FandolSong(0)/m/n/10.53937 面
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 齿
+....\TU/FandolSong(0)/m/n/10.53937 齿
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 轮
+....\TU/FandolSong(0)/m/n/10.53937 轮
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 设
+....\TU/FandolSong(0)/m/n/10.53937 设
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 计
+....\TU/FandolSong(0)/m/n/10.53937 计
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 清
+....\TU/FandolSong(0)/m/n/10.53937 清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 然
+....\TU/FandolSong(0)/m/n/10.53937 然
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.7229
 ...\hbox(8.11531+1.86545)x402.70135, glue set 333.9109fil, shifted 24.09
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1726,11 +1726,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 耀
+....\TU/FandolSong(0)/m/n/10.53937 耀
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 东
+....\TU/FandolSong(0)/m/n/10.53937 东
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1740,49 +1740,49 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 新
+....\TU/FandolSong(0)/m/n/10.53937 新
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 时
+....\TU/FandolSong(0)/m/n/10.53937 时
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 代
+....\TU/FandolSong(0)/m/n/10.53937 代
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 程
+....\TU/FandolSong(0)/m/n/10.53937 程
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 师
+....\TU/FandolSong(0)/m/n/10.53937 师
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [M/OL].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 台
+....\TU/FandolSong(0)/m/n/10.53937 台
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 天
+....\TU/FandolSong(0)/m/n/10.53937 天
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 下
+....\TU/FandolSong(0)/m/n/10.53937 下
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -1922,11 +1922,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 郑
+....\TU/FandolSong(0)/m/n/10.53937 郑
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 开
+....\TU/FandolSong(0)/m/n/10.53937 开
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 青
+....\TU/FandolSong(0)/m/n/10.53937 青
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1936,63 +1936,63 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 通
+....\TU/FandolSong(0)/m/n/10.53937 通
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讯
+....\TU/FandolSong(0)/m/n/10.53937 讯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 统
+....\TU/FandolSong(0)/m/n/10.53937 统
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 模
+....\TU/FandolSong(0)/m/n/10.53937 模
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 拟
+....\TU/FandolSong(0)/m/n/10.53937 拟
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 及
+....\TU/FandolSong(0)/m/n/10.53937 及
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 软
+....\TU/FandolSong(0)/m/n/10.53937 软
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 件
+....\TU/FandolSong(0)/m/n/10.53937 件
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [
-....\TU/FandolSong-Regular(0)/m/n/10.53937 硕
+....\TU/FandolSong(0)/m/n/10.53937 硕
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 士
+....\TU/FandolSong(0)/m/n/10.53937 士
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 位
+....\TU/FandolSong(0)/m/n/10.53937 位
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\TU/texgyretermes(0)/m/n/10.53937 ].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 清
+....\TU/FandolSong(0)/m/n/10.53937 清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 无
+....\TU/FandolSong(0)/m/n/10.53937 无
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 线
+....\TU/FandolSong(0)/m/n/10.53937 线
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 电
+....\TU/FandolSong(0)/m/n/10.53937 电
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2016,17 +2016,17 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 址
+....\TU/FandolSong(0)/m/n/10.53937 址
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2036,13 +2036,13 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 质
+....\TU/FandolSong(0)/m/n/10.53937 质
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 评
+....\TU/FandolSong(0)/m/n/10.53937 评
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2061,22 +2061,22 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 质
+....\TU/FandolSong(0)/m/n/10.53937 质
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2100,19 +2100,19 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2122,17 +2122,17 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 通
+....\TU/FandolSong(0)/m/n/10.53937 通
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讯
+....\TU/FandolSong(0)/m/n/10.53937 讯
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2151,22 +2151,22 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2190,33 +2190,33 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 共
+....\TU/FandolSong(0)/m/n/10.53937 共
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 和
+....\TU/FandolSong(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 家
+....\TU/FandolSong(0)/m/n/10.53937 家
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 监
+....\TU/FandolSong(0)/m/n/10.53937 监
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 督
+....\TU/FandolSong(0)/m/n/10.53937 督
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 局
+....\TU/FandolSong(0)/m/n/10.53937 局
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2230,64 +2230,64 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 共
+....\TU/FandolSong(0)/m/n/10.53937 共
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 和
+....\TU/FandolSong(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 家
+....\TU/FandolSong(0)/m/n/10.53937 家
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\TU/texgyretermes(0)/m/n/10.53937 -
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/10.53937 量
+....\TU/FandolSong(0)/m/n/10.53937 量
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 单
+....\TU/FandolSong(0)/m/n/10.53937 单
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 位
+....\TU/FandolSong(0)/m/n/10.53937 位
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.68073
 ...\hbox(8.19963+1.86545)x402.70135, glue set 309.3085fil, shifted 24.09
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2311,11 +2311,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 竺
+....\TU/FandolSong(0)/m/n/10.53937 竺
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 可
+....\TU/FandolSong(0)/m/n/10.53937 可
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 桢
+....\TU/FandolSong(0)/m/n/10.53937 桢
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2325,34 +2325,34 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2956,13 +2956,13 @@ Completed box being shipped out [2]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0

--- a/testfiles/08-bib/08-bib-bachelor.tlg
+++ b/testfiles/08-bib/08-bib-bachelor.tlg
@@ -57,13 +57,13 @@ Completed box being shipped out [1]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -112,13 +112,13 @@ C.}
 ...\glue(\baselineskip) 3.4529
 ...\hbox(12.6071+3.01927)x426.79135, glue set 181.27568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 参
+....\TU/FandolHei(0)/m/n/16.06 参
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 考
+....\TU/FandolHei(0)/m/n/16.06 考
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 文
+....\TU/FandolHei(0)/m/n/16.06 文
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 献
+....\TU/FandolHei(0)/m/n/16.06 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -147,34 +147,34 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 陈
+....\TU/FandolSong(0)/m/n/10.53937 陈
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 登
+....\TU/FandolSong(0)/m/n/10.53937 登
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 原
+....\TU/FandolSong(0)/m/n/10.53937 原
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 史
+....\TU/FandolSong(0)/m/n/10.53937 史
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 旧
+....\TU/FandolSong(0)/m/n/10.53937 旧
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 闻
+....\TU/FandolSong(0)/m/n/10.53937 闻
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 第
+....\TU/FandolSong(0)/m/n/10.53937 第
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 1
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 卷
+....\TU/FandolSong(0)/m/n/10.53937 卷
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -183,20 +183,20 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 局
+....\TU/FandolSong(0)/m/n/10.53937 局
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -231,48 +231,48 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 哈
+....\TU/FandolSong(0)/m/n/10.53937 哈
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 里
+....\TU/FandolSong(0)/m/n/10.53937 里
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 森
+....\TU/FandolSong(0)/m/n/10.53937 森
 ....\penalty 10000
 ....\glue 0.0 plus 0.41463
 ....\glue 4.72163 minus 2.36081
 ....\rule(0.0+0.0)x-4.72163
-....\TU/FandolSong-Regular(0)/m/n/10.53937 ^^b7
+....\TU/FandolSong(0)/m/n/10.53937 ^^b7
 ....\rule(0.0+0.0)x-4.72163
 ....\glue 4.72163 minus 2.36081
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 沃
+....\TU/FandolSong(0)/m/n/10.53937 沃
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 尔
+....\TU/FandolSong(0)/m/n/10.53937 尔
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 德
+....\TU/FandolSong(0)/m/n/10.53937 德
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 伦
+....\TU/FandolSong(0)/m/n/10.53937 伦
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 经
+....\TU/FandolSong(0)/m/n/10.53937 经
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 济
+....\TU/FandolSong(0)/m/n/10.53937 济
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 数
+....\TU/FandolSong(0)/m/n/10.53937 数
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 金
+....\TU/FandolSong(0)/m/n/10.53937 金
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 融
+....\TU/FandolSong(0)/m/n/10.53937 融
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 数
+....\TU/FandolSong(0)/m/n/10.53937 数
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -281,45 +281,45 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 谢
+....\TU/FandolSong(0)/m/n/10.53937 谢
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 远
+....\TU/FandolSong(0)/m/n/10.53937 远
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 涛
+....\TU/FandolSong(0)/m/n/10.53937 涛
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 译
+....\TU/FandolSong(0)/m/n/10.53937 译
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.0
@@ -450,11 +450,11 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 程
+....\TU/FandolSong(0)/m/n/10.53937 程
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 根
+....\TU/FandolSong(0)/m/n/10.53937 根
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 伟
+....\TU/FandolSong(0)/m/n/10.53937 伟
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -464,31 +464,31 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 长
+....\TU/FandolSong(0)/m/n/10.53937 长
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 江
+....\TU/FandolSong(0)/m/n/10.53937 江
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洪
+....\TU/FandolSong(0)/m/n/10.53937 洪
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 水
+....\TU/FandolSong(0)/m/n/10.53937 水
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 成
+....\TU/FandolSong(0)/m/n/10.53937 成
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 因
+....\TU/FandolSong(0)/m/n/10.53937 因
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 减
+....\TU/FandolSong(0)/m/n/10.53937 减
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 灾
+....\TU/FandolSong(0)/m/n/10.53937 灾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 对
+....\TU/FandolSong(0)/m/n/10.53937 对
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 策
+....\TU/FandolSong(0)/m/n/10.53937 策
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -496,74 +496,74 @@ C.}
 ....\kern -0.00024
 ....\kern 0.00024
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 许
+....\TU/FandolSong(0)/m/n/10.53937 许
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 厚
+....\TU/FandolSong(0)/m/n/10.53937 厚
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 泽
+....\TU/FandolSong(0)/m/n/10.53937 泽
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 其
+....\TU/FandolSong(0)/m/n/10.53937 其
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 长
+....\TU/FandolSong(0)/m/n/10.53937 长
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 江
+....\TU/FandolSong(0)/m/n/10.53937 江
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 流
+....\TU/FandolSong(0)/m/n/10.53937 流
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 域
+....\TU/FandolSong(0)/m/n/10.53937 域
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洪
+....\TU/FandolSong(0)/m/n/10.53937 洪
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 涝
+....\TU/FandolSong(0)/m/n/10.53937 涝
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 灾
+....\TU/FandolSong(0)/m/n/10.53937 灾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 害
+....\TU/FandolSong(0)/m/n/10.53937 害
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.6702
 ...\hbox(8.17854+1.86545)x404.41484, glue set 226.1344fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 对
+....\TU/FandolSong(0)/m/n/10.53937 对
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 策
+....\TU/FandolSong(0)/m/n/10.53937 策
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -747,39 +747,39 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 医
+....\TU/FandolSong(0)/m/n/10.53937 医
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 湖
+....\TU/FandolSong(0)/m/n/10.53937 湖
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 分
+....\TU/FandolSong(0)/m/n/10.53937 分
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 临
+....\TU/FandolSong(0)/m/n/10.53937 临
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 床
+....\TU/FandolSong(0)/m/n/10.53937 床
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 内
+....\TU/FandolSong(0)/m/n/10.53937 内
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 杂
+....\TU/FandolSong(0)/m/n/10.53937 杂
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 志
+....\TU/FandolSong(0)/m/n/10.53937 志
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -801,30 +801,30 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 武
+....\TU/FandolSong(0)/m/n/10.53937 武
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 汉
+....\TU/FandolSong(0)/m/n/10.53937 汉
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 医
+....\TU/FandolSong(0)/m/n/10.53937 医
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 湖
+....\TU/FandolSong(0)/m/n/10.53937 湖
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 分
+....\TU/FandolSong(0)/m/n/10.53937 分
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -974,89 +974,89 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 袁
+....\TU/FandolSong(0)/m/n/10.53937 袁
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 训
+....\TU/FandolSong(0)/m/n/10.53937 训
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 来
+....\TU/FandolSong(0)/m/n/10.53937 来
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 陈
+....\TU/FandolSong(0)/m/n/10.53937 陈
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 哲
+....\TU/FandolSong(0)/m/n/10.53937 哲
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 肖
+....\TU/FandolSong(0)/m/n/10.53937 肖
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 蓝
+....\TU/FandolSong(0)/m/n/10.53937 蓝
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 田
+....\TU/FandolSong(0)/m/n/10.53937 田
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 生
+....\TU/FandolSong(0)/m/n/10.53937 生
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 群
+....\TU/FandolSong(0)/m/n/10.53937 群
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 一
+....\TU/FandolSong(0)/m/n/10.53937 一
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 个
+....\TU/FandolSong(0)/m/n/10.53937 个
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 认
+....\TU/FandolSong(0)/m/n/10.53937 认
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 识
+....\TU/FandolSong(0)/m/n/10.53937 识
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 多
+....\TU/FandolSong(0)/m/n/10.53937 多
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 细
+....\TU/FandolSong(0)/m/n/10.53937 细
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 胞
+....\TU/FandolSong(0)/m/n/10.53937 胞
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 生
+....\TU/FandolSong(0)/m/n/10.53937 生
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 起
+....\TU/FandolSong(0)/m/n/10.53937 起
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 源
+....\TU/FandolSong(0)/m/n/10.53937 源
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 和
+....\TU/FandolSong(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 早
+....\TU/FandolSong(0)/m/n/10.53937 早
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 期
+....\TU/FandolSong(0)/m/n/10.53937 期
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 演
+....\TU/FandolSong(0)/m/n/10.53937 演
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 新
+....\TU/FandolSong(0)/m/n/10.53937 新
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 窗
+....\TU/FandolSong(0)/m/n/10.53937 窗
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 口
+....\TU/FandolSong(0)/m/n/10.53937 口
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -1067,13 +1067,13 @@ C.}
 ...\penalty 4150
 ...\glue(\baselineskip) 5.85991
 ...\hbox(8.05208+1.86545)x404.41484, glue set 275.8978fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 通
+....\TU/FandolSong(0)/m/n/10.53937 通
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1185,34 +1185,34 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 武
+....\TU/FandolSong(0)/m/n/10.53937 武
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 丽
+....\TU/FandolSong(0)/m/n/10.53937 丽
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 丽
+....\TU/FandolSong(0)/m/n/10.53937 丽
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 一
+....\TU/FandolSong(0)/m/n/10.53937 一
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 新
+....\TU/FandolSong(0)/m/n/10.53937 新
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 亚
+....\TU/FandolSong(0)/m/n/10.53937 亚
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 军
+....\TU/FandolSong(0)/m/n/10.53937 军
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1220,37 +1220,37 @@ C.}
 ....\glue 1.15933 plus 3.478 minus 0.73782
 ....\glue 6.16553 minus 5.26968
 ....\rule(0.0+0.0)x-6.16553
-....\TU/FandolSong-Regular(0)/m/n/10.53937 “北
+....\TU/FandolSong(0)/m/n/10.53937 “北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 斗
+....\TU/FandolSong(0)/m/n/10.53937 斗
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 一
+....\TU/FandolSong(0)/m/n/10.53937 一
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 号
+....\TU/FandolSong(0)/m/n/10.53937 号
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/10.53937 ”
+....\TU/FandolSong(0)/m/n/10.53937 ”
 ....\rule(0.0+0.0)x-6.16553
 ....\glue 6.16553 minus 5.26968
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 监
+....\TU/FandolSong(0)/m/n/10.53937 监
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 控
+....\TU/FandolSong(0)/m/n/10.53937 控
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 管
+....\TU/FandolSong(0)/m/n/10.53937 管
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 网
+....\TU/FandolSong(0)/m/n/10.53937 网
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 设
+....\TU/FandolSong(0)/m/n/10.53937 设
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 计
+....\TU/FandolSong(0)/m/n/10.53937 计
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 实
+....\TU/FandolSong(0)/m/n/10.53937 实
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 现
+....\TU/FandolSong(0)/m/n/10.53937 现
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -1259,13 +1259,13 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 测
+....\TU/FandolSong(0)/m/n/10.53937 测
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 绘
+....\TU/FandolSong(0)/m/n/10.53937 绘
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1906,27 +1906,27 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 邓
+....\TU/FandolSong(0)/m/n/10.53937 邓
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 一
+....\TU/FandolSong(0)/m/n/10.53937 一
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刚
+....\TU/FandolSong(0)/m/n/10.53937 刚
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 智
+....\TU/FandolSong(0)/m/n/10.53937 智
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 能
+....\TU/FandolSong(0)/m/n/10.53937 能
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 节
+....\TU/FandolSong(0)/m/n/10.53937 节
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 电
+....\TU/FandolSong(0)/m/n/10.53937 电
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 器
+....\TU/FandolSong(0)/m/n/10.53937 器
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2170,59 +2170,59 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 雷
+....\TU/FandolSong(0)/m/n/10.53937 雷
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 光
+....\TU/FandolSong(0)/m/n/10.53937 光
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 春
+....\TU/FandolSong(0)/m/n/10.53937 春
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 综
+....\TU/FandolSong(0)/m/n/10.53937 综
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 合
+....\TU/FandolSong(0)/m/n/10.53937 合
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 湿
+....\TU/FandolSong(0)/m/n/10.53937 湿
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 管
+....\TU/FandolSong(0)/m/n/10.53937 管
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/10.53937 ：
+....\TU/FandolSong(0)/m/n/10.53937 ：
 ....\rule(0.0+0.0)x-7.34593
 ....\glue 7.34593 minus 5.26968
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 综
+....\TU/FandolSong(0)/m/n/10.53937 综
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 合
+....\TU/FandolSong(0)/m/n/10.53937 合
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 湿
+....\TU/FandolSong(0)/m/n/10.53937 湿
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 管
+....\TU/FandolSong(0)/m/n/10.53937 管
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 际
+....\TU/FandolSong(0)/m/n/10.53937 际
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讨
+....\TU/FandolSong(0)/m/n/10.53937 讨
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 集
+....\TU/FandolSong(0)/m/n/10.53937 集
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -2231,22 +2231,22 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洋
+....\TU/FandolSong(0)/m/n/10.53937 洋
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2277,76 +2277,76 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 陈
+....\TU/FandolSong(0)/m/n/10.53937 陈
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 志
+....\TU/FandolSong(0)/m/n/10.53937 志
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 勇
+....\TU/FandolSong(0)/m/n/10.53937 勇
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 财
+....\TU/FandolSong(0)/m/n/10.53937 财
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 税
+....\TU/FandolSong(0)/m/n/10.53937 税
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 价
+....\TU/FandolSong(0)/m/n/10.53937 价
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 值
+....\TU/FandolSong(0)/m/n/10.53937 值
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
 ....\glue 6.16553 minus 5.26968
 ....\rule(0.0+0.0)x-6.16553
-....\TU/FandolSong-Regular(0)/m/n/10.53937 “中
+....\TU/FandolSong(0)/m/n/10.53937 “中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 财
+....\TU/FandolSong(0)/m/n/10.53937 财
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 税
+....\TU/FandolSong(0)/m/n/10.53937 税
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 际
+....\TU/FandolSong(0)/m/n/10.53937 际
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讨
+....\TU/FandolSong(0)/m/n/10.53937 讨
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/10.53937 ”
+....\TU/FandolSong(0)/m/n/10.53937 ”
 ....\rule(0.0+0.0)x-6.16553
 ....\glue 6.16553 minus 5.26968
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 集
+....\TU/FandolSong(0)/m/n/10.53937 集
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -2355,9 +2355,9 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.0
@@ -2365,19 +2365,19 @@ C.}
 ...\penalty 150
 ...\glue(\baselineskip) 5.58588
 ...\hbox(8.23125+2.28705)x404.41484, glue set 0.6181, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 经
+....\TU/FandolSong(0)/m/n/10.53937 经
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 济
+....\TU/FandolSong(0)/m/n/10.53937 济
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2668,70 +2668,70 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 献
+....\TU/FandolSong(0)/m/n/10.53937 献
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 委
+....\TU/FandolSong(0)/m/n/10.53937 委
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 员
+....\TU/FandolSong(0)/m/n/10.53937 员
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 献
+....\TU/FandolSong(0)/m/n/10.53937 献
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 著
+....\TU/FandolSong(0)/m/n/10.53937 著
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 录
+....\TU/FandolSong(0)/m/n/10.53937 录
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 第
+....\TU/FandolSong(0)/m/n/10.53937 第
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 4
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 部
+....\TU/FandolSong(0)/m/n/10.53937 部
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 分
+....\TU/FandolSong(0)/m/n/10.53937 分
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 10.53937
-....\TU/FandolSong-Regular(0)/m/n/10.53937 非
+....\TU/FandolSong(0)/m/n/10.53937 非
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 资
+....\TU/FandolSong(0)/m/n/10.53937 资
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 料
+....\TU/FandolSong(0)/m/n/10.53937 料
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2744,7 +2744,7 @@ C.}
 ....\penalty 0
 ....\glue 0.0
 ....\rule(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 —
+....\TU/FandolSong(0)/m/n/10.53937 —
 ....\rule(0.0+0.0)x0.0
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/10.53937 2009
@@ -2760,26 +2760,26 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2814,49 +2814,49 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 家
+....\TU/FandolSong(0)/m/n/10.53937 家
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 环
+....\TU/FandolSong(0)/m/n/10.53937 环
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 境
+....\TU/FandolSong(0)/m/n/10.53937 境
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 保
+....\TU/FandolSong(0)/m/n/10.53937 保
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 护
+....\TU/FandolSong(0)/m/n/10.53937 护
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 局
+....\TU/FandolSong(0)/m/n/10.53937 局
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 司
+....\TU/FandolSong(0)/m/n/10.53937 司
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 土
+....\TU/FandolSong(0)/m/n/10.53937 土
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 壤
+....\TU/FandolSong(0)/m/n/10.53937 壤
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 环
+....\TU/FandolSong(0)/m/n/10.53937 环
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 境
+....\TU/FandolSong(0)/m/n/10.53937 境
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 质
+....\TU/FandolSong(0)/m/n/10.53937 质
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 量
+....\TU/FandolSong(0)/m/n/10.53937 量
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2869,7 +2869,7 @@ C.}
 ....\penalty 0
 ....\glue 0.0
 ....\rule(0.0+0.0)x0.0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 —
+....\TU/FandolSong(0)/m/n/10.53937 —
 ....\rule(0.0+0.0)x0.0
 ....\glue 0.0
 ....\TU/texgyretermes(0)/m/n/10.53937 1995
@@ -2881,29 +2881,29 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.74397
 ...\hbox(8.12585+2.28705)x404.41484, glue set 0.32117, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3090,61 +3090,61 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 志
+....\TU/FandolSong(0)/m/n/10.53937 志
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 祥
+....\TU/FandolSong(0)/m/n/10.53937 祥
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 间
+....\TU/FandolSong(0)/m/n/10.53937 间
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 断
+....\TU/FandolSong(0)/m/n/10.53937 断
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 动
+....\TU/FandolSong(0)/m/n/10.53937 动
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 力
+....\TU/FandolSong(0)/m/n/10.53937 力
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 统
+....\TU/FandolSong(0)/m/n/10.53937 统
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 随
+....\TU/FandolSong(0)/m/n/10.53937 随
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 机
+....\TU/FandolSong(0)/m/n/10.53937 机
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 扰
+....\TU/FandolSong(0)/m/n/10.53937 扰
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 动
+....\TU/FandolSong(0)/m/n/10.53937 动
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 及
+....\TU/FandolSong(0)/m/n/10.53937 及
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 其
+....\TU/FandolSong(0)/m/n/10.53937 其
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 在
+....\TU/FandolSong(0)/m/n/10.53937 在
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 守
+....\TU/FandolSong(0)/m/n/10.53937 守
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 恒
+....\TU/FandolSong(0)/m/n/10.53937 恒
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 律
+....\TU/FandolSong(0)/m/n/10.53937 律
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 程
+....\TU/FandolSong(0)/m/n/10.53937 程
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 应
+....\TU/FandolSong(0)/m/n/10.53937 应
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 用
+....\TU/FandolSong(0)/m/n/10.53937 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -3153,31 +3153,31 @@ C.}
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 数
+....\TU/FandolSong(0)/m/n/10.53937 数
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.59642
 ...\hbox(8.17854+1.79167)x404.41484, glue set 339.13048fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 院
+....\TU/FandolSong(0)/m/n/10.53937 院
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3258,12 +3258,11 @@ C.}
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\kern 714.29128
 Underfull \hbox (badness 3078) in paragraph at lines 145--150
-[]\TU/FandolSong-Regular(0)/m/n/10.53937 汤 万 金\TU/texgyretermes(0)/m/n/10.53937
- , \TU/FandolSong-Regular(0)/m/n/10.53937 杨 跃 翔\TU/texgyretermes(0)/m/n/10.5393
-7 , \TU/FandolSong-Regular(0)/m/n/10.53937 刘 文\TU/texgyretermes(0)/m/n/10.53937
- , \TU/FandolSong-Regular(0)/m/n/10.53937 等\TU/texgyretermes(0)/m/n/10.53937 . 
- \TU/FandolSong-Regular(0)/m/n/10.53937 人 体 安 全 重 要 技 术 标 准 研 制 最 终 报 告\TU/texg
-yretermes(0)/m/n/10.53937 : 7178999X-
+[]\TU/FandolSong(0)/m/n/10.53937 汤 万 金\TU/texgyretermes(0)/m/n/10.53937 , \TU/F
+andolSong(0)/m/n/10.53937 杨 跃 翔\TU/texgyretermes(0)/m/n/10.53937 , \TU/FandolSo
+ng(0)/m/n/10.53937 刘 文\TU/texgyretermes(0)/m/n/10.53937 , \TU/FandolSong(0)/m/n
+/10.53937 等\TU/texgyretermes(0)/m/n/10.53937 .  \TU/FandolSong(0)/m/n/10.53937 
+人 体 安 全 重 要 技 术 标 准 研 制 最 终 报 告\TU/texgyretermes(0)/m/n/10.53937 : 7178999X-
 \hbox(8.29448+1.94977)x404.41484, glue set 3.13712
 .\hbox(7.12462+1.64412)x0.0
 ..\glue 0.0
@@ -3280,68 +3279,68 @@ yretermes(0)/m/n/10.53937 : 7178999X-
 ...\special{color pop}
 ..\glue 4.81792
 .\penalty 0
-.\TU/FandolSong-Regular(0)/m/n/10.53937 汤
+.\TU/FandolSong(0)/m/n/10.53937 汤
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 万
+.\TU/FandolSong(0)/m/n/10.53937 万
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 金
+.\TU/FandolSong(0)/m/n/10.53937 金
 .\TU/texgyretermes(0)/m/n/10.53937 ,
 .\kern -0.00021
 .\kern 0.00021
 .\glue 2.63484 plus 1.64676 minus 0.70262
-.\TU/FandolSong-Regular(0)/m/n/10.53937 杨
+.\TU/FandolSong(0)/m/n/10.53937 杨
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 跃
+.\TU/FandolSong(0)/m/n/10.53937 跃
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 翔
+.\TU/FandolSong(0)/m/n/10.53937 翔
 .\TU/texgyretermes(0)/m/n/10.53937 ,
 .\kern -0.00021
 .\kern 0.00021
 .\glue 2.63484 plus 1.64676 minus 0.70262
-.\TU/FandolSong-Regular(0)/m/n/10.53937 刘
+.\TU/FandolSong(0)/m/n/10.53937 刘
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 文
+.\TU/FandolSong(0)/m/n/10.53937 文
 .\TU/texgyretermes(0)/m/n/10.53937 ,
 .\kern -0.00021
 .\kern 0.00021
 .\glue 2.63484 plus 1.64676 minus 0.70262
-.\TU/FandolSong-Regular(0)/m/n/10.53937 等
+.\TU/FandolSong(0)/m/n/10.53937 等
 .\TU/texgyretermes(0)/m/n/10.53937 .
 .\kern -0.00021
 .\kern 0.00021
 .\glue 2.63484 plus 1.31741 minus 0.87828
 .\glue 1.15933 plus 3.478 minus 0.73782
-.\TU/FandolSong-Regular(0)/m/n/10.53937 人
+.\TU/FandolSong(0)/m/n/10.53937 人
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 体
+.\TU/FandolSong(0)/m/n/10.53937 体
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 安
+.\TU/FandolSong(0)/m/n/10.53937 安
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 全
+.\TU/FandolSong(0)/m/n/10.53937 全
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 重
+.\TU/FandolSong(0)/m/n/10.53937 重
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 要
+.\TU/FandolSong(0)/m/n/10.53937 要
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 技
+.\TU/FandolSong(0)/m/n/10.53937 技
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 术
+.\TU/FandolSong(0)/m/n/10.53937 术
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 标
+.\TU/FandolSong(0)/m/n/10.53937 标
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 准
+.\TU/FandolSong(0)/m/n/10.53937 准
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 研
+.\TU/FandolSong(0)/m/n/10.53937 研
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 制
+.\TU/FandolSong(0)/m/n/10.53937 制
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 最
+.\TU/FandolSong(0)/m/n/10.53937 最
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 终
+.\TU/FandolSong(0)/m/n/10.53937 终
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 报
+.\TU/FandolSong(0)/m/n/10.53937 报
 .\glue 0.0 plus 0.41463
-.\TU/FandolSong-Regular(0)/m/n/10.53937 告
+.\TU/FandolSong(0)/m/n/10.53937 告
 .\TU/texgyretermes(0)/m/n/10.53937 :
 .\kern -0.00021
 .\kern 0.00021
@@ -3395,13 +3394,13 @@ Completed box being shipped out [2]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -3441,53 +3440,53 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 吴
+....\TU/FandolSong(0)/m/n/10.53937 吴
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 云
+....\TU/FandolSong(0)/m/n/10.53937 云
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 芳
+....\TU/FandolSong(0)/m/n/10.53937 芳
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 面
+....\TU/FandolSong(0)/m/n/10.53937 面
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 向
+....\TU/FandolSong(0)/m/n/10.53937 向
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 处
+....\TU/FandolSong(0)/m/n/10.53937 处
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 现
+....\TU/FandolSong(0)/m/n/10.53937 现
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 代
+....\TU/FandolSong(0)/m/n/10.53937 代
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 汉
+....\TU/FandolSong(0)/m/n/10.53937 汉
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 语
+....\TU/FandolSong(0)/m/n/10.53937 语
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 并
+....\TU/FandolSong(0)/m/n/10.53937 并
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 列
+....\TU/FandolSong(0)/m/n/10.53937 列
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 结
+....\TU/FandolSong(0)/m/n/10.53937 结
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 构
+....\TU/FandolSong(0)/m/n/10.53937 构
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -3496,20 +3495,20 @@ Completed box being shipped out [2]
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3858,68 +3857,68 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 汤
+....\TU/FandolSong(0)/m/n/10.53937 汤
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 万
+....\TU/FandolSong(0)/m/n/10.53937 万
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 金
+....\TU/FandolSong(0)/m/n/10.53937 金
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 杨
+....\TU/FandolSong(0)/m/n/10.53937 杨
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 跃
+....\TU/FandolSong(0)/m/n/10.53937 跃
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 翔
+....\TU/FandolSong(0)/m/n/10.53937 翔
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刘
+....\TU/FandolSong(0)/m/n/10.53937 刘
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 体
+....\TU/FandolSong(0)/m/n/10.53937 体
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 安
+....\TU/FandolSong(0)/m/n/10.53937 安
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 重
+....\TU/FandolSong(0)/m/n/10.53937 重
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 要
+....\TU/FandolSong(0)/m/n/10.53937 要
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 制
+....\TU/FandolSong(0)/m/n/10.53937 制
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 最
+....\TU/FandolSong(0)/m/n/10.53937 最
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 终
+....\TU/FandolSong(0)/m/n/10.53937 终
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 告
+....\TU/FandolSong(0)/m/n/10.53937 告
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
@@ -4191,35 +4190,35 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 丁
+....\TU/FandolSong(0)/m/n/10.53937 丁
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 详
+....\TU/FandolSong(0)/m/n/10.53937 详
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 数
+....\TU/FandolSong(0)/m/n/10.53937 数
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 字
+....\TU/FandolSong(0)/m/n/10.53937 字
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 革
+....\TU/FandolSong(0)/m/n/10.53937 革
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 命
+....\TU/FandolSong(0)/m/n/10.53937 命
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 竞
+....\TU/FandolSong(0)/m/n/10.53937 竞
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 争
+....\TU/FandolSong(0)/m/n/10.53937 争
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 际
+....\TU/FandolSong(0)/m/n/10.53937 际
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -4228,15 +4227,15 @@ Completed box being shipped out [2]
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 青
+....\TU/FandolSong(0)/m/n/10.53937 青
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -4271,53 +4270,53 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刘
+....\TU/FandolSong(0)/m/n/10.53937 刘
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 裕
+....\TU/FandolSong(0)/m/n/10.53937 裕
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 杨
+....\TU/FandolSong(0)/m/n/10.53937 杨
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 柳
+....\TU/FandolSong(0)/m/n/10.53937 柳
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洋
+....\TU/FandolSong(0)/m/n/10.53937 洋
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 雾
+....\TU/FandolSong(0)/m/n/10.53937 雾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 霾
+....\TU/FandolSong(0)/m/n/10.53937 霾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 来
+....\TU/FandolSong(0)/m/n/10.53937 来
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 袭
+....\TU/FandolSong(0)/m/n/10.53937 袭
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 如
+....\TU/FandolSong(0)/m/n/10.53937 如
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 何
+....\TU/FandolSong(0)/m/n/10.53937 何
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 突
+....\TU/FandolSong(0)/m/n/10.53937 突
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 围
+....\TU/FandolSong(0)/m/n/10.53937 围
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0
@@ -4326,13 +4325,13 @@ Completed box being shipped out [2]
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 日
+....\TU/FandolSong(0)/m/n/10.53937 日
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -4581,35 +4580,35 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 强
+....\TU/FandolSong(0)/m/n/10.53937 强
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 解
+....\TU/FandolSong(0)/m/n/10.53937 解
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 医
+....\TU/FandolSong(0)/m/n/10.53937 医
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 患
+....\TU/FandolSong(0)/m/n/10.53937 患
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 矛
+....\TU/FandolSong(0)/m/n/10.53937 矛
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 盾
+....\TU/FandolSong(0)/m/n/10.53937 盾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 需
+....\TU/FandolSong(0)/m/n/10.53937 需
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 釜
+....\TU/FandolSong(0)/m/n/10.53937 釜
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 底
+....\TU/FandolSong(0)/m/n/10.53937 底
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 抽
+....\TU/FandolSong(0)/m/n/10.53937 抽
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 薪
+....\TU/FandolSong(0)/m/n/10.53937 薪
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 0

--- a/testfiles/08-bib/08-bib-inline.tlg
+++ b/testfiles/08-bib/08-bib-inline.tlg
@@ -236,13 +236,13 @@ Completed box being shipped out [2]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -281,13 +281,13 @@ C.}
 ...\glue(\baselineskip) 3.4529
 ...\hbox(12.6071+3.01927)x426.79135, glue set 181.27568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 参
+....\TU/FandolHei(0)/m/n/16.06 参
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 考
+....\TU/FandolHei(0)/m/n/16.06 考
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 文
+....\TU/FandolHei(0)/m/n/16.06 文
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 献
+....\TU/FandolHei(0)/m/n/16.06 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -316,100 +316,100 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 昆
+....\TU/FandolSong(0)/m/n/10.53937 昆
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 冯
+....\TU/FandolSong(0)/m/n/10.53937 冯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 立
+....\TU/FandolSong(0)/m/n/10.53937 立
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 群
+....\TU/FandolSong(0)/m/n/10.53937 群
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 余
+....\TU/FandolSong(0)/m/n/10.53937 余
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 昌
+....\TU/FandolSong(0)/m/n/10.53937 昌
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 钰
+....\TU/FandolSong(0)/m/n/10.53937 钰
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 机
+....\TU/FandolSong(0)/m/n/10.53937 机
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 器
+....\TU/FandolSong(0)/m/n/10.53937 器
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 柔
+....\TU/FandolSong(0)/m/n/10.53937 柔
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 性
+....\TU/FandolSong(0)/m/n/10.53937 性
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 手
+....\TU/FandolSong(0)/m/n/10.53937 手
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 腕
+....\TU/FandolSong(0)/m/n/10.53937 腕
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 球
+....\TU/FandolSong(0)/m/n/10.53937 球
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 面
+....\TU/FandolSong(0)/m/n/10.53937 面
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 齿
+....\TU/FandolSong(0)/m/n/10.53937 齿
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 轮
+....\TU/FandolSong(0)/m/n/10.53937 轮
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 设
+....\TU/FandolSong(0)/m/n/10.53937 设
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 计
+....\TU/FandolSong(0)/m/n/10.53937 计
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 清
+....\TU/FandolSong(0)/m/n/10.53937 清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 然
+....\TU/FandolSong(0)/m/n/10.53937 然
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue(\rightskip) 0.0
 ...\penalty 14000
 ...\glue(\baselineskip) 5.7229
 ...\hbox(8.11531+1.86545)x404.41484, glue set 319.81534fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -452,44 +452,44 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 竺
+....\TU/FandolSong(0)/m/n/10.53937 竺
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 可
+....\TU/FandolSong(0)/m/n/10.53937 可
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 桢
+....\TU/FandolSong(0)/m/n/10.53937 桢
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -732,73 +732,73 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 郑
+....\TU/FandolSong(0)/m/n/10.53937 郑
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 开
+....\TU/FandolSong(0)/m/n/10.53937 开
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 青
+....\TU/FandolSong(0)/m/n/10.53937 青
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 通
+....\TU/FandolSong(0)/m/n/10.53937 通
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讯
+....\TU/FandolSong(0)/m/n/10.53937 讯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 统
+....\TU/FandolSong(0)/m/n/10.53937 统
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 模
+....\TU/FandolSong(0)/m/n/10.53937 模
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 拟
+....\TU/FandolSong(0)/m/n/10.53937 拟
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 及
+....\TU/FandolSong(0)/m/n/10.53937 及
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 软
+....\TU/FandolSong(0)/m/n/10.53937 软
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 件
+....\TU/FandolSong(0)/m/n/10.53937 件
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [
-....\TU/FandolSong-Regular(0)/m/n/10.53937 硕
+....\TU/FandolSong(0)/m/n/10.53937 硕
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 士
+....\TU/FandolSong(0)/m/n/10.53937 士
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 位
+....\TU/FandolSong(0)/m/n/10.53937 位
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\TU/texgyretermes(0)/m/n/10.53937 ].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 清
+....\TU/FandolSong(0)/m/n/10.53937 清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 无
+....\TU/FandolSong(0)/m/n/10.53937 无
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 线
+....\TU/FandolSong(0)/m/n/10.53937 线
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 电
+....\TU/FandolSong(0)/m/n/10.53937 电
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -829,44 +829,44 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 姜
+....\TU/FandolSong(0)/m/n/10.53937 姜
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 锡
+....\TU/FandolSong(0)/m/n/10.53937 锡
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洲
+....\TU/FandolSong(0)/m/n/10.53937 洲
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 一
+....\TU/FandolSong(0)/m/n/10.53937 一
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 种
+....\TU/FandolSong(0)/m/n/10.53937 种
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 温
+....\TU/FandolSong(0)/m/n/10.53937 温
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 热
+....\TU/FandolSong(0)/m/n/10.53937 热
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 外
+....\TU/FandolSong(0)/m/n/10.53937 外
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 敷
+....\TU/FandolSong(0)/m/n/10.53937 敷
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 药
+....\TU/FandolSong(0)/m/n/10.53937 药
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 制
+....\TU/FandolSong(0)/m/n/10.53937 制
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 备
+....\TU/FandolSong(0)/m/n/10.53937 备
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 案
+....\TU/FandolSong(0)/m/n/10.53937 案
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -906,33 +906,33 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 共
+....\TU/FandolSong(0)/m/n/10.53937 共
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 和
+....\TU/FandolSong(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 家
+....\TU/FandolSong(0)/m/n/10.53937 家
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 监
+....\TU/FandolSong(0)/m/n/10.53937 监
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 督
+....\TU/FandolSong(0)/m/n/10.53937 督
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 局
+....\TU/FandolSong(0)/m/n/10.53937 局
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -942,64 +942,64 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 共
+....\TU/FandolSong(0)/m/n/10.53937 共
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 和
+....\TU/FandolSong(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 家
+....\TU/FandolSong(0)/m/n/10.53937 家
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\TU/texgyretermes(0)/m/n/10.53937 -
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/10.53937 量
+....\TU/FandolSong(0)/m/n/10.53937 量
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 单
+....\TU/FandolSong(0)/m/n/10.53937 单
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 位
+....\TU/FandolSong(0)/m/n/10.53937 位
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.68073
 ...\hbox(8.19963+1.86545)x404.41484, glue set 284.67357fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1429,86 +1429,86 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 马
+....\TU/FandolSong(0)/m/n/10.53937 马
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辉
+....\TU/FandolSong(0)/m/n/10.53937 辉
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 俭
+....\TU/FandolSong(0)/m/n/10.53937 俭
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刘
+....\TU/FandolSong(0)/m/n/10.53937 刘
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 耀
+....\TU/FandolSong(0)/m/n/10.53937 耀
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 明
+....\TU/FandolSong(0)/m/n/10.53937 明
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 利
+....\TU/FandolSong(0)/m/n/10.53937 利
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 用
+....\TU/FandolSong(0)/m/n/10.53937 用
 ....\glue 2.63484 plus 1.31609 minus 0.87915
 ....\TU/texgyretermes(0)/m/n/10.53937 REMPI
 ....\kern -0.0002
 ....\kern 0.0002
 ....\glue 2.63484 plus 1.31609 minus 0.87915
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 法
+....\TU/FandolSong(0)/m/n/10.53937 法
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 测
+....\TU/FandolSong(0)/m/n/10.53937 测
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 量
+....\TU/FandolSong(0)/m/n/10.53937 量
 ....\glue 2.63484 plus 1.31609 minus 0.87915
 ....\TU/texgyretermes(0)/m/n/10.53937 BaF
 ....\kern -0.0002
 ....\kern 0.0002
 ....\glue 2.63484 plus 1.31609 minus 0.87915
-....\TU/FandolSong-Regular(0)/m/n/10.53937 高
+....\TU/FandolSong(0)/m/n/10.53937 高
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 里
+....\TU/FandolSong(0)/m/n/10.53937 里
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 德
+....\TU/FandolSong(0)/m/n/10.53937 德
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 堡
+....\TU/FandolSong(0)/m/n/10.53937 堡
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 列
+....\TU/FandolSong(0)/m/n/10.53937 列
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 光
+....\TU/FandolSong(0)/m/n/10.53937 光
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 谱
+....\TU/FandolSong(0)/m/n/10.53937 谱
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.0
@@ -2342,68 +2342,68 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 广
+....\TU/FandolSong(0)/m/n/10.53937 广
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 西
+....\TU/FandolSong(0)/m/n/10.53937 西
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 壮
+....\TU/FandolSong(0)/m/n/10.53937 壮
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 族
+....\TU/FandolSong(0)/m/n/10.53937 族
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 治
+....\TU/FandolSong(0)/m/n/10.53937 治
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 区
+....\TU/FandolSong(0)/m/n/10.53937 区
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 林
+....\TU/FandolSong(0)/m/n/10.53937 林
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 厅
+....\TU/FandolSong(0)/m/n/10.53937 厅
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 广
+....\TU/FandolSong(0)/m/n/10.53937 广
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 西
+....\TU/FandolSong(0)/m/n/10.53937 西
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 然
+....\TU/FandolSong(0)/m/n/10.53937 然
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 保
+....\TU/FandolSong(0)/m/n/10.53937 保
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 护
+....\TU/FandolSong(0)/m/n/10.53937 护
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 区
+....\TU/FandolSong(0)/m/n/10.53937 区
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 林
+....\TU/FandolSong(0)/m/n/10.53937 林
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2434,50 +2434,50 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 霍
+....\TU/FandolSong(0)/m/n/10.53937 霍
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 斯
+....\TU/FandolSong(0)/m/n/10.53937 斯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 尼
+....\TU/FandolSong(0)/m/n/10.53937 尼
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 谷
+....\TU/FandolSong(0)/m/n/10.53937 谷
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 艺
+....\TU/FandolSong(0)/m/n/10.53937 艺
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 原
+....\TU/FandolSong(0)/m/n/10.53937 原
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 庆
+....\TU/FandolSong(0)/m/n/10.53937 庆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 龙
+....\TU/FandolSong(0)/m/n/10.53937 龙
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 译
+....\TU/FandolSong(0)/m/n/10.53937 译
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2486,32 +2486,32 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 食
+....\TU/FandolSong(0)/m/n/10.53937 食
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 品
+....\TU/FandolSong(0)/m/n/10.53937 品
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2546,42 +2546,42 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 王
+....\TU/FandolSong(0)/m/n/10.53937 王
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 夫
+....\TU/FandolSong(0)/m/n/10.53937 夫
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 之
+....\TU/FandolSong(0)/m/n/10.53937 之
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 宋
+....\TU/FandolSong(0)/m/n/10.53937 宋
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刻
+....\TU/FandolSong(0)/m/n/10.53937 刻
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 本
+....\TU/FandolSong(0)/m/n/10.53937 本
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 金
+....\TU/FandolSong(0)/m/n/10.53937 金
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 陵
+....\TU/FandolSong(0)/m/n/10.53937 陵
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 曾
+....\TU/FandolSong(0)/m/n/10.53937 曾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 氏
+....\TU/FandolSong(0)/m/n/10.53937 氏
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2589,17 +2589,17 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 1865
 ....\glue 6.68196 minus 5.26968
 ....\rule(0.0+0.0)x-6.68196
-....\TU/FandolSong-Regular(0)/m/n/10.53937 （清
+....\TU/FandolSong(0)/m/n/10.53937 （清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 同
+....\TU/FandolSong(0)/m/n/10.53937 同
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 治
+....\TU/FandolSong(0)/m/n/10.53937 治
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 四
+....\TU/FandolSong(0)/m/n/10.53937 四
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/10.53937 ）
+....\TU/FandolSong(0)/m/n/10.53937 ）
 ....\rule(0.0+0.0)x-6.68196
 ....\glue 6.68196 minus 5.26968
 ....\TU/texgyretermes(0)/m/n/10.53937 .
@@ -2628,59 +2628,59 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 耀
+....\TU/FandolSong(0)/m/n/10.53937 耀
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 东
+....\TU/FandolSong(0)/m/n/10.53937 东
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 新
+....\TU/FandolSong(0)/m/n/10.53937 新
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 时
+....\TU/FandolSong(0)/m/n/10.53937 时
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 代
+....\TU/FandolSong(0)/m/n/10.53937 代
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 程
+....\TU/FandolSong(0)/m/n/10.53937 程
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 师
+....\TU/FandolSong(0)/m/n/10.53937 师
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [M/OL].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 台
+....\TU/FandolSong(0)/m/n/10.53937 台
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 天
+....\TU/FandolSong(0)/m/n/10.53937 天
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 下
+....\TU/FandolSong(0)/m/n/10.53937 下
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2918,13 +2918,13 @@ Completed box being shipped out [3]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -2965,57 +2965,57 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 献
+....\TU/FandolSong(0)/m/n/10.53937 献
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 作
+....\TU/FandolSong(0)/m/n/10.53937 作
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 委
+....\TU/FandolSong(0)/m/n/10.53937 委
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 员
+....\TU/FandolSong(0)/m/n/10.53937 员
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 式
+....\TU/FandolSong(0)/m/n/10.53937 式
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 分
+....\TU/FandolSong(0)/m/n/10.53937 分
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 委
+....\TU/FandolSong(0)/m/n/10.53937 委
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 员
+....\TU/FandolSong(0)/m/n/10.53937 员
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3029,43 +3029,43 @@ Completed box being shipped out [3]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 名
+....\TU/FandolSong(0)/m/n/10.53937 名
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.7545
 ...\hbox(8.19963+1.86545)x404.41484, glue set 257.16582fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 页
+....\TU/FandolSong(0)/m/n/10.53937 页
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3096,101 +3096,101 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 资
+....\TU/FandolSong(0)/m/n/10.53937 资
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 试
+....\TU/FandolSong(0)/m/n/10.53937 试
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 办
+....\TU/FandolSong(0)/m/n/10.53937 办
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 公
+....\TU/FandolSong(0)/m/n/10.53937 公
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 室
+....\TU/FandolSong(0)/m/n/10.53937 室
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 资
+....\TU/FandolSong(0)/m/n/10.53937 资
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 试
+....\TU/FandolSong(0)/m/n/10.53937 试
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辅
+....\TU/FandolSong(0)/m/n/10.53937 辅
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 导
+....\TU/FandolSong(0)/m/n/10.53937 导
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 材
+....\TU/FandolSong(0)/m/n/10.53937 材
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.67018
 ...\hbox(8.21017+1.89706)x404.41484, glue set 123.79713fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 实
+....\TU/FandolSong(0)/m/n/10.53937 实
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 务
+....\TU/FandolSong(0)/m/n/10.53937 务
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 •
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 级
+....\TU/FandolSong(0)/m/n/10.53937 级
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3200,32 +3200,32 @@ Completed box being shipped out [3]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 上
+....\TU/FandolSong(0)/m/n/10.53937 上
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 上
+....\TU/FandolSong(0)/m/n/10.53937 上
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辞
+....\TU/FandolSong(0)/m/n/10.53937 辞
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3459,78 +3459,78 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 白
+....\TU/FandolSong(0)/m/n/10.53937 白
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 农
+....\TU/FandolSong(0)/m/n/10.53937 农
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 植
+....\TU/FandolSong(0)/m/n/10.53937 植
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 开
+....\TU/FandolSong(0)/m/n/10.53937 开
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 花
+....\TU/FandolSong(0)/m/n/10.53937 花
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 //
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 承
+....\TU/FandolSong(0)/m/n/10.53937 承
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 森
+....\TU/FandolSong(0)/m/n/10.53937 森
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 植
+....\TU/FandolSong(0)/m/n/10.53937 植
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 进
+....\TU/FandolSong(0)/m/n/10.53937 进
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 展
+....\TU/FandolSong(0)/m/n/10.53937 展
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 高
+....\TU/FandolSong(0)/m/n/10.53937 高
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3711,103 +3711,103 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 韩
+....\TU/FandolSong(0)/m/n/10.53937 韩
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 吉
+....\TU/FandolSong(0)/m/n/10.53937 吉
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 特
+....\TU/FandolSong(0)/m/n/10.53937 特
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 点
+....\TU/FandolSong(0)/m/n/10.53937 点
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 //
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 集
+....\TU/FandolSong(0)/m/n/10.53937 集
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.77559
 ...\hbox(8.11531+1.78114)x404.41484, glue set 312.78206fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3842,29 +3842,29 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 址
+....\TU/FandolSong(0)/m/n/10.53937 址
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 质
+....\TU/FandolSong(0)/m/n/10.53937 质
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 评
+....\TU/FandolSong(0)/m/n/10.53937 评
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3883,22 +3883,22 @@ Completed box being shipped out [3]
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 质
+....\TU/FandolSong(0)/m/n/10.53937 质
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3929,35 +3929,35 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 通
+....\TU/FandolSong(0)/m/n/10.53937 通
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讯
+....\TU/FandolSong(0)/m/n/10.53937 讯
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3976,22 +3976,22 @@ Completed box being shipped out [3]
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -4137,60 +4137,60 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 傅
+....\TU/FandolSong(0)/m/n/10.53937 傅
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刚
+....\TU/FandolSong(0)/m/n/10.53937 刚
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 承
+....\TU/FandolSong(0)/m/n/10.53937 承
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 佳
+....\TU/FandolSong(0)/m/n/10.53937 佳
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 路
+....\TU/FandolSong(0)/m/n/10.53937 路
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 风
+....\TU/FandolSong(0)/m/n/10.53937 风
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 沙
+....\TU/FandolSong(0)/m/n/10.53937 沙
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 过
+....\TU/FandolSong(0)/m/n/10.53937 过
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 后
+....\TU/FandolSong(0)/m/n/10.53937 后
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 思
+....\TU/FandolSong(0)/m/n/10.53937 思
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [N/OL].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 青
+....\TU/FandolSong(0)/m/n/10.53937 青
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -4389,35 +4389,35 @@ Completed box being shipped out [3]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 萧
+....\TU/FandolSong(0)/m/n/10.53937 萧
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 钰
+....\TU/FandolSong(0)/m/n/10.53937 钰
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 迈
+....\TU/FandolSong(0)/m/n/10.53937 迈
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 入
+....\TU/FandolSong(0)/m/n/10.53937 入
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 快
+....\TU/FandolSong(0)/m/n/10.53937 快
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 车
+....\TU/FandolSong(0)/m/n/10.53937 车
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 道
+....\TU/FandolSong(0)/m/n/10.53937 道
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [EB/OL].
 ....\kern -0.00021

--- a/testfiles/08-bib/08-bib.tlg
+++ b/testfiles/08-bib/08-bib.tlg
@@ -57,13 +57,13 @@ Completed box being shipped out [1]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -112,13 +112,13 @@ C.}
 ...\glue(\baselineskip) 3.4529
 ...\hbox(12.6071+3.01927)x426.79135, glue set 181.27568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 参
+....\TU/FandolHei(0)/m/n/16.06 参
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 考
+....\TU/FandolHei(0)/m/n/16.06 考
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 文
+....\TU/FandolHei(0)/m/n/16.06 文
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 献
+....\TU/FandolHei(0)/m/n/16.06 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -147,100 +147,100 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 张
+....\TU/FandolSong(0)/m/n/10.53937 张
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 昆
+....\TU/FandolSong(0)/m/n/10.53937 昆
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 冯
+....\TU/FandolSong(0)/m/n/10.53937 冯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 立
+....\TU/FandolSong(0)/m/n/10.53937 立
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 群
+....\TU/FandolSong(0)/m/n/10.53937 群
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 余
+....\TU/FandolSong(0)/m/n/10.53937 余
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 昌
+....\TU/FandolSong(0)/m/n/10.53937 昌
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 钰
+....\TU/FandolSong(0)/m/n/10.53937 钰
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 机
+....\TU/FandolSong(0)/m/n/10.53937 机
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 器
+....\TU/FandolSong(0)/m/n/10.53937 器
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 柔
+....\TU/FandolSong(0)/m/n/10.53937 柔
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 性
+....\TU/FandolSong(0)/m/n/10.53937 性
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 手
+....\TU/FandolSong(0)/m/n/10.53937 手
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 腕
+....\TU/FandolSong(0)/m/n/10.53937 腕
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 球
+....\TU/FandolSong(0)/m/n/10.53937 球
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 面
+....\TU/FandolSong(0)/m/n/10.53937 面
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 齿
+....\TU/FandolSong(0)/m/n/10.53937 齿
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 轮
+....\TU/FandolSong(0)/m/n/10.53937 轮
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 设
+....\TU/FandolSong(0)/m/n/10.53937 设
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 计
+....\TU/FandolSong(0)/m/n/10.53937 计
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 清
+....\TU/FandolSong(0)/m/n/10.53937 清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 然
+....\TU/FandolSong(0)/m/n/10.53937 然
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue(\rightskip) 0.0
 ...\penalty 14000
 ...\glue(\baselineskip) 5.7229
 ...\hbox(8.11531+1.86545)x404.41484, glue set 319.81534fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -283,44 +283,44 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 竺
+....\TU/FandolSong(0)/m/n/10.53937 竺
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 可
+....\TU/FandolSong(0)/m/n/10.53937 可
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 桢
+....\TU/FandolSong(0)/m/n/10.53937 桢
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -563,73 +563,73 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 郑
+....\TU/FandolSong(0)/m/n/10.53937 郑
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 开
+....\TU/FandolSong(0)/m/n/10.53937 开
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 青
+....\TU/FandolSong(0)/m/n/10.53937 青
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 通
+....\TU/FandolSong(0)/m/n/10.53937 通
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讯
+....\TU/FandolSong(0)/m/n/10.53937 讯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 统
+....\TU/FandolSong(0)/m/n/10.53937 统
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 模
+....\TU/FandolSong(0)/m/n/10.53937 模
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 拟
+....\TU/FandolSong(0)/m/n/10.53937 拟
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 及
+....\TU/FandolSong(0)/m/n/10.53937 及
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 软
+....\TU/FandolSong(0)/m/n/10.53937 软
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 件
+....\TU/FandolSong(0)/m/n/10.53937 件
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [
-....\TU/FandolSong-Regular(0)/m/n/10.53937 硕
+....\TU/FandolSong(0)/m/n/10.53937 硕
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 士
+....\TU/FandolSong(0)/m/n/10.53937 士
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 位
+....\TU/FandolSong(0)/m/n/10.53937 位
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\TU/texgyretermes(0)/m/n/10.53937 ].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 清
+....\TU/FandolSong(0)/m/n/10.53937 清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 无
+....\TU/FandolSong(0)/m/n/10.53937 无
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 线
+....\TU/FandolSong(0)/m/n/10.53937 线
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 电
+....\TU/FandolSong(0)/m/n/10.53937 电
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -660,44 +660,44 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 姜
+....\TU/FandolSong(0)/m/n/10.53937 姜
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 锡
+....\TU/FandolSong(0)/m/n/10.53937 锡
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 洲
+....\TU/FandolSong(0)/m/n/10.53937 洲
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 一
+....\TU/FandolSong(0)/m/n/10.53937 一
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 种
+....\TU/FandolSong(0)/m/n/10.53937 种
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 温
+....\TU/FandolSong(0)/m/n/10.53937 温
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 热
+....\TU/FandolSong(0)/m/n/10.53937 热
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 外
+....\TU/FandolSong(0)/m/n/10.53937 外
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 敷
+....\TU/FandolSong(0)/m/n/10.53937 敷
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 药
+....\TU/FandolSong(0)/m/n/10.53937 药
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 制
+....\TU/FandolSong(0)/m/n/10.53937 制
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 备
+....\TU/FandolSong(0)/m/n/10.53937 备
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 案
+....\TU/FandolSong(0)/m/n/10.53937 案
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -737,33 +737,33 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 共
+....\TU/FandolSong(0)/m/n/10.53937 共
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 和
+....\TU/FandolSong(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 家
+....\TU/FandolSong(0)/m/n/10.53937 家
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 监
+....\TU/FandolSong(0)/m/n/10.53937 监
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 督
+....\TU/FandolSong(0)/m/n/10.53937 督
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 局
+....\TU/FandolSong(0)/m/n/10.53937 局
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -773,64 +773,64 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 华
+....\TU/FandolSong(0)/m/n/10.53937 华
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 共
+....\TU/FandolSong(0)/m/n/10.53937 共
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 和
+....\TU/FandolSong(0)/m/n/10.53937 和
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 家
+....\TU/FandolSong(0)/m/n/10.53937 家
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\TU/texgyretermes(0)/m/n/10.53937 -
 ....\discretionary
-....\TU/FandolSong-Regular(0)/m/n/10.53937 量
+....\TU/FandolSong(0)/m/n/10.53937 量
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 单
+....\TU/FandolSong(0)/m/n/10.53937 单
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 位
+....\TU/FandolSong(0)/m/n/10.53937 位
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.68073
 ...\hbox(8.19963+1.86545)x404.41484, glue set 284.67357fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1260,86 +1260,86 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 马
+....\TU/FandolSong(0)/m/n/10.53937 马
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辉
+....\TU/FandolSong(0)/m/n/10.53937 辉
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 俭
+....\TU/FandolSong(0)/m/n/10.53937 俭
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刘
+....\TU/FandolSong(0)/m/n/10.53937 刘
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 耀
+....\TU/FandolSong(0)/m/n/10.53937 耀
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 明
+....\TU/FandolSong(0)/m/n/10.53937 明
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 利
+....\TU/FandolSong(0)/m/n/10.53937 利
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 用
+....\TU/FandolSong(0)/m/n/10.53937 用
 ....\glue 2.63484 plus 1.31609 minus 0.87915
 ....\TU/texgyretermes(0)/m/n/10.53937 REMPI
 ....\kern -0.0002
 ....\kern 0.0002
 ....\glue 2.63484 plus 1.31609 minus 0.87915
-....\TU/FandolSong-Regular(0)/m/n/10.53937 方
+....\TU/FandolSong(0)/m/n/10.53937 方
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 法
+....\TU/FandolSong(0)/m/n/10.53937 法
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 测
+....\TU/FandolSong(0)/m/n/10.53937 测
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 量
+....\TU/FandolSong(0)/m/n/10.53937 量
 ....\glue 2.63484 plus 1.31609 minus 0.87915
 ....\TU/texgyretermes(0)/m/n/10.53937 BaF
 ....\kern -0.0002
 ....\kern 0.0002
 ....\glue 2.63484 plus 1.31609 minus 0.87915
-....\TU/FandolSong-Regular(0)/m/n/10.53937 高
+....\TU/FandolSong(0)/m/n/10.53937 高
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 里
+....\TU/FandolSong(0)/m/n/10.53937 里
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 德
+....\TU/FandolSong(0)/m/n/10.53937 德
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 堡
+....\TU/FandolSong(0)/m/n/10.53937 堡
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 系
+....\TU/FandolSong(0)/m/n/10.53937 系
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 列
+....\TU/FandolSong(0)/m/n/10.53937 列
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 光
+....\TU/FandolSong(0)/m/n/10.53937 光
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 谱
+....\TU/FandolSong(0)/m/n/10.53937 谱
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.0
@@ -2173,68 +2173,68 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 广
+....\TU/FandolSong(0)/m/n/10.53937 广
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 西
+....\TU/FandolSong(0)/m/n/10.53937 西
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 壮
+....\TU/FandolSong(0)/m/n/10.53937 壮
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 族
+....\TU/FandolSong(0)/m/n/10.53937 族
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 治
+....\TU/FandolSong(0)/m/n/10.53937 治
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 区
+....\TU/FandolSong(0)/m/n/10.53937 区
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 林
+....\TU/FandolSong(0)/m/n/10.53937 林
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 厅
+....\TU/FandolSong(0)/m/n/10.53937 厅
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 广
+....\TU/FandolSong(0)/m/n/10.53937 广
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 西
+....\TU/FandolSong(0)/m/n/10.53937 西
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 自
+....\TU/FandolSong(0)/m/n/10.53937 自
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 然
+....\TU/FandolSong(0)/m/n/10.53937 然
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 保
+....\TU/FandolSong(0)/m/n/10.53937 保
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 护
+....\TU/FandolSong(0)/m/n/10.53937 护
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 区
+....\TU/FandolSong(0)/m/n/10.53937 区
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 林
+....\TU/FandolSong(0)/m/n/10.53937 林
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2265,50 +2265,50 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 霍
+....\TU/FandolSong(0)/m/n/10.53937 霍
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 斯
+....\TU/FandolSong(0)/m/n/10.53937 斯
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 尼
+....\TU/FandolSong(0)/m/n/10.53937 尼
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 谷
+....\TU/FandolSong(0)/m/n/10.53937 谷
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 艺
+....\TU/FandolSong(0)/m/n/10.53937 艺
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 原
+....\TU/FandolSong(0)/m/n/10.53937 原
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 庆
+....\TU/FandolSong(0)/m/n/10.53937 庆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 龙
+....\TU/FandolSong(0)/m/n/10.53937 龙
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 译
+....\TU/FandolSong(0)/m/n/10.53937 译
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2317,32 +2317,32 @@ C.}
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 食
+....\TU/FandolSong(0)/m/n/10.53937 食
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 品
+....\TU/FandolSong(0)/m/n/10.53937 品
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2377,42 +2377,42 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 王
+....\TU/FandolSong(0)/m/n/10.53937 王
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 夫
+....\TU/FandolSong(0)/m/n/10.53937 夫
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 之
+....\TU/FandolSong(0)/m/n/10.53937 之
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 宋
+....\TU/FandolSong(0)/m/n/10.53937 宋
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刻
+....\TU/FandolSong(0)/m/n/10.53937 刻
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 本
+....\TU/FandolSong(0)/m/n/10.53937 本
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 金
+....\TU/FandolSong(0)/m/n/10.53937 金
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 陵
+....\TU/FandolSong(0)/m/n/10.53937 陵
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 曾
+....\TU/FandolSong(0)/m/n/10.53937 曾
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 氏
+....\TU/FandolSong(0)/m/n/10.53937 氏
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2420,17 +2420,17 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 1865
 ....\glue 6.68196 minus 5.26968
 ....\rule(0.0+0.0)x-6.68196
-....\TU/FandolSong-Regular(0)/m/n/10.53937 （清
+....\TU/FandolSong(0)/m/n/10.53937 （清
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 同
+....\TU/FandolSong(0)/m/n/10.53937 同
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 治
+....\TU/FandolSong(0)/m/n/10.53937 治
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 四
+....\TU/FandolSong(0)/m/n/10.53937 四
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/10.53937 ）
+....\TU/FandolSong(0)/m/n/10.53937 ）
 ....\rule(0.0+0.0)x-6.68196
 ....\glue 6.68196 minus 5.26968
 ....\TU/texgyretermes(0)/m/n/10.53937 .
@@ -2459,59 +2459,59 @@ C.}
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 耀
+....\TU/FandolSong(0)/m/n/10.53937 耀
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 东
+....\TU/FandolSong(0)/m/n/10.53937 东
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 新
+....\TU/FandolSong(0)/m/n/10.53937 新
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 时
+....\TU/FandolSong(0)/m/n/10.53937 时
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 代
+....\TU/FandolSong(0)/m/n/10.53937 代
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 程
+....\TU/FandolSong(0)/m/n/10.53937 程
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 师
+....\TU/FandolSong(0)/m/n/10.53937 师
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [M/OL].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 台
+....\TU/FandolSong(0)/m/n/10.53937 台
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 天
+....\TU/FandolSong(0)/m/n/10.53937 天
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 下
+....\TU/FandolSong(0)/m/n/10.53937 下
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2750,13 +2750,13 @@ Completed box being shipped out [2]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 192.31694fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 参
+..........\TU/FandolSong(0)/m/n/10.53937 参
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 考
+..........\TU/FandolSong(0)/m/n/10.53937 考
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 献
+..........\TU/FandolSong(0)/m/n/10.53937 献
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -2796,57 +2796,57 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 献
+....\TU/FandolSong(0)/m/n/10.53937 献
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 作
+....\TU/FandolSong(0)/m/n/10.53937 作
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 技
+....\TU/FandolSong(0)/m/n/10.53937 技
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 术
+....\TU/FandolSong(0)/m/n/10.53937 术
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 委
+....\TU/FandolSong(0)/m/n/10.53937 委
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 员
+....\TU/FandolSong(0)/m/n/10.53937 员
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 式
+....\TU/FandolSong(0)/m/n/10.53937 式
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 分
+....\TU/FandolSong(0)/m/n/10.53937 分
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 委
+....\TU/FandolSong(0)/m/n/10.53937 委
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 员
+....\TU/FandolSong(0)/m/n/10.53937 员
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2860,43 +2860,43 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 名
+....\TU/FandolSong(0)/m/n/10.53937 名
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.7545
 ...\hbox(8.19963+1.86545)x404.41484, glue set 257.16582fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 页
+....\TU/FandolSong(0)/m/n/10.53937 页
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 标
+....\TU/FandolSong(0)/m/n/10.53937 标
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 准
+....\TU/FandolSong(0)/m/n/10.53937 准
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -2927,101 +2927,101 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 资
+....\TU/FandolSong(0)/m/n/10.53937 资
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 试
+....\TU/FandolSong(0)/m/n/10.53937 试
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 办
+....\TU/FandolSong(0)/m/n/10.53937 办
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 公
+....\TU/FandolSong(0)/m/n/10.53937 公
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 室
+....\TU/FandolSong(0)/m/n/10.53937 室
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 全
+....\TU/FandolSong(0)/m/n/10.53937 全
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 资
+....\TU/FandolSong(0)/m/n/10.53937 资
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 格
+....\TU/FandolSong(0)/m/n/10.53937 格
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 试
+....\TU/FandolSong(0)/m/n/10.53937 试
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辅
+....\TU/FandolSong(0)/m/n/10.53937 辅
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 导
+....\TU/FandolSong(0)/m/n/10.53937 导
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 材
+....\TU/FandolSong(0)/m/n/10.53937 材
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 专
+....\TU/FandolSong(0)/m/n/10.53937 专
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 理
+....\TU/FandolSong(0)/m/n/10.53937 理
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.67018
 ...\hbox(8.21017+1.89706)x404.41484, glue set 123.79713fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 与
+....\TU/FandolSong(0)/m/n/10.53937 与
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 实
+....\TU/FandolSong(0)/m/n/10.53937 实
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 务
+....\TU/FandolSong(0)/m/n/10.53937 务
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 •
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 级
+....\TU/FandolSong(0)/m/n/10.53937 级
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3031,32 +3031,32 @@ Completed box being shipped out [2]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 上
+....\TU/FandolSong(0)/m/n/10.53937 上
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 上
+....\TU/FandolSong(0)/m/n/10.53937 上
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 海
+....\TU/FandolSong(0)/m/n/10.53937 海
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 辞
+....\TU/FandolSong(0)/m/n/10.53937 辞
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3290,78 +3290,78 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 白
+....\TU/FandolSong(0)/m/n/10.53937 白
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 农
+....\TU/FandolSong(0)/m/n/10.53937 农
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 植
+....\TU/FandolSong(0)/m/n/10.53937 植
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 开
+....\TU/FandolSong(0)/m/n/10.53937 开
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 花
+....\TU/FandolSong(0)/m/n/10.53937 花
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 //
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 承
+....\TU/FandolSong(0)/m/n/10.53937 承
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 森
+....\TU/FandolSong(0)/m/n/10.53937 森
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 植
+....\TU/FandolSong(0)/m/n/10.53937 植
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 物
+....\TU/FandolSong(0)/m/n/10.53937 物
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 科
+....\TU/FandolSong(0)/m/n/10.53937 科
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 进
+....\TU/FandolSong(0)/m/n/10.53937 进
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 展
+....\TU/FandolSong(0)/m/n/10.53937 展
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 高
+....\TU/FandolSong(0)/m/n/10.53937 高
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 等
+....\TU/FandolSong(0)/m/n/10.53937 等
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3542,103 +3542,103 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 韩
+....\TU/FandolSong(0)/m/n/10.53937 韩
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 吉
+....\TU/FandolSong(0)/m/n/10.53937 吉
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 特
+....\TU/FandolSong(0)/m/n/10.53937 特
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 点
+....\TU/FandolSong(0)/m/n/10.53937 点
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 //
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 职
+....\TU/FandolSong(0)/m/n/10.53937 职
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 工
+....\TU/FandolSong(0)/m/n/10.53937 工
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 研
+....\TU/FandolSong(0)/m/n/10.53937 研
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 究
+....\TU/FandolSong(0)/m/n/10.53937 究
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 文
+....\TU/FandolSong(0)/m/n/10.53937 文
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 集
+....\TU/FandolSong(0)/m/n/10.53937 集
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 人
+....\TU/FandolSong(0)/m/n/10.53937 人
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 民
+....\TU/FandolSong(0)/m/n/10.53937 民
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 教
+....\TU/FandolSong(0)/m/n/10.53937 教
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 育
+....\TU/FandolSong(0)/m/n/10.53937 育
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
 ...\glue(\baselineskip) 5.77559
 ...\hbox(8.11531+1.78114)x404.41484, glue set 312.78206fil, shifted 22.37651
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3673,29 +3673,29 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 址
+....\TU/FandolSong(0)/m/n/10.53937 址
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 质
+....\TU/FandolSong(0)/m/n/10.53937 质
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 评
+....\TU/FandolSong(0)/m/n/10.53937 评
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 论
+....\TU/FandolSong(0)/m/n/10.53937 论
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3714,22 +3714,22 @@ Completed box being shipped out [2]
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 地
+....\TU/FandolSong(0)/m/n/10.53937 地
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 质
+....\TU/FandolSong(0)/m/n/10.53937 质
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 社
+....\TU/FandolSong(0)/m/n/10.53937 社
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3760,35 +3760,35 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 中
+....\TU/FandolSong(0)/m/n/10.53937 中
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 国
+....\TU/FandolSong(0)/m/n/10.53937 国
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 会
+....\TU/FandolSong(0)/m/n/10.53937 会
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 学
+....\TU/FandolSong(0)/m/n/10.53937 学
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 通
+....\TU/FandolSong(0)/m/n/10.53937 通
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 讯
+....\TU/FandolSong(0)/m/n/10.53937 讯
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3807,22 +3807,22 @@ Completed box being shipped out [2]
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.51312 plus 2.63483 minus 0.43913
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 图
+....\TU/FandolSong(0)/m/n/10.53937 图
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 书
+....\TU/FandolSong(0)/m/n/10.53937 书
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 馆
+....\TU/FandolSong(0)/m/n/10.53937 馆
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -3968,60 +3968,60 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 傅
+....\TU/FandolSong(0)/m/n/10.53937 傅
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 刚
+....\TU/FandolSong(0)/m/n/10.53937 刚
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 赵
+....\TU/FandolSong(0)/m/n/10.53937 赵
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 承
+....\TU/FandolSong(0)/m/n/10.53937 承
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.64676 minus 0.70262
-....\TU/FandolSong-Regular(0)/m/n/10.53937 李
+....\TU/FandolSong(0)/m/n/10.53937 李
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 佳
+....\TU/FandolSong(0)/m/n/10.53937 佳
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 路
+....\TU/FandolSong(0)/m/n/10.53937 路
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 大
+....\TU/FandolSong(0)/m/n/10.53937 大
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 风
+....\TU/FandolSong(0)/m/n/10.53937 风
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 沙
+....\TU/FandolSong(0)/m/n/10.53937 沙
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 过
+....\TU/FandolSong(0)/m/n/10.53937 过
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 后
+....\TU/FandolSong(0)/m/n/10.53937 后
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 的
+....\TU/FandolSong(0)/m/n/10.53937 的
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 思
+....\TU/FandolSong(0)/m/n/10.53937 思
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 考
+....\TU/FandolSong(0)/m/n/10.53937 考
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [N/OL].
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 北
+....\TU/FandolSong(0)/m/n/10.53937 北
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 京
+....\TU/FandolSong(0)/m/n/10.53937 京
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 青
+....\TU/FandolSong(0)/m/n/10.53937 青
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 年
+....\TU/FandolSong(0)/m/n/10.53937 年
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 报
+....\TU/FandolSong(0)/m/n/10.53937 报
 ....\TU/texgyretermes(0)/m/n/10.53937 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -4220,35 +4220,35 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/10.53937 萧
+....\TU/FandolSong(0)/m/n/10.53937 萧
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 钰
+....\TU/FandolSong(0)/m/n/10.53937 钰
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
-....\TU/FandolSong-Regular(0)/m/n/10.53937 出
+....\TU/FandolSong(0)/m/n/10.53937 出
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 版
+....\TU/FandolSong(0)/m/n/10.53937 版
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 业
+....\TU/FandolSong(0)/m/n/10.53937 业
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 信
+....\TU/FandolSong(0)/m/n/10.53937 信
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 息
+....\TU/FandolSong(0)/m/n/10.53937 息
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 化
+....\TU/FandolSong(0)/m/n/10.53937 化
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 迈
+....\TU/FandolSong(0)/m/n/10.53937 迈
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 入
+....\TU/FandolSong(0)/m/n/10.53937 入
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 快
+....\TU/FandolSong(0)/m/n/10.53937 快
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 车
+....\TU/FandolSong(0)/m/n/10.53937 车
 ....\glue 0.0 plus 0.41463
-....\TU/FandolSong-Regular(0)/m/n/10.53937 道
+....\TU/FandolSong(0)/m/n/10.53937 道
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 [EB/OL].
 ....\kern -0.00021

--- a/testfiles/09-acknowledgements.tlg
+++ b/testfiles/09-acknowledgements.tlg
@@ -44,11 +44,11 @@ Completed box being shipped out [115]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 致
+..........\TU/FandolSong(0)/m/n/10.53937 致
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 谢
+..........\TU/FandolSong(0)/m/n/10.53937 谢
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -93,11 +93,11 @@ Completed box being shipped out [115]
 ...\glue(\baselineskip) 3.62956
 ...\hbox(12.43044+2.93896)x426.79135, glue set 189.30568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 致
+....\TU/FandolHei(0)/m/n/16.06 致
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 谢
+....\TU/FandolHei(0)/m/n/16.06 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -111,92 +111,92 @@ Completed box being shipped out [115]
 ...\glue(\baselineskip) 7.69275
 ...\hbox(9.44328+2.2283)x426.79135, glue set 0.38664
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 衷
+....\TU/FandolSong(0)/m/n/12.045 衷
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 心
+....\TU/FandolSong(0)/m/n/12.045 心
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 感
+....\TU/FandolSong(0)/m/n/12.045 感
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谢
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 师
+....\TU/FandolSong(0)/m/n/12.045 师
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 ^^d7^^d7^^d7
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 教
+....\TU/FandolSong(0)/m/n/12.045 教
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 授
+....\TU/FandolSong(0)/m/n/12.045 授
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 物
+....\TU/FandolSong(0)/m/n/12.045 物
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 ^^d7^^d7
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 副
+....\TU/FandolSong(0)/m/n/12.045 副
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 教
+....\TU/FandolSong(0)/m/n/12.045 教
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 授
+....\TU/FandolSong(0)/m/n/12.045 授
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 精
+....\TU/FandolSong(0)/m/n/12.045 精
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 心
+....\TU/FandolSong(0)/m/n/12.045 心
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 言
+....\TU/FandolSong(0)/m/n/12.045 言
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 传
+....\TU/FandolSong(0)/m/n/12.045 传
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
 ...\glue(\baselineskip) 8.34319
 ...\hbox(9.50351+2.04764)x426.79135, glue set 314.09834fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 身
+....\TU/FandolSong(0)/m/n/12.045 身
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 教
+....\TU/FandolSong(0)/m/n/12.045 教
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 终
+....\TU/FandolSong(0)/m/n/12.045 终
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 受
+....\TU/FandolSong(0)/m/n/12.045 受
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 益
+....\TU/FandolSong(0)/m/n/12.045 益
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -209,61 +209,61 @@ Completed box being shipped out [115]
 ...\glue(\baselineskip) 8.63226
 ...\hbox(9.3951+2.32468)x426.79135, glue set - 0.09322
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 美
+....\TU/FandolSong(0)/m/n/12.045 美
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 麻
+....\TU/FandolSong(0)/m/n/12.045 麻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 省
+....\TU/FandolSong(0)/m/n/12.045 省
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 理
+....\TU/FandolSong(0)/m/n/12.045 理
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 院
+....\TU/FandolSong(0)/m/n/12.045 院
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 九
+....\TU/FandolSong(0)/m/n/12.045 九
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 合
+....\TU/FandolSong(0)/m/n/12.045 合
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 间
+....\TU/FandolSong(0)/m/n/12.045 间
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 承
+....\TU/FandolSong(0)/m/n/12.045 承
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 蒙
+....\TU/FandolSong(0)/m/n/12.045 蒙
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 Robert
 ....\kern -0.00021
@@ -273,40 +273,40 @@ Completed box being shipped out [115]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 教
+....\TU/FandolSong(0)/m/n/12.045 教
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 8.31909
 ...\hbox(9.43123+2.32468)x426.79135, glue set 265.91835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 授
+....\TU/FandolSong(0)/m/n/12.045 授
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 热
+....\TU/FandolSong(0)/m/n/12.045 热
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 心
+....\TU/FandolSong(0)/m/n/12.045 心
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 帮
+....\TU/FandolSong(0)/m/n/12.045 帮
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 助
+....\TU/FandolSong(0)/m/n/12.045 助
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 胜
+....\TU/FandolSong(0)/m/n/12.045 胜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 感
+....\TU/FandolSong(0)/m/n/12.045 感
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 激
+....\TU/FandolSong(0)/m/n/12.045 激
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -319,80 +319,80 @@ Completed box being shipped out [115]
 ...\glue(\baselineskip) 8.31909
 ...\hbox(9.43123+2.32468)x426.79135, glue set - 0.09471
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 感
+....\TU/FandolSong(0)/m/n/12.045 感
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谢
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 ^^d7^^d7^^d7^^d7^^d7
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 室
+....\TU/FandolSong(0)/m/n/12.045 室
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 主
+....\TU/FandolSong(0)/m/n/12.045 主
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 ^^d7^^d7^^d7
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 教
+....\TU/FandolSong(0)/m/n/12.045 教
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 授
+....\TU/FandolSong(0)/m/n/12.045 授
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 实
+....\TU/FandolSong(0)/m/n/12.045 实
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 验
+....\TU/FandolSong(0)/m/n/12.045 验
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 室
+....\TU/FandolSong(0)/m/n/12.045 室
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 全
+....\TU/FandolSong(0)/m/n/12.045 全
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 老
+....\TU/FandolSong(0)/m/n/12.045 老
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 师
+....\TU/FandolSong(0)/m/n/12.045 师
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 同
+....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 窗
+....\TU/FandolSong(0)/m/n/12.045 窗
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 们
+....\TU/FandolSong(0)/m/n/12.045 们
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 热
+....\TU/FandolSong(0)/m/n/12.045 热
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 情
+....\TU/FandolSong(0)/m/n/12.045 情
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 帮
+....\TU/FandolSong(0)/m/n/12.045 帮
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 8.41545
 ...\hbox(9.33487+2.02354)x426.79135, glue set 374.96173fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 助
+....\TU/FandolSong(0)/m/n/12.045 助
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 支
+....\TU/FandolSong(0)/m/n/12.045 支
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ！
+....\TU/FandolSong(0)/m/n/12.045 ！
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -405,49 +405,49 @@ Completed box being shipped out [115]
 ...\glue(\baselineskip) 8.57204
 ...\hbox(9.47942+2.32468)x426.79135, glue set 149.7564fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 课
+....\TU/FandolSong(0)/m/n/12.045 课
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 题
+....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 承
+....\TU/FandolSong(0)/m/n/12.045 承
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 蒙
+....\TU/FandolSong(0)/m/n/12.045 蒙
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 自
+....\TU/FandolSong(0)/m/n/12.045 自
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 科
+....\TU/FandolSong(0)/m/n/12.045 科
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 资
+....\TU/FandolSong(0)/m/n/12.045 资
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 助
+....\TU/FandolSong(0)/m/n/12.045 助
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 特
+....\TU/FandolSong(0)/m/n/12.045 特
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 此
+....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 致
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 谢
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047

--- a/testfiles/10-statement.tlg
+++ b/testfiles/10-statement.tlg
@@ -57,11 +57,11 @@ Completed box being shipped out [116]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 声
+..........\TU/FandolSong(0)/m/n/10.53937 声
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 明
+..........\TU/FandolSong(0)/m/n/10.53937 明
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -105,11 +105,11 @@ Completed box being shipped out [116]
 ...\glue(\baselineskip) 3.59744
 ...\hbox(12.46255+2.87473)x426.79135, glue set 189.30568fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 声
+....\TU/FandolHei(0)/m/n/16.06 声
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 明
+....\TU/FandolHei(0)/m/n/16.06 明
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -123,279 +123,279 @@ Completed box being shipped out [116]
 ...\glue(\baselineskip) 7.74495
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.34389
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 郑
+....\TU/FandolSong(0)/m/n/12.045 郑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 重
+....\TU/FandolSong(0)/m/n/12.045 重
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 声
+....\TU/FandolSong(0)/m/n/12.045 声
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\glue 8.39537 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 呈
+....\TU/FandolSong(0)/m/n/12.045 呈
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 是
+....\TU/FandolSong(0)/m/n/12.045 是
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 师
+....\TU/FandolSong(0)/m/n/12.045 师
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 导
+....\TU/FandolSong(0)/m/n/12.045 导
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 下
+....\TU/FandolSong(0)/m/n/12.045 下
 ....\kern -0.00018
 ....\kern 0.00018
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 独
+....\TU/FandolSong(0)/m/n/12.045 独
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 立
+....\TU/FandolSong(0)/m/n/12.045 立
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 行
+....\TU/FandolSong(0)/m/n/12.045 行
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 尽
+....\TU/FandolSong(0)/m/n/12.045 尽
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 我
+....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 知
+....\TU/FandolSong(0)/m/n/12.045 知
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 除
+....\TU/FandolSong(0)/m/n/12.045 除
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 经
+....\TU/FandolSong(0)/m/n/12.045 经
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 注
+....\TU/FandolSong(0)/m/n/12.045 注
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 引
+....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 外
+....\TU/FandolSong(0)/m/n/12.045 外
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.30058)x426.79135, glue set 0.3022
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 果
+....\TU/FandolSong(0)/m/n/12.045 果
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 不
+....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 包
+....\TU/FandolSong(0)/m/n/12.045 包
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 含
+....\TU/FandolSong(0)/m/n/12.045 含
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 何
+....\TU/FandolSong(0)/m/n/12.045 何
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 享
+....\TU/FandolSong(0)/m/n/12.045 享
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 有
+....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 著
+....\TU/FandolSong(0)/m/n/12.045 著
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 权
+....\TU/FandolSong(0)/m/n/12.045 权
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 内
+....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 对
+....\TU/FandolSong(0)/m/n/12.045 对
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 论
+....\TU/FandolSong(0)/m/n/12.045 论
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 所
+....\TU/FandolSong(0)/m/n/12.045 所
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 涉
+....\TU/FandolSong(0)/m/n/12.045 涉
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 及
+....\TU/FandolSong(0)/m/n/12.045 及
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 作
+....\TU/FandolSong(0)/m/n/12.045 作
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 做
+....\TU/FandolSong(0)/m/n/12.045 做
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 贡
+....\TU/FandolSong(0)/m/n/12.045 贡
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 献
+....\TU/FandolSong(0)/m/n/12.045 献
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.40341
 ...\hbox(9.371+2.32468)x426.79135, glue set 181.60336fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 他
+....\TU/FandolSong(0)/m/n/12.045 他
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 个
+....\TU/FandolSong(0)/m/n/12.045 个
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 人
+....\TU/FandolSong(0)/m/n/12.045 人
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 集
+....\TU/FandolSong(0)/m/n/12.045 集
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 均
+....\TU/FandolSong(0)/m/n/12.045 均
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 在
+....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 以
+....\TU/FandolSong(0)/m/n/12.045 以
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 确
+....\TU/FandolSong(0)/m/n/12.045 确
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 式
+....\TU/FandolSong(0)/m/n/12.045 式
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 标
+....\TU/FandolSong(0)/m/n/12.045 标
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -410,13 +410,13 @@ Completed box being shipped out [116]
 ...\hbox(9.32283+3.97446)x426.79135, glue set 159.0776fill
 ....\hbox(0.0+0.0)x24.09
 ....\glue 0.0 plus 1.0fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 签
+....\TU/FandolSong(0)/m/n/12.045 签
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052
@@ -434,13 +434,13 @@ Completed box being shipped out [116]
 .....\rule(0.79489+0.0)x*
 ....\mathoff
 ....\glue 3.0
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 12.045
-....\TU/FandolSong-Regular(0)/m/n/12.045 期
+....\TU/FandolSong(0)/m/n/12.045 期
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ：
+....\TU/FandolSong(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.39537
 ....\kern 0.00052
 ....\kern -0.00052

--- a/testfiles/11-resume.tlg
+++ b/testfiles/11-resume.tlg
@@ -45,49 +45,49 @@ Completed box being shipped out [116]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 102.73232fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 个
+..........\TU/FandolSong(0)/m/n/10.53937 个
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 人
+..........\TU/FandolSong(0)/m/n/10.53937 人
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 简
+..........\TU/FandolSong(0)/m/n/10.53937 简
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 历
+..........\TU/FandolSong(0)/m/n/10.53937 历
 ..........\penalty 10000
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 、
+..........\TU/FandolSong(0)/m/n/10.53937 、
 ..........\rule(0.0+0.0)x-6.87167
 ..........\glue 6.87167 minus 5.26968
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 在
+..........\TU/FandolSong(0)/m/n/10.53937 在
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 学
+..........\TU/FandolSong(0)/m/n/10.53937 学
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 期
+..........\TU/FandolSong(0)/m/n/10.53937 期
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 间
+..........\TU/FandolSong(0)/m/n/10.53937 间
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 发
+..........\TU/FandolSong(0)/m/n/10.53937 发
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 表
+..........\TU/FandolSong(0)/m/n/10.53937 表
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 的
+..........\TU/FandolSong(0)/m/n/10.53937 的
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 学
+..........\TU/FandolSong(0)/m/n/10.53937 学
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 术
+..........\TU/FandolSong(0)/m/n/10.53937 术
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 论
+..........\TU/FandolSong(0)/m/n/10.53937 论
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 文
+..........\TU/FandolSong(0)/m/n/10.53937 文
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 与
+..........\TU/FandolSong(0)/m/n/10.53937 与
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 研
+..........\TU/FandolSong(0)/m/n/10.53937 研
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 究
+..........\TU/FandolSong(0)/m/n/10.53937 究
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 成
+..........\TU/FandolSong(0)/m/n/10.53937 成
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 果
+..........\TU/FandolSong(0)/m/n/10.53937 果
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -130,49 +130,49 @@ Completed box being shipped out [116]
 ...\glue(\baselineskip) 3.43684
 ...\hbox(12.62315+2.93896)x426.79135, glue set 44.7657fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 个
+....\TU/FandolHei(0)/m/n/16.06 个
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 人
+....\TU/FandolHei(0)/m/n/16.06 人
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 简
+....\TU/FandolHei(0)/m/n/16.06 简
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 历
+....\TU/FandolHei(0)/m/n/16.06 历
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/16.06 、
+....\TU/FandolHei(0)/m/n/16.06 、
 ....\rule(0.0+0.0)x-10.47112
 ....\glue 10.47112 minus 8.03
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 在
+....\TU/FandolHei(0)/m/n/16.06 在
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 学
+....\TU/FandolHei(0)/m/n/16.06 学
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 期
+....\TU/FandolHei(0)/m/n/16.06 期
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 间
+....\TU/FandolHei(0)/m/n/16.06 间
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 发
+....\TU/FandolHei(0)/m/n/16.06 发
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 表
+....\TU/FandolHei(0)/m/n/16.06 表
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 的
+....\TU/FandolHei(0)/m/n/16.06 的
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 学
+....\TU/FandolHei(0)/m/n/16.06 学
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 术
+....\TU/FandolHei(0)/m/n/16.06 术
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 论
+....\TU/FandolHei(0)/m/n/16.06 论
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 文
+....\TU/FandolHei(0)/m/n/16.06 文
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 与
+....\TU/FandolHei(0)/m/n/16.06 与
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 研
+....\TU/FandolHei(0)/m/n/16.06 研
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 究
+....\TU/FandolHei(0)/m/n/16.06 究
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 成
+....\TU/FandolHei(0)/m/n/16.06 成
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 果
+....\TU/FandolHei(0)/m/n/16.06 果
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -187,13 +187,13 @@ Completed box being shipped out [116]
 ...\glue(\baselineskip) 4.28406
 ...\hbox(11.04526+2.5716)x426.79135, glue set 185.2907fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/14.05249 个
+....\TU/FandolHei(0)/m/n/14.05249 个
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 人
+....\TU/FandolHei(0)/m/n/14.05249 人
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 简
+....\TU/FandolHei(0)/m/n/14.05249 简
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 历
+....\TU/FandolHei(0)/m/n/14.05249 历
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -207,39 +207,39 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 日
+....\TU/FandolSong(0)/m/n/12.045 日
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 生
+....\TU/FandolSong(0)/m/n/12.045 生
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 省
+....\TU/FandolSong(0)/m/n/12.045 省
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 县
+....\TU/FandolSong(0)/m/n/12.045 县
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -256,85 +256,85 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 9
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 入
+....\TU/FandolSong(0)/m/n/12.045 入
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 专
+....\TU/FandolSong(0)/m/n/12.045 专
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\TU/texgyretermes(0)/m/n/12.045 xxxx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 本
+....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 科
+....\TU/FandolSong(0)/m/n/12.045 科
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 毕
+....\TU/FandolSong(0)/m/n/12.045 毕
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 业
+....\TU/FandolSong(0)/m/n/12.045 业
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 并
+....\TU/FandolSong(0)/m/n/12.045 并
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 获
+....\TU/FandolSong(0)/m/n/12.045 获
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 得
+....\TU/FandolSong(0)/m/n/12.045 得
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 士
+....\TU/FandolSong(0)/m/n/12.045 士
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+1.99945)x426.79135, glue set 398.41333fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -351,53 +351,53 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 年
+....\TU/FandolSong(0)/m/n/12.045 年
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 9
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 免
+....\TU/FandolSong(0)/m/n/12.045 免
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 试
+....\TU/FandolSong(0)/m/n/12.045 试
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 入
+....\TU/FandolSong(0)/m/n/12.045 入
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 大
+....\TU/FandolSong(0)/m/n/12.045 大
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 系
+....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 攻
+....\TU/FandolSong(0)/m/n/12.045 攻
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 读
+....\TU/FandolSong(0)/m/n/12.045 读
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 xx
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 位
+....\TU/FandolSong(0)/m/n/12.045 位
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 今
+....\TU/FandolSong(0)/m/n/12.045 今
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -411,19 +411,19 @@ Completed box being shipped out [116]
 ...\glue(\baselineskip) 5.10713
 ...\hbox(11.01715+2.52943)x426.79135, glue set 164.21196fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/14.05249 发
+....\TU/FandolHei(0)/m/n/14.05249 发
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 表
+....\TU/FandolHei(0)/m/n/14.05249 表
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 的
+....\TU/FandolHei(0)/m/n/14.05249 的
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 学
+....\TU/FandolHei(0)/m/n/14.05249 学
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 术
+....\TU/FandolHei(0)/m/n/14.05249 术
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 论
+....\TU/FandolHei(0)/m/n/14.05249 论
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 文
+....\TU/FandolHei(0)/m/n/14.05249 文
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -547,21 +547,21 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 检
+....\TU/FandolSong(0)/m/n/12.045 检
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 3.34845
 ...\hbox(9.20238+2.13194)x398.33861, glue set 343.79886fil, shifted 28.45274
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\TU/texgyretermes(0)/m/n/12.045 :758FZ.)
 ....\kern -0.00021
 ....\kern 0.00021
@@ -587,91 +587,91 @@ Completed box being shipped out [116]
 ......\special{color pop}
 .....\glue 4.45274
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 杨
+....\TU/FandolSong(0)/m/n/12.045 杨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 轶
+....\TU/FandolSong(0)/m/n/12.045 轶
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宁
+....\TU/FandolSong(0)/m/n/12.045 宁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 欣
+....\TU/FandolSong(0)/m/n/12.045 欣
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 天
+....\TU/FandolSong(0)/m/n/12.045 天
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 令
+....\TU/FandolSong(0)/m/n/12.045 令
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 硅
+....\TU/FandolSong(0)/m/n/12.045 硅
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 铁
+....\TU/FandolSong(0)/m/n/12.045 铁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 微
+....\TU/FandolSong(0)/m/n/12.045 微
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 声
+....\TU/FandolSong(0)/m/n/12.045 声
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 薄
+....\TU/FandolSong(0)/m/n/12.045 薄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 膜
+....\TU/FandolSong(0)/m/n/12.045 膜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 残
+....\TU/FandolSong(0)/m/n/12.045 残
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 余
+....\TU/FandolSong(0)/m/n/12.045 余
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 应
+....\TU/FandolSong(0)/m/n/12.045 应
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 力
+....\TU/FandolSong(0)/m/n/12.045 力
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 3.61345
 ...\hbox(9.33487+2.13194)x398.33861, glue set 55.07626fil, shifted 28.45274
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 械
+....\TU/FandolSong(0)/m/n/12.045 械
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -688,18 +688,18 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 检
+....\TU/FandolSong(0)/m/n/12.045 检
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\TU/texgyretermes(0)/m/n/12.045 :0534931
 ....\kern -0.00021
 ....\kern 0.00021
@@ -729,78 +729,78 @@ Completed box being shipped out [116]
 ......\special{color pop}
 .....\glue 4.45274
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 杨
+....\TU/FandolSong(0)/m/n/12.045 杨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 轶
+....\TU/FandolSong(0)/m/n/12.045 轶
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宁
+....\TU/FandolSong(0)/m/n/12.045 宁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 欣
+....\TU/FandolSong(0)/m/n/12.045 欣
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 天
+....\TU/FandolSong(0)/m/n/12.045 天
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 令
+....\TU/FandolSong(0)/m/n/12.045 令
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 集
+....\TU/FandolSong(0)/m/n/12.045 集
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 铁
+....\TU/FandolSong(0)/m/n/12.045 铁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 件
+....\TU/FandolSong(0)/m/n/12.045 件
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 键
+....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 工
+....\TU/FandolSong(0)/m/n/12.045 工
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 艺
+....\TU/FandolSong(0)/m/n/12.045 艺
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 仪
+....\TU/FandolSong(0)/m/n/12.045 仪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仪
+....\TU/FandolSong(0)/m/n/12.045 仪
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 报
+....\TU/FandolSong(0)/m/n/12.045 报
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.0
@@ -820,9 +820,9 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 刊
+....\TU/FandolSong(0)/m/n/12.045 刊
 ....\TU/texgyretermes(0)/m/n/12.045 .)
 ....\kern -0.00021
 ....\kern 0.00021
@@ -920,12 +920,12 @@ Completed box being shipped out [116]
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
 ....\TU/texgyretermes(0)/m/n/12.045 (
-....\TU/FandolSong-Regular(0)/m/n/12.045 已
+....\TU/FandolSong(0)/m/n/12.045 已
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 8.1625
 ...\hbox(9.2867+2.6258)x398.33861, glue set 173.78778fil, shifted 28.45274
-....\TU/FandolSong-Regular(0)/m/n/12.045 被
+....\TU/FandolSong(0)/m/n/12.045 被
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 Integrated
 ....\kern -0.00021
@@ -935,9 +935,9 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
@@ -946,9 +946,9 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 源
+....\TU/FandolSong(0)/m/n/12.045 源
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 刊
+....\TU/FandolSong(0)/m/n/12.045 刊
 ....\TU/texgyretermes(0)/m/n/12.045 .)
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1063,18 +1063,18 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 检
+....\TU/FandolSong(0)/m/n/12.045 检
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\kern -0.00018
 ....\kern 0.00018
 ....\TU/texgyretermes(0)/m/n/12.045 :896KM)
@@ -1102,87 +1102,87 @@ Completed box being shipped out [116]
 ......\special{color pop}
 .....\glue 4.45274
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 贾
+....\TU/FandolSong(0)/m/n/12.045 贾
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 泽
+....\TU/FandolSong(0)/m/n/12.045 泽
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 杨
+....\TU/FandolSong(0)/m/n/12.045 杨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 轶
+....\TU/FandolSong(0)/m/n/12.045 轶
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 陈
+....\TU/FandolSong(0)/m/n/12.045 陈
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 兢
+....\TU/FandolSong(0)/m/n/12.045 兢
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 压
+....\TU/FandolSong(0)/m/n/12.045 压
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 容
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 微
+....\TU/FandolSong(0)/m/n/12.045 微
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 克
+....\TU/FandolSong(0)/m/n/12.045 克
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 风
+....\TU/FandolSong(0)/m/n/12.045 风
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 体
+....\TU/FandolSong(0)/m/n/12.045 体
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 硅
+....\TU/FandolSong(0)/m/n/12.045 硅
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 腐
+....\TU/FandolSong(0)/m/n/12.045 腐
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 蚀
+....\TU/FandolSong(0)/m/n/12.045 蚀
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 相
+....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 关
+....\TU/FandolSong(0)/m/n/12.045 关
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 研
+....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 究
+....\TU/FandolSong(0)/m/n/12.045 究
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 压
+....\TU/FandolSong(0)/m/n/12.045 压
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 与
+....\TU/FandolSong(0)/m/n/12.045 与
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 3.54117
 ...\hbox(9.33487+2.21626)x398.33861, glue set 103.25626fil, shifted 28.45274
-....\TU/FandolSong-Regular(0)/m/n/12.045 声
+....\TU/FandolSong(0)/m/n/12.045 声
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 光
+....\TU/FandolSong(0)/m/n/12.045 光
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1199,18 +1199,18 @@ Completed box being shipped out [116]
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.5041 minus 1.00473
-....\TU/FandolSong-Regular(0)/m/n/12.045 收
+....\TU/FandolSong(0)/m/n/12.045 收
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 检
+....\TU/FandolSong(0)/m/n/12.045 检
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 索
+....\TU/FandolSong(0)/m/n/12.045 索
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\TU/texgyretermes(0)/m/n/12.045 :06129773469)
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1236,83 +1236,83 @@ Completed box being shipped out [116]
 ......\special{color pop}
 .....\glue 4.45274
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 伍
+....\TU/FandolSong(0)/m/n/12.045 伍
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 晓
+....\TU/FandolSong(0)/m/n/12.045 晓
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 杨
+....\TU/FandolSong(0)/m/n/12.045 杨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 轶
+....\TU/FandolSong(0)/m/n/12.045 轶
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 宁
+....\TU/FandolSong(0)/m/n/12.045 宁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 欣
+....\TU/FandolSong(0)/m/n/12.045 欣
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 于
+....\TU/FandolSong(0)/m/n/12.045 于
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/texgyretermes(0)/m/n/12.045 MEMS
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 技
+....\TU/FandolSong(0)/m/n/12.045 技
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 术
+....\TU/FandolSong(0)/m/n/12.045 术
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 集
+....\TU/FandolSong(0)/m/n/12.045 集
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 铁
+....\TU/FandolSong(0)/m/n/12.045 铁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 硅
+....\TU/FandolSong(0)/m/n/12.045 硅
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 微
+....\TU/FandolSong(0)/m/n/12.045 微
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 麦
+....\TU/FandolSong(0)/m/n/12.045 麦
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 克
+....\TU/FandolSong(0)/m/n/12.045 克
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 风
+....\TU/FandolSong(0)/m/n/12.045 风
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 集
+....\TU/FandolSong(0)/m/n/12.045 集
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 成
+....\TU/FandolSong(0)/m/n/12.045 成
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 3.66162
 ...\hbox(9.2867+1.85492)x398.33861, glue set 291.6079fil, shifted 28.45274
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 路
+....\TU/FandolSong(0)/m/n/12.045 路
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1334,13 +1334,13 @@ Completed box being shipped out [116]
 ...\glue(\baselineskip) 5.49457
 ...\hbox(10.9188+2.47322)x426.79135, glue set 185.2907fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/14.05249 研
+....\TU/FandolHei(0)/m/n/14.05249 研
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 究
+....\TU/FandolHei(0)/m/n/14.05249 究
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 成
+....\TU/FandolHei(0)/m/n/14.05249 成
 ....\glue 0.0 plus 0.68819
-....\TU/FandolHei-Regular(0)/m/n/14.05249 果
+....\TU/FandolHei(0)/m/n/14.05249 果
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1366,95 +1366,95 @@ Completed box being shipped out [116]
 ......\special{color pop}
 .....\glue 4.45274
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 任
+....\TU/FandolSong(0)/m/n/12.045 任
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 天
+....\TU/FandolSong(0)/m/n/12.045 天
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 令
+....\TU/FandolSong(0)/m/n/12.045 令
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 杨
+....\TU/FandolSong(0)/m/n/12.045 杨
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 轶
+....\TU/FandolSong(0)/m/n/12.045 轶
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 朱
+....\TU/FandolSong(0)/m/n/12.045 朱
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 一
+....\TU/FandolSong(0)/m/n/12.045 一
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 平
+....\TU/FandolSong(0)/m/n/12.045 平
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/FandolSong-Regular(0)/m/n/12.045 等
+....\TU/FandolSong(0)/m/n/12.045 等
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\TU/FandolSong-Regular(0)/m/n/12.045 硅
+....\TU/FandolSong(0)/m/n/12.045 硅
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 基
+....\TU/FandolSong(0)/m/n/12.045 基
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 铁
+....\TU/FandolSong(0)/m/n/12.045 铁
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 微
+....\TU/FandolSong(0)/m/n/12.045 微
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 声
+....\TU/FandolSong(0)/m/n/12.045 声
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 学
+....\TU/FandolSong(0)/m/n/12.045 学
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 传
+....\TU/FandolSong(0)/m/n/12.045 传
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 感
+....\TU/FandolSong(0)/m/n/12.045 感
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 畴
+....\TU/FandolSong(0)/m/n/12.045 畴
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 化
+....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 区
+....\TU/FandolSong(0)/m/n/12.045 区
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 域
+....\TU/FandolSong(0)/m/n/12.045 域
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 控
+....\TU/FandolSong(0)/m/n/12.045 控
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 制
+....\TU/FandolSong(0)/m/n/12.045 制
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 电
+....\TU/FandolSong(0)/m/n/12.045 电
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 连
+....\TU/FandolSong(0)/m/n/12.045 连
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 接
+....\TU/FandolSong(0)/m/n/12.045 接
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 3.54117
 ...\hbox(9.371+2.13194)x398.33861, glue set 158.78369fil, shifted 28.45274
-....\TU/FandolSong-Regular(0)/m/n/12.045 的
+....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 方
+....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 法
+....\TU/FandolSong(0)/m/n/12.045 法
 ....\TU/texgyretermes(0)/m/n/12.045 :
 ....\kern -0.00021
 ....\kern 0.00021
 ....\glue 4.01498 plus 3.01123 minus 0.50186
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1464,19 +1464,19 @@ Completed box being shipped out [116]
 ....\kern 0.00021
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (
-....\TU/FandolSong-Regular(0)/m/n/12.045 中
+....\TU/FandolSong(0)/m/n/12.045 中
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 专
+....\TU/FandolSong(0)/m/n/12.045 专
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 利
+....\TU/FandolSong(0)/m/n/12.045 利
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 公
+....\TU/FandolSong(0)/m/n/12.045 公
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 开
+....\TU/FandolSong(0)/m/n/12.045 开
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\TU/texgyretermes(0)/m/n/12.045 )
 ....\kern -0.00021
 ....\kern 0.00021
@@ -1716,23 +1716,23 @@ Completed box being shipped out [117]
 ....\kern 0.00021
 ....\glue 4.01498 plus 4.51685 minus 0.33458
 ....\TU/texgyretermes(0)/m/n/12.045 (
-....\TU/FandolSong-Regular(0)/m/n/12.045 美
+....\TU/FandolSong(0)/m/n/12.045 美
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 国
+....\TU/FandolSong(0)/m/n/12.045 国
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 发
+....\TU/FandolSong(0)/m/n/12.045 发
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 明
+....\TU/FandolSong(0)/m/n/12.045 明
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 专
+....\TU/FandolSong(0)/m/n/12.045 专
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 利
+....\TU/FandolSong(0)/m/n/12.045 利
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 申
+....\TU/FandolSong(0)/m/n/12.045 申
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 请
+....\TU/FandolSong(0)/m/n/12.045 请
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 号
+....\TU/FandolSong(0)/m/n/12.045 号
 ....\TU/texgyretermes(0)/m/n/12.045 )
 ....\kern -0.00021
 ....\kern 0.00021

--- a/testfiles/package-amsthm.tlg
+++ b/testfiles/package-amsthm.tlg
@@ -1,8 +1,8 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 第1章
-LaTeX Font Warning: Font shape `TU/FandolHei-Regular(0)/m/it' undefined
-(Font)              using `TU/FandolHei-Regular(0)/m/n' instead on input line ....
+LaTeX Font Warning: Font shape `TU/FandolHei(0)/m/it' undefined
+(Font)              using `TU/FandolHei(0)/m/n' instead on input line ....
 LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
 (Font)              scaled to size 12.04628pt on input line ....
 LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
@@ -59,17 +59,17 @@ Completed box being shipped out [1]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 181.77757fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 1
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 定
+..........\TU/FandolSong(0)/m/n/10.53937 定
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -110,17 +110,17 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 3.50108
 ...\hbox(12.55891+2.8426)x426.79135, glue set 164.31633fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 第
+....\TU/FandolHei(0)/m/n/16.06 第
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 1
 ....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/FandolHei-Regular(0)/m/n/16.06 章
+....\TU/FandolHei(0)/m/n/16.06 章
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 定
+....\TU/FandolHei(0)/m/n/16.06 定
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 理
+....\TU/FandolHei(0)/m/n/16.06 理
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -132,9 +132,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 7.77707
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 定
+....\TU/FandolHei(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 理
+....\TU/FandolHei(0)/m/n/12.045 理
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -143,7 +143,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -152,183 +152,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -351,13 +351,13 @@ Completed box being shipped out [1]
 .....\hbox(8.9374+1.95128)x40.95291
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 证
+......\TU/FandolHei(0)/m/n/12.045 证
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 明
+......\TU/FandolHei(0)/m/n/12.045 明
 ......\kern -0.00017
 ......\kern 0.00017
 ......\penalty 10000
-......\TU/FandolSong-Regular(0)/m/it/12.045 ：
+......\TU/FandolSong(0)/m/it/12.045 ：
 ......\rule(0.0+0.0)x-8.39537
 ......\kern 0.00052
 ......\kern -0.00052
@@ -367,182 +367,182 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 295.48882fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -570,9 +570,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 假
+....\TU/FandolHei(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 设
+....\TU/FandolHei(0)/m/n/12.045 设
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -581,7 +581,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -590,183 +590,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -784,9 +784,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 公
+....\TU/FandolHei(0)/m/n/12.045 公
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 理
+....\TU/FandolHei(0)/m/n/12.045 理
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -795,7 +795,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -804,183 +804,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -998,9 +998,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 猜
+....\TU/FandolHei(0)/m/n/12.045 猜
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 想
+....\TU/FandolHei(0)/m/n/12.045 想
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1009,7 +1009,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -1018,183 +1018,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1212,9 +1212,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 推
+....\TU/FandolHei(0)/m/n/12.045 推
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 论
+....\TU/FandolHei(0)/m/n/12.045 论
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1223,7 +1223,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -1232,183 +1232,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1426,9 +1426,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 定
+....\TU/FandolHei(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 义
+....\TU/FandolHei(0)/m/n/12.045 义
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1437,7 +1437,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -1446,183 +1446,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1640,7 +1640,7 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 例
+....\TU/FandolHei(0)/m/n/12.045 例
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1649,7 +1649,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -1658,183 +1658,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 302.05334fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1852,9 +1852,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 练
+....\TU/FandolHei(0)/m/n/12.045 练
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 习
+....\TU/FandolHei(0)/m/n/12.045 习
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1863,7 +1863,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -1872,183 +1872,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2066,9 +2066,9 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 引
+....\TU/FandolHei(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 理
+....\TU/FandolHei(0)/m/n/12.045 理
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2077,7 +2077,7 @@ Completed box being shipped out [1]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -2086,183 +2086,183 @@ Completed box being shipped out [1]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2405,9 +2405,9 @@ Completed box being shipped out [2]
 ...\glue(\topskip) 2.54468
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 问
+....\TU/FandolHei(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 题
+....\TU/FandolHei(0)/m/n/12.045 题
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2416,7 +2416,7 @@ Completed box being shipped out [2]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -2425,183 +2425,183 @@ Completed box being shipped out [2]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2619,9 +2619,9 @@ Completed box being shipped out [2]
 ...\glue(\baselineskip) 8.21068
 ...\hbox(9.53964+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 命
+....\TU/FandolHei(0)/m/n/12.045 命
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 题
+....\TU/FandolHei(0)/m/n/12.045 题
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2630,7 +2630,7 @@ Completed box being shipped out [2]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -2639,183 +2639,183 @@ Completed box being shipped out [2]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2833,9 +2833,9 @@ Completed box being shipped out [2]
 ...\glue(\baselineskip) 8.295
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
-....\TU/FandolHei-Regular(0)/m/n/12.045 注
+....\TU/FandolHei(0)/m/n/12.045 注
 ....\glue 0.0 plus 0.52307
-....\TU/FandolHei-Regular(0)/m/n/12.045 释
+....\TU/FandolHei(0)/m/n/12.045 释
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2844,7 +2844,7 @@ Completed box being shipped out [2]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\penalty 10000
-....\TU/FandolHei-Regular(0)/m/n/12.045 ：
+....\TU/FandolHei(0)/m/n/12.045 ：
 ....\rule(0.0+0.0)x-8.52786
 ....\kern 0.00052
 ....\kern -0.00052
@@ -2853,183 +2853,183 @@ Completed box being shipped out [2]
 ....\glue 8.52786 minus 6.0225
 ....\glue 6.02249
 ....\special{color pop}
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047

--- a/testfiles/package-ntheorem.tlg
+++ b/testfiles/package-ntheorem.tlg
@@ -57,17 +57,17 @@ Completed box being shipped out [1]
 .........\hbox(9.59079+4.1104)x426.79135, glue set 181.77757fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 第
+..........\TU/FandolSong(0)/m/n/10.53937 第
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 1
 ..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 章
+..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 10.53937
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 定
+..........\TU/FandolSong(0)/m/n/10.53937 定
 ..........\glue 0.0 plus 0.41463
-..........\TU/FandolSong-Regular(0)/m/n/10.53937 理
+..........\TU/FandolSong(0)/m/n/10.53937 理
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\rule(9.59079+4.1104)x0.0
@@ -108,17 +108,17 @@ Completed box being shipped out [1]
 ...\glue(\baselineskip) 3.50108
 ...\hbox(12.55891+2.8426)x426.79135, glue set 164.31633fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei-Regular(0)/m/n/16.06 第
+....\TU/FandolHei(0)/m/n/16.06 第
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 1
 ....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/FandolHei-Regular(0)/m/n/16.06 章
+....\TU/FandolHei(0)/m/n/16.06 章
 ....\kern -0.00017
 ....\kern 0.00017
 ....\glue 16.06
-....\TU/FandolHei-Regular(0)/m/n/16.06 定
+....\TU/FandolHei(0)/m/n/16.06 定
 ....\glue 0.0 plus 1.0538
-....\TU/FandolHei-Regular(0)/m/n/16.06 理
+....\TU/FandolHei(0)/m/n/16.06 理
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -138,9 +138,9 @@ Completed box being shipped out [1]
 .....\hbox(9.19034+1.89105)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 定
+......\TU/FandolHei(0)/m/n/12.045 定
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 理
+......\TU/FandolHei(0)/m/n/12.045 理
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -151,7 +151,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -161,183 +161,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -363,191 +363,191 @@ Completed box being shipped out [1]
 .....\hbox(8.9374+1.95128)x28.90791
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 证
+......\TU/FandolHei(0)/m/n/12.045 证
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 明
+......\TU/FandolHei(0)/m/n/12.045 明
 ......\kern -0.00017
 ......\kern 0.00017
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set 0.3217
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 319.57881fill
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -579,9 +579,9 @@ Completed box being shipped out [1]
 .....\hbox(9.25056+2.07173)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 假
+......\TU/FandolHei(0)/m/n/12.045 假
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 设
+......\TU/FandolHei(0)/m/n/12.045 设
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -592,7 +592,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -602,183 +602,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -804,9 +804,9 @@ Completed box being shipped out [1]
 .....\hbox(8.92534+1.95128)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 公
+......\TU/FandolHei(0)/m/n/12.045 公
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 理
+......\TU/FandolHei(0)/m/n/12.045 理
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -817,7 +817,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -827,183 +827,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1029,9 +1029,9 @@ Completed box being shipped out [1]
 .....\hbox(9.3951+2.13194)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 猜
+......\TU/FandolHei(0)/m/n/12.045 猜
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 想
+......\TU/FandolHei(0)/m/n/12.045 想
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1042,7 +1042,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -1052,183 +1052,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1254,9 +1254,9 @@ Completed box being shipped out [1]
 .....\hbox(9.41919+2.07173)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 推
+......\TU/FandolHei(0)/m/n/12.045 推
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 论
+......\TU/FandolHei(0)/m/n/12.045 论
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1267,7 +1267,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -1277,183 +1277,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1479,9 +1479,9 @@ Completed box being shipped out [1]
 .....\hbox(9.25056+1.89105)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 定
+......\TU/FandolHei(0)/m/n/12.045 定
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 义
+......\TU/FandolHei(0)/m/n/12.045 义
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1492,7 +1492,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -1502,183 +1502,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1704,7 +1704,7 @@ Completed box being shipped out [1]
 .....\hbox(9.20238+2.10786)x48.99898
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 例
+......\TU/FandolHei(0)/m/n/12.045 例
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1715,7 +1715,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -1725,183 +1725,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 302.05334fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -1927,9 +1927,9 @@ Completed box being shipped out [1]
 .....\hbox(9.38306+1.95128)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 练
+......\TU/FandolHei(0)/m/n/12.045 练
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 习
+......\TU/FandolHei(0)/m/n/12.045 习
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -1940,7 +1940,7 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -1950,183 +1950,183 @@ Completed box being shipped out [1]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2277,9 +2277,9 @@ Completed box being shipped out [2]
 .....\hbox(9.0217+2.03558)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 引
+......\TU/FandolHei(0)/m/n/12.045 引
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 理
+......\TU/FandolHei(0)/m/n/12.045 理
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2290,7 +2290,7 @@ Completed box being shipped out [2]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -2300,183 +2300,183 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2502,9 +2502,9 @@ Completed box being shipped out [2]
 .....\hbox(9.03375+1.98741)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 问
+......\TU/FandolHei(0)/m/n/12.045 问
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 题
+......\TU/FandolHei(0)/m/n/12.045 题
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2515,7 +2515,7 @@ Completed box being shipped out [2]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -2525,183 +2525,183 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2727,9 +2727,9 @@ Completed box being shipped out [2]
 .....\hbox(9.53964+2.144)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 命
+......\TU/FandolHei(0)/m/n/12.045 命
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 题
+......\TU/FandolHei(0)/m/n/12.045 题
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2740,7 +2740,7 @@ Completed box being shipped out [2]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -2750,183 +2750,183 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047
@@ -2952,9 +2952,9 @@ Completed box being shipped out [2]
 .....\hbox(9.33487+2.144)x61.04398
 ......\special{color push gray 0}
 ......\glue 4.81792
-......\TU/FandolHei-Regular(0)/m/n/12.045 注
+......\TU/FandolHei(0)/m/n/12.045 注
 ......\glue 0.0 plus 0.52307
-......\TU/FandolHei-Regular(0)/m/n/12.045 释
+......\TU/FandolHei(0)/m/n/12.045 释
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2965,7 +2965,7 @@ Completed box being shipped out [2]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\penalty 10000
-......\TU/FandolHei-Regular(0)/m/n/12.045 ：
+......\TU/FandolHei(0)/m/n/12.045 ：
 ......\rule(0.0+0.0)x-8.52786
 ......\kern 0.00052
 ......\kern -0.00052
@@ -2975,183 +2975,183 @@ Completed box being shipped out [2]
 ......\special{color pop}
 .....\glue 4.81792
 ....\penalty 0
-....\TU/FandolSong-Regular(0)/m/n/12.045 劳
+....\TU/FandolSong(0)/m/n/12.045 劳
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 仑
+....\TU/FandolSong(0)/m/n/12.045 仑
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 衣
+....\TU/FandolSong(0)/m/n/12.045 衣
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 普
+....\TU/FandolSong(0)/m/n/12.045 普
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 桑
+....\TU/FandolSong(0)/m/n/12.045 桑
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 认
+....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 至
+....\TU/FandolSong(0)/m/n/12.045 至
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 将
+....\TU/FandolSong(0)/m/n/12.045 将
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 指
+....\TU/FandolSong(0)/m/n/12.045 指
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 点
+....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 效
+....\TU/FandolSong(0)/m/n/12.045 效
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 则
+....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 机
+....\TU/FandolSong(0)/m/n/12.045 机
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 最
+....\TU/FandolSong(0)/m/n/12.045 最
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 你
+....\TU/FandolSong(0)/m/n/12.045 你
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 更
+....\TU/FandolSong(0)/m/n/12.045 更
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 枝
+....\TU/FandolSong(0)/m/n/12.045 枝
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 想
+....\TU/FandolSong(0)/m/n/12.045 想
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 极
+....\TU/FandolSong(0)/m/n/12.045 极
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 整
+....\TU/FandolSong(0)/m/n/12.045 整
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 月
+....\TU/FandolSong(0)/m/n/12.045 月
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 正
+....\TU/FandolSong(0)/m/n/12.045 正
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 进
+....\TU/FandolSong(0)/m/n/12.045 进
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 好
+....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 志
+....\TU/FandolSong(0)/m/n/12.045 志
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 次
+....\TU/FandolSong(0)/m/n/12.045 次
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
 ...\hbox(9.50351+2.32468)x426.79135, glue set - 0.28346
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 般
+....\TU/FandolSong(0)/m/n/12.045 般
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 段
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 然
+....\TU/FandolSong(0)/m/n/12.045 然
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 取
+....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 向
+....\TU/FandolSong(0)/m/n/12.045 向
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 使
+....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 张
+....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 规
+....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 军
+....\TU/FandolSong(0)/m/n/12.045 军
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 证
+....\TU/FandolSong(0)/m/n/12.045 证
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 回
+....\TU/FandolSong(0)/m/n/12.045 回
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 世
+....\TU/FandolSong(0)/m/n/12.045 世
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 市
+....\TU/FandolSong(0)/m/n/12.045 市
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 总
+....\TU/FandolSong(0)/m/n/12.045 总
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 李
+....\TU/FandolSong(0)/m/n/12.045 李
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 率
+....\TU/FandolSong(0)/m/n/12.045 率
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 英
+....\TU/FandolSong(0)/m/n/12.045 英
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 茄
+....\TU/FandolSong(0)/m/n/12.045 茄
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 持
+....\TU/FandolSong(0)/m/n/12.045 持
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 伴
+....\TU/FandolSong(0)/m/n/12.045 伴
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\glue 7.75697 minus 6.02249
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 阶
+....\TU/FandolSong(0)/m/n/12.045 阶
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 千
+....\TU/FandolSong(0)/m/n/12.045 千
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 样
+....\TU/FandolSong(0)/m/n/12.045 样
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 响
+....\TU/FandolSong(0)/m/n/12.045 响
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 领
+....\TU/FandolSong(0)/m/n/12.045 领
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 交
+....\TU/FandolSong(0)/m/n/12.045 交
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 出
+....\TU/FandolSong(0)/m/n/12.045 出
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 器
+....\TU/FandolSong(0)/m/n/12.045 器
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 程
+....\TU/FandolSong(0)/m/n/12.045 程
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 办
+....\TU/FandolSong(0)/m/n/12.045 办
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.2709
 ...\hbox(9.47942+2.32468)x426.79135, glue set 290.00835fil
-....\TU/FandolSong-Regular(0)/m/n/12.045 管
+....\TU/FandolSong(0)/m/n/12.045 管
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 据
+....\TU/FandolSong(0)/m/n/12.045 据
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 家
+....\TU/FandolSong(0)/m/n/12.045 家
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 元
+....\TU/FandolSong(0)/m/n/12.045 元
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 写
+....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 ，
+....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 名
+....\TU/FandolSong(0)/m/n/12.045 名
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 其
+....\TU/FandolSong(0)/m/n/12.045 其
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 直
+....\TU/FandolSong(0)/m/n/12.045 直
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 金
+....\TU/FandolSong(0)/m/n/12.045 金
 ....\glue 0.0 plus 0.52307
-....\TU/FandolSong-Regular(0)/m/n/12.045 团
+....\TU/FandolSong(0)/m/n/12.045 团
 ....\penalty 10000
-....\TU/FandolSong-Regular(0)/m/n/12.045 。
+....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
 ....\kern 0.00047
 ....\kern -0.00047

--- a/testfiles/package-siunitx.tlg
+++ b/testfiles/package-siunitx.tlg
@@ -272,7 +272,7 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(1)/m/n/12.045 glyph#122
 .....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -305,7 +305,7 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(1)/m/n/12.045 glyph#122
 .....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -358,7 +358,7 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(1)/m/n/12.045 glyph#76
 .....\mathoff
 ....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong-Regular(0)/m/n/12.045 和
+....\TU/FandolSong(0)/m/n/12.045 和
 ....\kern -0.00018
 ....\kern 0.00018
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -393,7 +393,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 3.34851 minus 1.67426
 ....\rule(0.0+0.0)x-3.34851
-....\TU/FandolSong-Regular(0)/m/n/12.045 ～
+....\TU/FandolSong(0)/m/n/12.045 ～
 ....\rule(0.0+0.0)x-3.34851
 ....\kern 0.0002
 ....\kern -0.0002
@@ -434,7 +434,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 3.34851 minus 1.67426
 ....\rule(0.0+0.0)x-3.34851
-....\TU/FandolSong-Regular(0)/m/n/12.045 ～
+....\TU/FandolSong(0)/m/n/12.045 ～
 ....\rule(0.0+0.0)x-3.34851
 ....\kern 0.0002
 ....\kern -0.0002

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1166,6 +1166,64 @@
       english,
     },
   },
+%    \end{macrocode}
+%
+% 字体
+%    \begin{macrocode}
+  fontset = {
+    choices = {
+      windows,
+      mac,
+      ubuntu,
+      fandol,
+      none,
+    },
+    default = none,
+  },
+  system = {
+    choices = {
+      mac,
+      unix,
+      windows,
+      auto,
+    },
+    default = auto,
+  },
+  font = {
+    choices = {
+      times,
+      termes,
+      xits,
+      libertinus,
+      lm,
+      auto,
+      none,
+    },
+    default = auto,
+  },
+  cjk-font = {
+    name = cjk@font,
+    choices = {
+      windows,
+      mac,
+      noto,
+      fandol,
+      auto,
+      none,
+    },
+    default = auto,
+  },
+  math-font = {
+    name = math@font,
+    choices = {
+      xits,
+      stix,
+      libertinus,
+      lm,
+      none,
+    },
+    default = xits,
+  },
 }
 \newif\ifthu@degree@graduate
 \newcommand\thu@set@graduate{%
@@ -1216,7 +1274,7 @@
 % 使用 \pkg{ctexbook} 类，优于调用 \pkg{ctex} 宏包。
 %    \begin{macrocode}
 \PassOptionsToPackage{quiet}{xeCJK}
-\LoadClass[a4paper,UTF8,zihao=-4,scheme=plain]{ctexbook}[2017/04/01]
+\LoadClass[a4paper,UTF8,zihao=-4,scheme=plain,fontset=none]{ctexbook}[2017/04/01]
 %    \end{macrocode}
 %
 %
@@ -1422,39 +1480,214 @@
 % \label{sec:font}
 % 使用 \pkg{fontspec} 配置字体。
 %    \begin{macrocode}
-\newcommand\thu@fontset{\csname g__ctex_fontset_tl\endcsname}
-\ifthenelse{\equal{\thu@fontset}{fandol}}{
-  \setmainfont[
-    Extension      = .otf,
-    UprightFont    = *-regular,
-    BoldFont       = *-bold,
-    ItalicFont     = *-italic,
-    BoldItalicFont = *-bolditalic,
-  ]{texgyretermes}
-  \setsansfont[
-    Extension      = .otf,
-    UprightFont    = *-regular,
-    BoldFont       = *-bold,
-    ItalicFont     = *-italic,
-    BoldItalicFont = *-bolditalic,
-  ]{texgyreheros}
-  \setmonofont[
-    Extension      = .otf,
-    UprightFont    = *-regular,
-    BoldFont       = *-bold,
-    ItalicFont     = *-italic,
-    BoldItalicFont = *-bolditalic,
-    Scale          = MatchLowercase,
-  ]{texgyrecursor}
-}{
-  \setmainfont{Times New Roman}
-  \setsansfont{Arial}
-  \ifthenelse{\equal{\thu@fontset}{mac}}{
-    \setmonofont[Scale=MatchLowercase]{Menlo}
-  }{
-    \setmonofont[Scale=MatchLowercase]{Courier New}
+\ifthu@fontset@mac
+  \thusetup{
+    font     = times,
+    cjk-font = mac,
   }
+\else
+  \ifthu@fontset@windows
+    \thusetup{
+      font     = times,
+      cjk-font = windows,
+    }
+  \else
+    \ifthu@fontset@fandol
+      \thusetup{
+        font     = termes,
+        cjk-font = fandol,
+      }
+    \else
+      \ifthu@fontset@ubuntu
+        \thusetup{
+          font     = termes,
+          cjk-font = noto,
+        }
+      \fi
+    \fi
+  \fi
+\fi
+%    \end{macrocode}
+%
+% 检测系统
+%    \begin{macrocode}
+\ifthu@system@auto
+  \IfFileExists{/System/Library/Fonts/Menlo.ttc}{
+    \thusetup{system = mac}
+  }{
+    \IfFileExists{/dev/null}{
+      \IfFileExists{null:}{
+        \thusetup{system = windows}
+      }{
+        \thusetup{system = unix}
+      }
+    }{
+      \thusetup{system = windows}
+    }
+  }
+\fi
+%    \end{macrocode}
+%
+% XITS 字体于 2018-10-03 更改了字体的文件名，所以需要判断。
+% 原文件名为 \file{xits-regular.otf}、\file{xits-math.otf} 等，
+% 后改为 \file{XITS-Regular.otf}、\file{XITSMath-Regular.otf} 等。
+%
+% Libertinus 字体同样。
+%    \begin{macrocode}
+\let\thu@font@family@xits\@empty
+\newcommand\thu@set@xits@names{%
+  \ifx\thu@font@family@xits\@empty
+    \IfFontExistsTF{XITSMath-Regular.otf}{%
+      \gdef\thu@font@family@xits{XITS}%
+      \gdef\thu@font@style@xits@rm{Regular}%
+      \gdef\thu@font@style@xits@bf{Bold}%
+      \gdef\thu@font@style@xits@it{Italic}%
+      \gdef\thu@font@style@xits@bfit{BoldItalic}%
+      \gdef\thu@font@name@xits@math@rm{XITSMath-Regular}%
+      \gdef\thu@font@name@xits@math@bf{XITSMath-Bold}%
+    }{%
+      \gdef\thu@font@family@xits{xits}%
+      \gdef\thu@font@style@xits@rm{regular}%
+      \gdef\thu@font@style@xits@bf{bold}%
+      \gdef\thu@font@style@xits@it{italic}%
+      \gdef\thu@font@style@xits@bfit{bolditalic}%
+      \gdef\thu@font@name@xits@math@rm{xits-math}%
+      \gdef\thu@font@name@xits@math@bf{xits-mathbold}%
+    }%
+  \fi
 }
+\let\thu@font@family@libertinus\@empty
+\newcommand\thu@set@libertinus@names{%
+  \ifx\thu@font@family@libertinus\@empty
+    \IfFontExistsTF{LibertinusSerif-Regular.otf}{%
+      \gdef\thu@font@family@libertinus@serif{LibertinusSerif}%
+      \gdef\thu@font@family@libertinus@sans{LibertinusSans}%
+      \gdef\thu@font@name@libertinus@math{LibertinusMath-Regular}%
+      \gdef\thu@font@style@libertinus@rm{Regular}%
+      \gdef\thu@font@style@libertinus@bf{Bold}%
+      \gdef\thu@font@style@libertinus@it{Italic}%
+      \gdef\thu@font@style@libertinus@bfit{BoldItalic}%
+    }{%
+      \gdef\thu@font@family@libertinus@serif{libertinusserif}%
+      \gdef\thu@font@family@libertinus@sans{libertinussans}%
+      \gdef\thu@font@name@libertinus@math{libertinusmath-regular}%
+      \gdef\thu@font@style@libertinus@rm{regular}%
+      \gdef\thu@font@style@libertinus@bf{bold}%
+      \gdef\thu@font@style@libertinus@it{italic}%
+      \gdef\thu@font@style@libertinus@bfit{bolditalic}%
+    }%
+  \fi
+}
+%    \end{macrocode}
+%
+% 《撰写手册》要求西文字体使用 Times New Roman 和 Arial，
+% 但是在 Linux 下没有这两个字体，所以使用它们的克隆版 TeX Gyre Termes 和
+% TeX Gyre Heros。
+%    \begin{macrocode}
+\ifthu@font@auto
+  \ifthu@system@unix
+    \thusetup{font=termes}
+  \else
+    \thusetup{font=times}
+  \fi
+\fi
+\newcommand\thu@load@font@times{%
+  \setmainfont{Times New Roman}%
+  \setsansfont{Arial}%
+  \ifthu@system@mac
+    \setmonofont{Menlo}[Scale = MatchLowercase]%
+  \else
+    \setmonofont{Courier New}[Scale = MatchLowercase]%
+  \fi
+}
+\newcommand\thu@load@font@termes{%
+  \setmainfont{texgyretermes}[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]%
+  \thu@load@texgyre@sans@mono
+}
+\newcommand\thu@load@texgyre@sans@mono{%
+  \setsansfont{texgyreheros}[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]%
+  \setmonofont{texgyrecursor}[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]%
+}
+\newcommand\thu@load@font@xits{%
+  \thu@set@xits@names
+  \setmainfont{\thu@font@family@xits}[
+    Extension      = .otf,
+    UprightFont    = *-\thu@font@style@xits@rm,
+    BoldFont       = *-\thu@font@style@xits@bf,
+    ItalicFont     = *-\thu@font@style@xits@it,
+    BoldItalicFont = *-\thu@font@style@xits@bfit,
+  ]%
+  \thu@load@texgyre@sans@mono
+}
+\newcommand\thu@load@font@libertinus{%
+  \thu@set@libertinus@names
+  \setmainfont{\thu@font@family@libertinus@serif}[
+    Extension      = .otf,
+    UprightFont    = *-\thu@font@style@libertinus@rm,
+    BoldFont       = *-\thu@font@style@libertinus@bf,
+    ItalicFont     = *-\thu@font@style@libertinus@it,
+    BoldItalicFont = *-\thu@font@style@libertinus@bfit,
+  ]%
+  \setsansfont{\thu@font@family@libertinus@sans}[
+    Extension      = .otf,
+    UprightFont    = *-\thu@font@style@libertinus@rm,
+    BoldFont       = *-\thu@font@style@libertinus@bf,
+    ItalicFont     = *-\thu@font@style@libertinus@it,
+  ]%
+  \setmonofont{lmmonolt10}[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-oblique,
+    BoldItalicFont = *-boldoblique,
+  ]%
+}
+\@namedef{thu@load@font@lm}{%
+  \setmainfont{lmroman10}[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]%
+  \setsansfont{lmsans10}[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-oblique,
+    BoldItalicFont = *-boldoblique,
+  ]%
+  \setmonofont{lmmonolt10}[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-oblique,
+    BoldItalicFont = *-boldoblique,
+  ]%
+}
+\newcommand\thu@load@font{%
+  \@nameuse{thu@load@font@\thu@font}%
+}
+\thu@load@font
+\thu@option@hook{font}{\thu@load@font}
 %    \end{macrocode}
 %
 % 使用 \pkg{unicode-math} 配置数学字体
@@ -1465,59 +1698,177 @@
   nabla      = upright,
   partial    = upright,
 }
-\IfFontExistsTF{XITSMath-Regular.otf}{
-  \setmathfont[
+\newcommand\thu@load@math@font@xits{%
+  \thu@set@xits@names
+  \setmathfont{\thu@font@name@xits@math@rm}[
     Extension    = .otf,
-    BoldFont     = XITSMath-Bold,
+    BoldFont     = \thu@font@name@xits@math@bf,
     StylisticSet = 8,
-  ]{XITSMath-Regular}
-  \setmathfont[range={cal,bfcal},StylisticSet=1]{XITSMath-Regular.otf}
-}{
-  \setmathfont[
+  ]%
+  \setmathfont{\thu@font@name@xits@math@rm}[
     Extension    = .otf,
-    BoldFont     = *bold,
+    StylisticSet = 1,
+    range        = {cal,bfcal},
+  ]%
+}
+\newcommand\thu@load@math@font@stix{%
+  \setmathfont{STIX2Math}[
+    Extension    = .otf,
     StylisticSet = 8,
-  ]{xits-math}
-  \setmathfont[range={cal,bfcal},StylisticSet=1]{xits-math.otf}
+  ]%
+  \setmathfont{STIX2Math}[
+    Extension    = .otf,
+    StylisticSet = 1,
+    range        = {cal,bfcal},
+  ]%
+}
+\newcommand\thu@load@math@font@libertinus{%
+  \thu@set@libertinus@names
+  \setmathfont{\thu@font@name@libertinus@math .otf}%
+}
+\newcommand\thu@load@math@font@lm{%
+  \setmathfont{latinmodern-math.otf}%
+}
+\newcommand\thu@load@math@font{%
+  \csname thu@load@math@font@\thu@math@font\endcsname
+}
+\thu@load@math@font
+\thu@option@hook{math-font}{\thu@load@math@font}
+%    \end{macrocode}
+%
+% 中文字体
+%    \begin{macrocode}
+\ifthu@cjk@font@auto
+  \ifthu@system@mac
+    \thusetup{cjk-font = mac}
+  \else
+    \ifthu@system@windows
+      \thusetup{cjk-font = windows}
+    \else
+      \IfFontExistsTF{Noto Serif CJK SC}{
+        \thusetup{cjk-font = noto}
+      }{
+        \thusetup{cjk-font = fandol}
+      }
+    \fi
+  \fi
+\fi
+\newcommand\thu@load@cjk@font@windows{%
+  \xeCJKsetup{EmboldenFactor=2}
+  \setCJKmainfont{SimSun}[
+    AutoFakeBold = true,
+    ItalicFont   = KaiTi,
+  ]%
+  \setCJKsansfont{SimHei}[AutoFakeBold]%
+  \setCJKmonofont{FangSong}%
+  \setCJKfamilyfont{zhsong}{SimSun}[AutoFakeBold]%
+  \setCJKfamilyfont{zhhei}{SimHei}[AutoFakeBold]%
+  \setCJKfamilyfont{zhkai}{KaiTi}%
+  \setCJKfamilyfont{zhfs}{FangSong}%
+}
+\newcommand\thu@load@cjk@font@mac{%
+  \setCJKmainfont{Songti SC}[
+    UprightFont    = * Light,
+    BoldFont       = * Bold,
+    ItalicFont     = Kaiti SC,
+    BoldItalicFont = Kaiti SC Bold,
+  ]%
+  \setCJKsansfont{Heiti SC}[BoldFont=* Medium]%
+  \setCJKmonofont{STFangsong}
+  \setCJKfamilyfont{zhsong}{Songti SC}[
+    UprightFont = * Light,
+      BoldFont  = * Bold,
+  ]%
+  \setCJKfamilyfont{zhhei}{Heiti SC}[
+    UprightFont = * Light,
+    BoldFont    = * Medium,
+  ]%
+  \setCJKfamilyfont{zhfs}{STFangsong}%
+  \setCJKfamilyfont{zhkai}{Kaiti SC}[BoldFont = * Bold]%
+  \setCJKfamilyfont{zhli}{Baoli SC}%
+  \setCJKfamilyfont{zhyuan}{Yuanyi SC}[
+    UprightFont = * Light,
+    BoldFont    = * Bold,
+  ]%
+  \xeCJKsetwidth{‘’“”}{1em}%
 }
 %    \end{macrocode}
 %
-% 在使用 Windows Vista 或之后版本的系统时，\pkg{ctex} 宏包会默认使用微软雅黑字体，
-% 这可能会导致审查不合格。下面设置适合印刷的黑体，同时保持跨平台兼容性。
+% 注意 Noto CJK 的 regular 字重名字不带“Regular”。
 %    \begin{macrocode}
-\ifthenelse{\equal{\thu@fontset}{windows}}{
-  \xeCJKsetup{EmboldenFactor=2}
-  \IfFileExists{C:/bootfont.bin}{
-    \setCJKmainfont[AutoFakeBold,ItalicFont=KaiTi_GB2312]{SimSun}
-    \setCJKfamilyfont{zhkai}[AutoFakeBold]{KaiTi_GB2312}
-  }{
-    \setCJKmainfont[AutoFakeBold,ItalicFont=KaiTi]{SimSun}
-    \setCJKfamilyfont{zhkai}[AutoFakeBold]{KaiTi}
-  }
-  \setCJKsansfont[AutoFakeBold]{SimHei}
-  \setCJKfamilyfont{zhsong}[AutoFakeBold]{SimSun}
-  \setCJKfamilyfont{zhhei}[AutoFakeBold]{SimHei}
-}{}
-%    \end{macrocode}
-%
-% 类似地，\pkg{ctex} 2.4.14 开始在 macOS 下自动调用苹方黑体，所以必进行调整。
-%    \begin{macrocode}
-\ifthenelse{\equal{\thu@fontset}{mac}}{
-  \setCJKmainfont[
-         UprightFont = * Light,
-            BoldFont = * Bold,
-          ItalicFont = Kaiti SC,
-      BoldItalicFont = Kaiti SC Bold,
-    ]{Songti SC}
-  \setCJKsansfont[BoldFont=* Medium]{Heiti SC}
-  \setCJKfamilyfont{zhsong}[
-         UprightFont = * Light,
-            BoldFont = * Bold,
-    ]{Songti SC}
-  \setCJKfamilyfont{zhhei}[BoldFont=* Medium]{Heiti SC}
-  \setCJKfamilyfont{zhkai}[BoldFont=* Bold]{Kaiti SC}
-  \xeCJKsetwidth{‘’“”}{1em}
-}{}
+\newcommand\thu@load@cjk@font@noto{%
+  \setCJKmainfont{Noto Serif CJK SC}[
+    UprightFont    = * Light,
+    BoldFont       = * Bold,
+    ItalicFont     = FandolKai-Regular,
+    ItalicFeatures = {Extension = .otf},
+  ]%
+  \setCJKsansfont{Noto Sans CJK SC}[
+    BoldFont    = * Medium,
+  ]%
+  \setCJKmonofont{Noto Sans Mono CJK SC}%
+  \setCJKfamilyfont{zhsong}{Noto Serif CJK SC}[
+    UprightFont = * Light,
+    UprightFont = * Bold,
+  ]%
+  \setCJKfamilyfont{zhhei}{Noto Sans CJK SC}[
+    BoldFont    = * Medium,
+  ]%
+  \setCJKfamilyfont{zhfs}{FandolFang}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+  ]%
+  \setCJKfamilyfont{zhkai}{FandolKai}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+  ]%
+}
+\newcommand\thu@load@cjk@font@fandol{%
+  \setCJKmainfont{FandolSong}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+    BoldFont    = *-Bold,
+    ItalicFont  = FandolKai-Regular,
+  ]%
+  \setCJKsansfont{FandolHei}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+    BoldFont    = *-Bold,
+  ]%
+  \setCJKmonofont{FandolFang}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+  ]%
+  \setCJKfamilyfont{zhsong}{FandolSong}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+    BoldFont    = *-Bold,
+  ]%
+  \setCJKfamilyfont{zhhei}{FandolHei}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+    BoldFont    = *-Bold,
+  ]%
+  \setCJKfamilyfont{zhfs}{FandolFang}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+  ]%
+  \setCJKfamilyfont{zhkai}{FandolKai}[
+    Extension   = .otf,
+    UprightFont = *-Regular,
+  ]%
+}
+\ifthu@cjk@font@none\else
+  \providecommand\songti{\CJKfamily{zhsong}}
+  \providecommand\heiti{\CJKfamily{zhhei}}
+  \providecommand\fangsong{\CJKfamily{zhfs}}
+  \providecommand\kaishu{\CJKfamily{zhkai}}
+\fi
+\newcommand\thu@load@cjk@font{%
+  \@nameuse{thu@load@cjk@font@\thu@cjk@font}%
+}
+\thu@load@cjk@font
+\thu@option@hook{cjk-font}{\thu@load@cjk@font}
 %    \end{macrocode}
 %
 % \begin{macro}{\normalsize}
@@ -1852,19 +2203,28 @@
 % \begin{macro}{\thu@textcircled}
 % 生成带圈的脚注数字，最多处理到 10。
 %    \begin{macrocode}
-\ifthenelse{\equal{\thu@fontset}{mac}}{
-  \newfontfamily\thu@circlefont{Songti SC Light}
-}{
-  \ifthenelse{\equal{\thu@fontset}{windows}}{
-    \newfontfamily\thu@circlefont{SimSun}
-  }{
-    \IfFontExistsTF{XITS-Regular.otf}{
-      \newfontfamily\thu@circlefont{XITS-Regular.otf}
-    }{
-      \newfontfamily\thu@circlefont{xits-regular.otf}
-    }
-  }
-}
+\ifthu@font@times
+  \ifthu@cjk@font@mac
+    \newfontfamily\thu@circlefont{Songti SC Light}
+  \else
+    \ifthu@cjk@font@windows
+      \newfontfamily\thu@circlefont{SimSun}
+    \fi
+  \fi
+\else
+  \ifthu@font@xits
+    \let\thu@circlefont\relax
+  \else
+    \ifthu@font@libertinus
+      \let\thu@circlefont\relax
+    \else
+      \thu@set@xits@names
+      \newfontfamily\thu@circlefont{%
+        \thu@font@family@xits-\thu@font@style@xits@rm .otf%
+      }
+    \fi
+  \fi
+\fi
 \def\thu@textcircled#1{%
   \ifnum\value{#1} >9%
     \thu@error{%

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -2203,28 +2203,6 @@
 % \begin{macro}{\thu@textcircled}
 % 生成带圈的脚注数字，最多处理到 10。
 %    \begin{macrocode}
-\ifthu@font@times
-  \ifthu@cjk@font@mac
-    \newfontfamily\thu@circlefont{Songti SC Light}
-  \else
-    \ifthu@cjk@font@windows
-      \newfontfamily\thu@circlefont{SimSun}
-    \fi
-  \fi
-\else
-  \ifthu@font@xits
-    \let\thu@circlefont\relax
-  \else
-    \ifthu@font@libertinus
-      \let\thu@circlefont\relax
-    \else
-      \thu@set@xits@names
-      \newfontfamily\thu@circlefont{%
-        \thu@font@family@xits-\thu@font@style@xits@rm .otf%
-      }
-    \fi
-  \fi
-\fi
 \def\thu@textcircled#1{%
   \ifnum\value{#1} >9%
     \thu@error{%
@@ -2232,7 +2210,7 @@
       Keep footnote less than 10%
     }%
   \fi
-  {\thu@circlefont\symbol{\the\numexpr\value{#1}+"245F\relax}}%
+  {\CJKfamily+{}\symbol{\the\numexpr\value{#1}+"245F\relax}}%
 }
 \renewcommand{\thefootnote}{\thu@textcircled{footnote}}
 \renewcommand{\thempfootnote}{\thu@textcircled{mpfootnote}}

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -2204,7 +2204,7 @@
 % 生成带圈的脚注数字，最多处理到 10。
 %    \begin{macrocode}
 \def\thu@textcircled#1{%
-  \ifnum\value{#1} >9%
+  \ifnum\value{#1} >10\relax
     \thu@error{%
       Too many footnotes in this page.
       Keep footnote less than 10%

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1730,7 +1730,7 @@
   \setmathfont{latinmodern-math.otf}%
 }
 \newcommand\thu@load@math@font{%
-  \csname thu@load@math@font@\thu@math@font\endcsname
+  \@nameuse{thu@load@math@font@\thu@math@font}
 }
 \thu@load@math@font
 \thu@option@hook{math-font}{\thu@load@math@font}


### PR DESCRIPTION
1. 提供 `font`, `cjk-font`, `math-font` 选项设置字体（感谢 [fduthesis](https://github.com/stone-zeng/fduthesis)）；
1. 接管 ctex 的 fontset 选项，避免在 macOS 10.15 的系统检测问题；
1. Overleaf 上会优先使用 Noto CJK 作为中文字体。
