### PR TITLE
本科学位论文的调研报告/翻译应置于其他附录之前

### DIFF
--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -58,9 +58,9 @@
 
 % 附录
 \appendix
-\input{data/appendix}
 % \input{data/appendix-survey}       % 本科生：外文资料的调研阅读报告
 % \input{data/appendix-translation}  % 本科生：外文资料的书面翻译
+\input{data/appendix}
 
 % 致谢
 \input{data/acknowledgements}


### PR DESCRIPTION
15. 附录A：为外文资料的调研阅读报告或书面翻译。调研阅读报告需附参考文献；书面翻译需注明外文资料原文的索引。标题为“外文资料的调研阅读报告或书面翻译”，用黑体小三号字，段前30pt，段后20pt，行距20pt。内容部分采用宋体小四号字，行距用固定值20pt，段前后0pt。
调研阅读报告的参考文献（或书面翻译对应的外文资料的原文索引）标题用宋体小四号字，段前20pt，段后6pt，行距20pt。内容用宋体五号字，取固定行距17pt，段前后3pt。
16．附录B：有些不宜放在正文中，但有参考价值的内容，如公式的推演、编写的算法语言程序设计、图纸、数据表格等。
