### PR TITLE
replace `/bin/bash` with `/usr/bin/env bash` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SOURCES = $(PACKAGE).ins $(PACKAGE).dtx
 CLSFILE = dtx-style.sty $(PACKAGE).cls
 
 LATEXMK = latexmk
-SHELL  := /bin/bash
+SHELL  := /usr/bin/env bash
 NPM    ?= npm
 
 # make deletion work on Windows


### PR DESCRIPTION
Make life of non-FHS distro user easier