### PR TITLE
feat: implement thesis-type option for bachelor proposals  

### DIFF
--- a/thusetup.tex
+++ b/thusetup.tex
@@ -14,6 +14,9 @@
   %   选择打印版（print）或用于提交的电子版（electronic），前者会插入空白页以便直接双面打印
   %
   output = print,
+  % 格式类型
+  %   默认为论文（thesis），也可以设置为开题报告（proposal）
+  % thesis-type = proposal,
   %
   % 标题
   %   可使用“\\”命令手动控制换行

--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -28,6 +28,7 @@
 \input{data/committee}
 
 % 使用授权的说明
+% 本科生开题报告不需要
 \copyrightpage
 % 将签字扫描后授权文件 scan-copyright.pdf 替换原始页面
 % \copyrightpage[file=scan-copyright.pdf]
@@ -74,6 +75,7 @@
 \input{data/acknowledgements}
 
 % 声明
+% 本科生开题报告不需要
 \statement
 % 将签字扫描后的声明文件 scan-statement.pdf 替换原始页面
 % \statement[file=scan-statement.pdf]

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -412,7 +412,7 @@
 %
 % \subsubsection{开题报告}
 % \DescribeOption{thesis-type}
-% 模板还支持博士生论文开题报告的格式，可以通过设置 \option{thesis-type=proposal} 得到。
+% 模板还支持本科生、博士生论文开题报告的格式，可以通过设置 \option{thesis-type=proposal} 得到。
 %
 % 开题报告与学位论文有两点不同：
 % \begin{enumerate}
@@ -4771,7 +4771,11 @@
     \centering
     \includegraphics{tsinghua-name-bachelor.pdf}%
     \vskip 0.94cm%
-    {\sffamily\bfseries\xiaochu\ziju{0.5}综合论文训练\par}%
+    \ifthu@thesis@type@proposal
+      {\sffamily\bfseries\xiaochu\ziju{0.5}综合论文训练\\开题报告\par}%
+    \else
+      {\sffamily\bfseries\xiaochu\ziju{0.5}综合论文训练\par}%
+    \fi
   \endgroup
   \vskip 1.8cm%
   \begingroup


### PR DESCRIPTION
（至少对本科生而言）开题报告和毕业论文使用同一格式，是否可以考虑添加一个`main-title`配置项，使得可以直接编译开题报告封面