### PR TITLE
Use l3build for tagging and archiving (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Click version names to see the code diff between versions on GitHub.
 
+## [Unreleased]
+
 ## [v6.1.0] - 2020-06-08
 ### Changed
 - 在`translation` 环境中使用 `\bibliography` 改为生成参考文献，
@@ -561,64 +563,66 @@ Click version names to see the code diff between versions on GitHub.
 - Please refer to “Bao--Pan“ version.
 
 
-[v6.1.0]: https://github.com/tuna/thuthesis/compare/v6.0.2...v6.1.0
-[v6.0.2]: https://github.com/tuna/thuthesis/compare/v6.0.1...v6.0.2
-[v6.0.1]: https://github.com/tuna/thuthesis/compare/v6.0.0...v6.0.1
-[v6.0.0]: https://github.com/tuna/thuthesis/compare/v5.5.2...v6.0.0
-[v5.5.2]: https://github.com/tuna/thuthesis/compare/v5.5.1...v5.5.2
-[v5.5.1]: https://github.com/tuna/thuthesis/compare/v5.5.0...v5.5.1
-[v5.5.0]: https://github.com/tuna/thuthesis/compare/v5.4.5...v5.5.0
-[v5.4.5]: https://github.com/tuna/thuthesis/compare/v5.4.4...v5.4.5
-[v5.4.4]: https://github.com/tuna/thuthesis/compare/v5.4.2...v5.4.4
-[v5.4.2]: https://github.com/tuna/thuthesis/compare/v5.4.1...v5.4.2
-[v5.4.1]: https://github.com/tuna/thuthesis/compare/v5.4.0...v5.4.1
-[v5.4.0]: https://github.com/tuna/thuthesis/compare/v5.3.2...v5.4.0
-[v5.3.2]: https://github.com/tuna/thuthesis/compare/v5.3.1...v5.3.2
-[v5.3.1]: https://github.com/tuna/thuthesis/compare/v5.3.0...v5.3.1
-[v5.3.0]: https://github.com/tuna/thuthesis/compare/v5.2.3...v5.3.0
-[v5.2.3]: https://github.com/tuna/thuthesis/compare/v5.2.2...v5.2.3
-[v5.2.2]: https://github.com/tuna/thuthesis/compare/v5.2.1...v5.2.2
-[v5.2.1]: https://github.com/tuna/thuthesis/compare/v5.2.0...v5.2.1
-[v5.2.0]: https://github.com/tuna/thuthesis/compare/v5.1.0...v5.2.0
-[v5.1.0]: https://github.com/tuna/thuthesis/compare/v5.0.0...v5.1.0
-[v5.0.0]: https://github.com/tuna/thuthesis/compare/v4.8.1...v5.0.0
-[v4.8.1]: https://github.com/tuna/thuthesis/compare/v4.8...v4.8.1
-[v4.8]:   https://github.com/tuna/thuthesis/compare/v4.7...v4.8
-[v4.7]:   https://github.com/tuna/thuthesis/compare/v4.6...v4.7
-[v4.6]:   https://github.com/tuna/thuthesis/compare/v4.5.2...v4.6
-[v4.5.2]: https://github.com/tuna/thuthesis/compare/v4.5.1...v4.5.2
-[v4.5.1]: https://github.com/tuna/thuthesis/compare/v4.5...v4.5.1
-[v4.5]:   https://github.com/tuna/thuthesis/compare/v4.4.4...v4.5
-[v4.4.4]: https://github.com/tuna/thuthesis/compare/v4.4.3...v4.4.4
-[v4.4.3]: https://github.com/tuna/thuthesis/compare/v4.4.2...v4.4.3
-[v4.4.2]: https://github.com/tuna/thuthesis/compare/v4.4...v4.4.2
-[v4.4]:   https://github.com/tuna/thuthesis/compare/v4.3...v4.4
-[v4.3]:   https://github.com/tuna/thuthesis/compare/v4.2...v4.3
-[v4.2]:   https://github.com/tuna/thuthesis/compare/v4.0...v4.2
-[v4.0]:   https://github.com/tuna/thuthesis/compare/v3.1...v4.0
-[v3.1]:   https://github.com/tuna/thuthesis/compare/v3.0...v3.1
-[v3.0]:   https://github.com/tuna/thuthesis/compare/v2.6.4...v3.0
-[v2.6.4]: https://github.com/tuna/thuthesis/compare/v2.6.3...v2.6.4
-[v2.6.3]: https://github.com/tuna/thuthesis/compare/v2.6.2...v2.6.3
-[v2.6.2]: https://github.com/tuna/thuthesis/compare/v2.6.1...v2.6.2
-[v2.6.1]: https://github.com/tuna/thuthesis/compare/v2.6...v2.6.1
-[v2.6]:   https://github.com/tuna/thuthesis/compare/v2.5.3...v2.6
-[v2.5.3]: https://github.com/tuna/thuthesis/compare/v2.5.2...v2.5.3
-[v2.5.2]: https://github.com/tuna/thuthesis/compare/v2.5.1...v2.5.2
-[v2.5.1]: https://github.com/tuna/thuthesis/compare/v2.5...v2.5.1
-[v2.5]:   https://github.com/tuna/thuthesis/compare/v2.4.2...v2.5
-[v2.4.2]: https://github.com/tuna/thuthesis/compare/v2.4.1...v2.4.2
-[v2.4.1]: https://github.com/tuna/thuthesis/compare/v2.4...v2.4.1
-[v2.4]:   https://github.com/tuna/thuthesis/compare/v2.3...v2.4
-[v2.3]:   https://github.com/tuna/thuthesis/compare/v2.2...v2.3
-[v2.2]:   https://github.com/tuna/thuthesis/compare/v2.1...v2.2
-[v2.1]:   https://github.com/tuna/thuthesis/compare/v2.0e...v2.1
-[v2.0e]:  https://github.com/tuna/thuthesis/compare/v2.0...v2.0e
-[v2.0]:   https://github.com/tuna/thuthesis/compare/v1.5...v2.0
-[v1.5]:   https://github.com/tuna/thuthesis/compare/v1.4rc1...v1.5
-[v1.4rc1]:https://github.com/tuna/thuthesis/compare/v1.4...v1.4rc1
-[v1.4]:   https://github.com/tuna/thuthesis/compare/v1.3...v1.4
-[v1.3]:   https://github.com/tuna/thuthesis/compare/v1.2...v1.3
-[v1.2]:   https://github.com/tuna/thuthesis/compare/v1.1...v1.2
-[v1.1]:   https://github.com/tuna/thuthesis/compare/v1.0...v1.1
-[v1.0]:   https://github.com/tuna/thuthesis/releases/tag/v1.0
+
+[Unreleased]: https://github.com/tuna/thuthesis/compare/v6.1.0...HEAD
+[v6.1.0]:     https://github.com/tuna/thuthesis/compare/v6.0.2...v6.1.0
+[v6.0.2]:     https://github.com/tuna/thuthesis/compare/v6.0.1...v6.0.2
+[v6.0.1]:     https://github.com/tuna/thuthesis/compare/v6.0.0...v6.0.1
+[v6.0.0]:     https://github.com/tuna/thuthesis/compare/v5.5.2...v6.0.0
+[v5.5.2]:     https://github.com/tuna/thuthesis/compare/v5.5.1...v5.5.2
+[v5.5.1]:     https://github.com/tuna/thuthesis/compare/v5.5.0...v5.5.1
+[v5.5.0]:     https://github.com/tuna/thuthesis/compare/v5.4.5...v5.5.0
+[v5.4.5]:     https://github.com/tuna/thuthesis/compare/v5.4.4...v5.4.5
+[v5.4.4]:     https://github.com/tuna/thuthesis/compare/v5.4.2...v5.4.4
+[v5.4.2]:     https://github.com/tuna/thuthesis/compare/v5.4.1...v5.4.2
+[v5.4.1]:     https://github.com/tuna/thuthesis/compare/v5.4.0...v5.4.1
+[v5.4.0]:     https://github.com/tuna/thuthesis/compare/v5.3.2...v5.4.0
+[v5.3.2]:     https://github.com/tuna/thuthesis/compare/v5.3.1...v5.3.2
+[v5.3.1]:     https://github.com/tuna/thuthesis/compare/v5.3.0...v5.3.1
+[v5.3.0]:     https://github.com/tuna/thuthesis/compare/v5.2.3...v5.3.0
+[v5.2.3]:     https://github.com/tuna/thuthesis/compare/v5.2.2...v5.2.3
+[v5.2.2]:     https://github.com/tuna/thuthesis/compare/v5.2.1...v5.2.2
+[v5.2.1]:     https://github.com/tuna/thuthesis/compare/v5.2.0...v5.2.1
+[v5.2.0]:     https://github.com/tuna/thuthesis/compare/v5.1.0...v5.2.0
+[v5.1.0]:     https://github.com/tuna/thuthesis/compare/v5.0.0...v5.1.0
+[v5.0.0]:     https://github.com/tuna/thuthesis/compare/v4.8.1...v5.0.0
+[v4.8.1]:     https://github.com/tuna/thuthesis/compare/v4.8...v4.8.1
+[v4.8]:       https://github.com/tuna/thuthesis/compare/v4.7...v4.8
+[v4.7]:       https://github.com/tuna/thuthesis/compare/v4.6...v4.7
+[v4.6]:       https://github.com/tuna/thuthesis/compare/v4.5.2...v4.6
+[v4.5.2]:     https://github.com/tuna/thuthesis/compare/v4.5.1...v4.5.2
+[v4.5.1]:     https://github.com/tuna/thuthesis/compare/v4.5...v4.5.1
+[v4.5]:       https://github.com/tuna/thuthesis/compare/v4.4.4...v4.5
+[v4.4.4]:     https://github.com/tuna/thuthesis/compare/v4.4.3...v4.4.4
+[v4.4.3]:     https://github.com/tuna/thuthesis/compare/v4.4.2...v4.4.3
+[v4.4.2]:     https://github.com/tuna/thuthesis/compare/v4.4...v4.4.2
+[v4.4]:       https://github.com/tuna/thuthesis/compare/v4.3...v4.4
+[v4.3]:       https://github.com/tuna/thuthesis/compare/v4.2...v4.3
+[v4.2]:       https://github.com/tuna/thuthesis/compare/v4.0...v4.2
+[v4.0]:       https://github.com/tuna/thuthesis/compare/v3.1...v4.0
+[v3.1]:       https://github.com/tuna/thuthesis/compare/v3.0...v3.1
+[v3.0]:       https://github.com/tuna/thuthesis/compare/v2.6.4...v3.0
+[v2.6.4]:     https://github.com/tuna/thuthesis/compare/v2.6.3...v2.6.4
+[v2.6.3]:     https://github.com/tuna/thuthesis/compare/v2.6.2...v2.6.3
+[v2.6.2]:     https://github.com/tuna/thuthesis/compare/v2.6.1...v2.6.2
+[v2.6.1]:     https://github.com/tuna/thuthesis/compare/v2.6...v2.6.1
+[v2.6]:       https://github.com/tuna/thuthesis/compare/v2.5.3...v2.6
+[v2.5.3]:     https://github.com/tuna/thuthesis/compare/v2.5.2...v2.5.3
+[v2.5.2]:     https://github.com/tuna/thuthesis/compare/v2.5.1...v2.5.2
+[v2.5.1]:     https://github.com/tuna/thuthesis/compare/v2.5...v2.5.1
+[v2.5]:       https://github.com/tuna/thuthesis/compare/v2.4.2...v2.5
+[v2.4.2]:     https://github.com/tuna/thuthesis/compare/v2.4.1...v2.4.2
+[v2.4.1]:     https://github.com/tuna/thuthesis/compare/v2.4...v2.4.1
+[v2.4]:       https://github.com/tuna/thuthesis/compare/v2.3...v2.4
+[v2.3]:       https://github.com/tuna/thuthesis/compare/v2.2...v2.3
+[v2.2]:       https://github.com/tuna/thuthesis/compare/v2.1...v2.2
+[v2.1]:       https://github.com/tuna/thuthesis/compare/v2.0e...v2.1
+[v2.0e]:      https://github.com/tuna/thuthesis/compare/v2.0...v2.0e
+[v2.0]:       https://github.com/tuna/thuthesis/compare/v1.5...v2.0
+[v1.5]:       https://github.com/tuna/thuthesis/compare/v1.4rc1...v1.5
+[v1.4rc1]:    https://github.com/tuna/thuthesis/compare/v1.4...v1.4rc1
+[v1.4]:       https://github.com/tuna/thuthesis/compare/v1.3...v1.4
+[v1.3]:       https://github.com/tuna/thuthesis/compare/v1.2...v1.3
+[v1.2]:       https://github.com/tuna/thuthesis/compare/v1.1...v1.2
+[v1.1]:       https://github.com/tuna/thuthesis/compare/v1.0...v1.1
+[v1.0]:       https://github.com/tuna/thuthesis/releases/tag/v1.0

--- a/build.lua
+++ b/build.lua
@@ -13,7 +13,7 @@ docfiles = {
 }
 installfiles = {"*.cls", "*.bst", "tsinghua.pdf"}
 sourcefiles = {"*.dtx", "*.ins", "*.bst", "tsinghua.pdf"}
-tagfiles = {"*.dtx", "CHANGELOG.md"}
+tagfiles = {"*.dtx", "CHANGELOG.md", "package.json"}
 textfiles = {"*.md","LICENSE"}
 typesetdemofiles = {"main.tex", "spine.tex"}
 
@@ -74,6 +74,12 @@ function update_tag(file, content, tagname, tagdate)
       gittag .. "...HEAD\n" ..
       string.format("%-14s", "[" .. gittag .. "]:") .. url .. "/compare/"
         .. previous .. "..." .. gittag)
+
+  elseif string.match(file, "package.json") then
+    content = string.gsub(content,
+      "\"version\": \"[0-9.]+\"",
+      "\"version\": \"" .. tagname .. "\"")
   end
+
   return content
 end

--- a/build.lua
+++ b/build.lua
@@ -3,26 +3,71 @@
 module = "thuthesis"
 
 supportdir = "./testfiles/support-main"
-
 checksuppfiles = {"fontset.tex"}
-demofiles = {"main.tex", "thusetup.tex", "math_commands.tex", "data", "figures", "ref"}
+
+demofiles = {"latexmkrc", "Makefile"}
+docfiles = {
+  "CHANGELOG.md",
+  "thusetup.tex", "math_commands.tex",
+  "data", "figures", "ref",
+}
 installfiles = {"*.cls", "*.bst", "tsinghua.pdf"}
 sourcefiles = {"*.dtx", "*.ins", "*.bst", "tsinghua.pdf"}
+tagfiles = {"*.dtx", "CHANGELOG.md"}
+textfiles = {"*.md","LICENSE"}
+typesetdemofiles = {"main.tex", "spine.tex"}
 
 checkengines = {"xetex"}
 stdengine = "xetex"
 
 checkconfigs = {
-    "build",
-    "testfiles/config-cover",
-    "testfiles/config-nomencl",
-    "testfiles/config-bib",
+  "build",
+  "testfiles/config-cover",
+  "testfiles/config-nomencl",
+  "testfiles/config-bib",
 }
 
 typesetexe = "xelatex"
 unpackexe = "xetex"
 
 checkopts = "-file-line-error -halt-on-error -interaction=nonstopmode"
-typesetopts = "-file-line-error -halt-on-error -interaction=nonstopmode"
+typesetopts = "-shell-escape -file-line-error -halt-on-error -interaction=nonstopmode"
 
 lvtext = ".tex"
+
+function docinit_hook()
+  for _, file in pairs({"dtx-style.sty"}) do
+    cp(file, unpackdir, typesetdir)
+  end
+  return 0
+end
+
+function update_tag(file, content, tagname, tagdate)
+  local url = "https://github.com/tuna/thuthesis"
+  local date = string.gsub(tagdate, "%-", "/")
+  if string.match(file, "%.dtx$") then
+    if string.match(content, "%d%d%d%d/%d%d/%d%d [0-9.]+") then
+      content = string.gsub(content, "%d%d%d%d/%d%d/%d%d [0-9.]+",
+        date .. " " .. tagname)
+    end
+    if string.match(content, "\\def\\version{[0-9.]+}") then
+      content = string.gsub(content, "\\def\\version{[0-9.]+}",
+        "\\def\\version{" .. tagname .. "}")
+    end
+
+  elseif string.match(file, "CHANGELOG.md") then
+    local previous = string.match(content, "/compare/(.*)%.%.%.HEAD")
+    local gittag = 'v' .. tagname
+
+    if gittag == previous then return content end
+    content = string.gsub(content,
+      "## %[Unreleased%]",
+      "## [Unreleased]\n\n## [" .. gittag .."] - " .. tagdate)
+    content = string.gsub(content,
+      previous .. "%.%.%.HEAD",
+      gittag .. "...HEAD\n" ..
+      string.format("%-14s", "[" .. gittag .. "]:") .. url .. "/compare/"
+        .. previous .. "..." .. gittag)
+  end
+  return content
+end

--- a/build.lua
+++ b/build.lua
@@ -33,6 +33,12 @@ unpackexe = "xetex"
 checkopts = "-file-line-error -halt-on-error -interaction=nonstopmode"
 typesetopts = "-shell-escape -file-line-error -halt-on-error -interaction=nonstopmode"
 
+packtdszip = true
+
+tdslocations = {
+  "bibtex/bst/thuthesis/*.bst",
+}
+
 lvtext = ".tex"
 
 function docinit_hook()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thuthesis",
   "version": "6.1.0",
-  "description": "Tsinghua University Thesis LaTex Template",
+  "description": "Tsinghua University Thesis LaTeX Template",
   "main": "gulpfile.js",
   "scripts": {
     "build": "gulp build"


### PR DESCRIPTION
`l3build` 的大致用法是：

1. 编译文档 `thuthesis.pdf` 和示例 `main.pdf`, `spine.pdf`；
```
l3build doc
```
2. 更新 `thuthesis.dtx` 和 `CHANGELOG.md` 的版本号和日期；
```
l3build tag 6.2.0
```
3. 生成 zip 压缩包（用来提交 CTAN）
```
l3build ctan
```
这个有点坑的是，每次都会执行一遍 `l3build check` 和 `l3build doc`，所以比较耗时间。

`Makefile` 的 `make dist` 还没改，看你们更喜欢哪种方法。