### PR TITLE
Fix "partial" option and document inconsistency

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -806,7 +806,7 @@
 %     积分号上下限的位置，可选：\option{true}（在上下）、\option{false}（在右侧）。
 %     这个设置只影响行间公式，行内公式统一居右侧，不受影响。
 %   \item \DescribeOption{partial}
-%     偏微分符号的正/斜体，可选：\option{upright}、\option{slanted}。
+%     偏微分符号的正/斜体，可选：\option{upright}、\option{italic}。
 %   \item \DescribeOption{math-ellipsis}
 %     省略号 \cs{dots} 的样式，可选：\option{centered}（按照中文的习惯固定居中）、
 %     \option{lower} 和 \option{AMS}（取决于前后符号的位置）。


### PR DESCRIPTION
修正数学符号选项"partial"的文档与选项不一致的问题。