### PR TITLE
[*] fix the long table caption according to the requirement

### DIFF
--- a/data/chap02.tex
+++ b/data/chap02.tex
@@ -93,7 +93,7 @@
     表头 1 & 表头 2 & 表头 3 & 表头 4 \\
     \midrule
   \endfirsthead
-    \caption[]{跨页长表格的表题（续）} \\
+    \caption*{续表~\thetable \hskip1em 跨页长表格的表题}\\
     \toprule
     表头 1 & 表头 2 & 表头 3 & 表头 4 \\
     \midrule


### PR DESCRIPTION
按照《研究生 学位论文写作指南》二○二○年七月版的要求：
> 当表格较大,不能在一页内打印时,可以“续表”的形式另页打印,格式同前,只需在每页表序前加“续”字即可,例如“ 续表 3.1 第四次全国经济普查数据(北京) ”。