### PR TITLE
修正目录中顶格标题的断行问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 修正目录中顶格标题的断行问题（[#963](https://github.com/tuna/thuthesis/issues/963)）。
+
 ## [v7.5.2] - 2024-07-01
 
 ### Added

--- a/testfiles/06-contents.tlg
+++ b/testfiles/06-contents.tlg
@@ -123,6 +123,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -135,6 +136,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 I
 ....\kern -0.0002
 ....\kern 0.0002
@@ -156,6 +158,7 @@ Completed box being shipped out [4]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -168,6 +171,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 II
 ....\kern -0.0002
 ....\kern 0.0002
@@ -193,6 +197,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -205,6 +210,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 IV
 ....\kern -0.0002
 ....\kern 0.0002
@@ -238,6 +244,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -250,6 +257,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 VIII
 ....\kern -0.0002
 ....\kern 0.0002
@@ -285,6 +293,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -297,6 +306,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 IX
 ....\kern -0.0002
 ....\kern 0.0002
@@ -334,6 +344,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -346,6 +357,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -383,6 +395,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -395,6 +408,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -444,6 +458,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -456,6 +471,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -527,6 +543,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -539,6 +556,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 4
 ....\kern -0.0002
 ....\kern 0.0002
@@ -592,6 +610,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -604,6 +623,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -643,6 +663,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -655,6 +676,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -706,6 +728,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -718,6 +741,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -755,6 +779,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -767,6 +792,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -804,6 +830,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -816,6 +843,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -853,6 +881,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -865,6 +894,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -902,6 +932,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -914,6 +945,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 9
 ....\kern -0.0002
 ....\kern 0.0002
@@ -955,6 +987,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -967,6 +1000,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 11
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1034,6 +1068,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1046,6 +1081,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 11
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1093,6 +1129,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1105,6 +1142,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 11
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1156,6 +1194,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1168,6 +1207,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 12
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1223,6 +1263,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1235,6 +1276,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 15
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1300,6 +1342,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1312,6 +1355,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 18
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1373,6 +1417,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1385,6 +1430,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 18
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1450,6 +1496,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1462,6 +1509,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 23
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1531,6 +1579,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1543,6 +1592,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 27
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1614,6 +1664,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1626,6 +1677,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 27
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1693,6 +1745,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1705,6 +1758,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 28
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1742,6 +1796,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1754,6 +1809,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 38
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1833,6 +1889,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1845,6 +1902,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 40
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1882,6 +1940,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1894,6 +1953,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 40
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2046,6 +2106,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2058,6 +2119,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 41
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2115,6 +2177,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2127,6 +2190,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 46
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2180,6 +2244,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2192,6 +2257,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 46
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2255,6 +2321,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2267,6 +2334,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 47
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2316,6 +2384,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2328,6 +2397,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 53
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2369,6 +2439,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2381,6 +2452,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 53
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2422,6 +2494,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2434,6 +2507,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 57
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2487,6 +2561,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2499,6 +2574,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 59
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2544,6 +2620,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2556,6 +2633,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 60
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2601,6 +2679,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2613,6 +2692,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 61
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2664,6 +2744,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2676,6 +2757,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 62
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2713,6 +2795,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2725,6 +2808,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 63
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2800,6 +2884,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2812,6 +2897,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 64
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2849,6 +2935,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2861,6 +2948,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 64
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2898,6 +2986,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2910,6 +2999,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 65
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2957,6 +3047,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2969,6 +3060,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 65
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3020,6 +3112,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3032,6 +3125,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 67
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3091,6 +3185,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3103,6 +3198,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 68
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3144,6 +3240,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3156,6 +3253,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 69
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3193,6 +3291,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3205,6 +3304,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 69
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3250,6 +3350,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3262,6 +3363,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 69
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3307,6 +3409,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3319,6 +3422,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 70
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3360,6 +3464,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3372,6 +3477,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 72
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3413,6 +3519,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3425,6 +3532,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 73
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3466,6 +3574,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3478,6 +3587,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 74
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3519,6 +3629,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3531,6 +3642,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 77
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3576,6 +3688,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3588,6 +3701,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 77
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3649,6 +3763,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3661,6 +3776,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 78
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3698,6 +3814,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3710,6 +3827,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 79
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3755,6 +3873,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3767,6 +3886,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 79
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3812,6 +3932,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3824,6 +3945,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 85
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3861,6 +3983,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3873,6 +3996,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 91
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3914,6 +4038,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3926,6 +4051,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 91
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4086,6 +4212,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4098,6 +4225,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 91
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4143,6 +4271,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4155,6 +4284,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 99
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4192,6 +4322,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4204,6 +4335,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 105
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4241,6 +4373,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4253,6 +4386,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 107
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4290,6 +4424,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4302,6 +4437,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 108
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4373,6 +4509,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4385,6 +4522,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 109
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4432,6 +4570,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4444,6 +4583,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 109
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4495,6 +4635,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4507,6 +4648,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 110
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4548,6 +4690,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4560,6 +4703,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 110
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4621,6 +4765,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4633,6 +4778,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 111
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4674,6 +4820,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4686,6 +4833,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 115
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4727,6 +4875,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4739,6 +4888,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 115
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4788,6 +4938,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4800,6 +4951,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 120
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4853,6 +5005,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4865,6 +5018,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 120
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4910,6 +5064,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4922,6 +5077,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 120
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4967,6 +5123,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4979,6 +5136,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 124
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5034,6 +5192,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5046,6 +5205,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 128
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5091,6 +5251,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5103,6 +5264,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 128
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5148,6 +5310,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5160,6 +5323,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 130
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5201,6 +5365,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5213,6 +5378,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 134
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5258,6 +5424,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5270,6 +5437,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 134
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5315,6 +5483,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5327,6 +5496,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 135
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5384,6 +5554,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5396,6 +5567,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 137
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5433,6 +5605,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5445,6 +5618,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 139
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5520,6 +5694,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5532,6 +5707,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 141
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5569,6 +5745,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5581,6 +5758,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 141
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5646,6 +5824,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5658,6 +5837,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 141
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5725,6 +5905,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5737,6 +5918,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 143
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5774,6 +5956,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5786,6 +5969,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 148
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5855,6 +6039,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5867,6 +6052,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 148
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5934,6 +6120,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5946,6 +6133,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 151
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5983,6 +6171,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5995,6 +6184,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 153
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6155,6 +6345,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6167,6 +6358,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 155
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6200,6 +6392,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6212,6 +6405,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 155
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6245,6 +6439,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6257,6 +6452,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 158
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6284,6 +6480,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6296,6 +6493,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 159
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6371,6 +6569,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6383,6 +6582,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 173
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6462,6 +6662,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6474,6 +6675,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 179
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6499,6 +6701,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6511,6 +6714,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 184
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6536,6 +6740,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6548,6 +6753,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 185
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6605,6 +6811,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6617,6 +6824,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 186
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6648,6 +6856,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6660,6 +6869,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 188
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6695,6 +6905,7 @@ Completed box being shipped out [7]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6707,6 +6918,7 @@ Completed box being shipped out [7]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 189
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/07-1-figures-tables.tlg
+++ b/testfiles/07-1-figures-tables.tlg
@@ -173,6 +173,7 @@ Completed box being shipped out [3]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -185,6 +186,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 10
@@ -262,6 +264,7 @@ Completed box being shipped out [3]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -274,6 +277,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 19
@@ -357,6 +361,7 @@ Completed box being shipped out [3]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -369,6 +374,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 42
@@ -458,6 +464,7 @@ Completed box being shipped out [3]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -470,6 +477,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 43
@@ -533,6 +541,7 @@ Completed box being shipped out [3]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -545,6 +554,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 49
@@ -625,6 +635,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -637,6 +648,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 13
 ....\kern -0.0002
 ....\kern 0.0002
@@ -719,6 +731,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -731,6 +744,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 25
 ....\kern -0.0002
 ....\kern 0.0002
@@ -827,6 +841,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -839,6 +854,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 45
 ....\kern -0.0002
 ....\kern 0.0002
@@ -907,6 +923,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -919,6 +936,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 46
 ....\kern -0.0002
 ....\kern 0.0002
@@ -989,6 +1007,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1001,6 +1020,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 47
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1074,6 +1094,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1086,6 +1107,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 68
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1162,6 +1184,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1174,6 +1197,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 70
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1238,6 +1262,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1250,6 +1275,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 110
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1314,6 +1340,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1326,6 +1353,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 111
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/07-2-figures.tlg
+++ b/testfiles/07-2-figures.tlg
@@ -159,6 +159,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -171,6 +172,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 10
@@ -248,6 +250,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -260,6 +263,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 19
@@ -351,6 +355,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -363,6 +368,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 28
@@ -468,6 +474,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -480,6 +487,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 29
@@ -577,6 +585,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -589,6 +598,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 30
@@ -664,6 +674,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -676,6 +687,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 33
@@ -759,6 +771,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -771,6 +784,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 42
@@ -860,6 +874,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -872,6 +887,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 43
@@ -935,6 +951,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -947,6 +964,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 49
@@ -1014,6 +1032,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1026,6 +1045,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 49
@@ -1093,6 +1113,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1105,6 +1126,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 52
@@ -1172,6 +1194,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1184,6 +1207,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 53
@@ -1255,6 +1279,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1267,6 +1292,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 54
@@ -1370,6 +1396,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1382,6 +1409,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 56
@@ -1453,6 +1481,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1465,6 +1494,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 58
@@ -1514,6 +1544,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1526,6 +1557,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 66
@@ -1597,6 +1629,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1609,6 +1642,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 82
@@ -1668,6 +1702,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1680,6 +1715,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 83
@@ -1739,6 +1775,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1751,6 +1788,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 91
@@ -1818,6 +1856,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1830,6 +1869,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 93
@@ -1893,6 +1933,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1905,6 +1946,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 94
@@ -1954,6 +1996,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1966,6 +2009,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 94
@@ -2029,6 +2073,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2041,6 +2086,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 95
@@ -2106,6 +2152,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2118,6 +2165,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 95
@@ -2187,6 +2235,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2199,6 +2248,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 97
@@ -2272,6 +2322,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2284,6 +2335,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 97
@@ -2355,6 +2407,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2367,6 +2420,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 98
@@ -2440,6 +2494,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2452,6 +2507,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 98
@@ -2519,6 +2575,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2531,6 +2588,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 100
@@ -2723,6 +2781,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2735,6 +2794,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 101
@@ -2798,6 +2858,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2810,6 +2871,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 103
@@ -2869,6 +2931,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2881,6 +2944,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 103
@@ -2944,6 +3008,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2956,6 +3021,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 103
@@ -3023,6 +3089,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3035,6 +3102,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 104
@@ -3090,6 +3158,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3102,6 +3171,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 104
@@ -3163,6 +3233,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3175,6 +3246,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 104
@@ -3266,6 +3338,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3278,6 +3351,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 106
@@ -3349,6 +3423,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3361,6 +3436,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 106
@@ -3464,6 +3540,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3476,6 +3553,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 106
@@ -3576,6 +3654,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3588,6 +3667,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 107
@@ -3691,6 +3771,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3703,6 +3784,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 107
@@ -3754,6 +3836,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3766,6 +3849,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 109
@@ -3857,6 +3941,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3869,6 +3954,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 111
@@ -3980,6 +4066,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3992,6 +4079,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 113
@@ -4093,6 +4181,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4105,6 +4194,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 116
@@ -4181,6 +4271,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4193,6 +4284,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 116
@@ -4278,6 +4370,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4290,6 +4383,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 117
@@ -4385,6 +4479,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4397,6 +4492,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 117
@@ -4469,6 +4565,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4481,6 +4578,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 118
@@ -4552,6 +4650,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4564,6 +4663,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 118
@@ -4629,6 +4729,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4641,6 +4742,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 121
@@ -4712,6 +4814,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4724,6 +4827,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 121
@@ -4815,6 +4919,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4827,6 +4932,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 122
@@ -4912,6 +5018,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4924,6 +5031,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 125
@@ -5001,6 +5109,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5013,6 +5122,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 126
@@ -5074,6 +5184,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5086,6 +5197,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 126
@@ -5179,6 +5291,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5191,6 +5304,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 127
@@ -5286,6 +5400,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5298,6 +5413,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 127
@@ -5383,6 +5499,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5395,6 +5512,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 128
@@ -5600,6 +5718,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5612,6 +5731,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 130
@@ -5699,6 +5819,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5711,6 +5832,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 131
@@ -5800,6 +5922,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5812,6 +5935,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 132
@@ -5887,6 +6011,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5899,6 +6024,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 133
@@ -5966,6 +6092,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5978,6 +6105,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 134
@@ -6055,6 +6183,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6067,6 +6196,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 135
@@ -6144,6 +6274,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6156,6 +6287,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 137
@@ -6243,6 +6375,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6255,6 +6388,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 139
@@ -6349,6 +6483,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6361,6 +6496,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 141
@@ -6452,6 +6588,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6464,6 +6601,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 142
@@ -6578,6 +6716,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6590,6 +6729,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 143
@@ -6676,6 +6816,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6688,6 +6829,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 145
@@ -6778,6 +6920,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6790,6 +6933,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 145
@@ -6871,6 +7015,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6883,6 +7028,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 147
@@ -6964,6 +7110,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -6976,6 +7123,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 147
@@ -7085,6 +7233,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7097,6 +7246,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 149
@@ -7180,6 +7330,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7192,6 +7343,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 150
@@ -7281,6 +7433,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7293,6 +7446,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 151
@@ -7350,6 +7504,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7362,6 +7517,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 152
@@ -7419,6 +7575,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7431,6 +7588,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 152
@@ -7538,6 +7696,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7550,6 +7709,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 152
@@ -7613,6 +7773,7 @@ Completed box being shipped out [5]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7625,6 +7786,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 153

--- a/testfiles/07-3-tables.tlg
+++ b/testfiles/07-3-tables.tlg
@@ -176,6 +176,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -188,6 +189,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 13
 ....\kern -0.0002
 ....\kern 0.0002
@@ -270,6 +272,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -282,6 +285,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 25
 ....\kern -0.0002
 ....\kern 0.0002
@@ -362,6 +366,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -374,6 +379,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 26
 ....\kern -0.0002
 ....\kern 0.0002
@@ -452,6 +458,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -464,6 +471,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 28
 ....\kern -0.0002
 ....\kern 0.0002
@@ -520,6 +528,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -532,6 +541,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 35
 ....\kern -0.0002
 ....\kern 0.0002
@@ -594,6 +604,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -606,6 +617,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 36
 ....\kern -0.0002
 ....\kern 0.0002
@@ -714,6 +726,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -726,6 +739,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 36
 ....\kern -0.0002
 ....\kern 0.0002
@@ -822,6 +836,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -834,6 +849,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 45
 ....\kern -0.0002
 ....\kern 0.0002
@@ -902,6 +918,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -914,6 +931,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 46
 ....\kern -0.0002
 ....\kern 0.0002
@@ -984,6 +1002,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -996,6 +1015,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 47
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1070,6 +1090,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1082,6 +1103,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 48
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1142,6 +1164,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1154,6 +1177,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 51
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1238,6 +1262,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1250,6 +1275,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 55
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1326,6 +1352,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1338,6 +1365,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 60
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1408,6 +1436,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1420,6 +1449,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 62
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1493,6 +1523,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1505,6 +1536,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 68
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1581,6 +1613,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1593,6 +1626,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 70
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1666,6 +1700,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1678,6 +1713,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 72
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1736,6 +1772,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1748,6 +1785,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 76
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1820,6 +1858,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1832,6 +1871,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 78
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1913,6 +1953,7 @@ C.}
 ....\glue 7.63654 minus 6.0225
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1925,6 +1966,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 85
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1983,6 +2025,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1995,6 +2038,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 89
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2078,6 +2122,7 @@ C.}
 ....\glue 7.63654 minus 6.0225
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2090,6 +2135,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 90
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2140,6 +2186,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2152,6 +2199,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 96
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2216,6 +2264,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2228,6 +2277,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 110
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2292,6 +2342,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2304,6 +2355,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 111
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2368,6 +2420,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2380,6 +2433,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 112
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2455,6 +2509,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2467,6 +2522,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 112
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2541,6 +2597,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2553,6 +2610,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 113
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2746,6 +2804,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2758,6 +2817,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 114
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2818,6 +2878,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2830,6 +2891,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 114
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2896,6 +2958,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2908,6 +2971,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 114
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2968,6 +3032,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2980,6 +3045,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 115
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3068,6 +3134,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3080,6 +3147,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 115
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3160,6 +3228,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3172,6 +3241,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 115
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3244,6 +3314,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3256,6 +3327,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 119
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3336,6 +3408,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3348,6 +3421,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 119
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3432,6 +3506,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3444,6 +3519,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 122
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3528,6 +3604,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3540,6 +3617,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 123
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3596,6 +3674,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3608,6 +3687,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 123
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3678,6 +3758,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3690,6 +3771,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 127
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3774,6 +3856,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3786,6 +3869,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 132
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3882,6 +3966,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3894,6 +3979,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 136
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3956,6 +4042,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3968,6 +4055,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 138
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4060,6 +4148,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4072,6 +4161,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 144
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4150,6 +4240,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4162,6 +4253,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 149
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4250,6 +4342,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4262,6 +4355,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 150
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/09-main-bachelor-en.tlg
+++ b/testfiles/09-main-bachelor-en.tlg
@@ -2372,6 +2372,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2384,6 +2385,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2421,6 +2423,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2433,6 +2436,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2472,6 +2476,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2484,6 +2489,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2521,6 +2527,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2533,6 +2540,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2569,6 +2577,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2581,6 +2590,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2616,6 +2626,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2628,6 +2639,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2671,6 +2683,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2683,6 +2696,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2725,6 +2739,7 @@ Completed box being shipped out [5]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2737,6 +2752,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2771,6 +2787,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2783,6 +2800,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2816,6 +2834,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2828,6 +2847,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2863,6 +2883,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2875,6 +2896,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2908,6 +2930,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2920,6 +2943,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2958,6 +2982,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2970,6 +2995,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3014,6 +3040,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3026,6 +3053,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3061,6 +3089,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3073,6 +3102,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3108,6 +3138,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3120,6 +3151,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3161,6 +3193,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3173,6 +3206,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3210,6 +3244,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3222,6 +3257,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3255,6 +3291,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3267,6 +3304,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3302,6 +3340,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3314,6 +3353,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3347,6 +3387,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3359,6 +3400,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3398,6 +3440,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3410,6 +3453,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3449,6 +3493,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3461,6 +3506,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3506,6 +3552,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3518,6 +3565,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3555,6 +3603,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3567,6 +3616,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3601,6 +3651,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3613,6 +3664,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 10
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3635,6 +3687,7 @@ Completed box being shipped out [5]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3647,6 +3700,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 11
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3777,6 +3831,7 @@ Completed box being shipped out [6]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3789,6 +3844,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 12
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3811,6 +3867,7 @@ Completed box being shipped out [6]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3823,6 +3880,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 13
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3849,6 +3907,7 @@ Completed box being shipped out [6]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3861,6 +3920,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 15
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3895,6 +3955,7 @@ Completed box being shipped out [6]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3907,6 +3968,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 17
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3941,6 +4003,7 @@ Completed box being shipped out [6]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3953,6 +4016,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 18
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3975,6 +4039,7 @@ Completed box being shipped out [6]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3987,6 +4052,7 @@ Completed box being shipped out [6]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 19
 ....\kern -0.0002
 ....\kern 0.0002
@@ -13483,6 +13549,7 @@ Completed box being shipped out [11]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -13495,6 +13562,7 @@ Completed box being shipped out [11]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -13539,6 +13607,7 @@ Completed box being shipped out [11]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -13551,6 +13620,7 @@ Completed box being shipped out [11]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -13593,6 +13663,7 @@ Completed box being shipped out [11]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -13605,6 +13676,7 @@ Completed box being shipped out [11]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -13649,6 +13721,7 @@ Completed box being shipped out [11]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -13661,6 +13734,7 @@ Completed box being shipped out [11]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/09-main-bachelor.tlg
+++ b/testfiles/09-main-bachelor.tlg
@@ -1864,6 +1864,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1876,6 +1877,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1913,6 +1915,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1925,6 +1928,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1962,6 +1966,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1974,6 +1979,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2019,6 +2025,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2031,6 +2038,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2075,6 +2083,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2087,6 +2096,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2124,6 +2134,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2136,6 +2147,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2181,6 +2193,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2193,6 +2206,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 4
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2221,6 +2235,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2233,6 +2248,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2261,6 +2277,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2273,6 +2290,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2301,6 +2319,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2313,6 +2332,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2339,6 +2359,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2351,6 +2372,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 9
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2377,6 +2399,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2389,6 +2412,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 11
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2445,6 +2469,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2457,6 +2482,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 13
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2503,6 +2529,7 @@ Completed box being shipped out [5]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2515,6 +2542,7 @@ Completed box being shipped out [5]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 14
 ....\kern -0.0002
 ....\kern 0.0002
@@ -7072,6 +7100,7 @@ C.}
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7084,6 +7113,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 4
@@ -7281,6 +7311,7 @@ C.}
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -7293,6 +7324,7 @@ C.}
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/09-main-en.tlg
+++ b/testfiles/09-main-en.tlg
@@ -755,6 +755,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -767,6 +768,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 I
 ....\kern -0.0002
 ....\kern 0.0002
@@ -788,6 +790,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -800,6 +803,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 II
 ....\kern -0.0002
 ....\kern 0.0002
@@ -825,6 +829,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -837,6 +842,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 III
 ....\kern -0.0002
 ....\kern 0.0002
@@ -866,6 +872,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -878,6 +885,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 IV
 ....\kern -0.0002
 ....\kern 0.0002
@@ -907,6 +915,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -919,6 +928,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 V
 ....\kern -0.0002
 ....\kern 0.0002
@@ -952,6 +962,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -964,6 +975,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -993,6 +1005,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1005,6 +1018,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1034,6 +1048,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1046,6 +1061,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1075,6 +1091,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1087,6 +1104,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1116,6 +1134,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1128,6 +1147,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1157,6 +1177,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1169,6 +1190,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1190,6 +1212,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1202,6 +1225,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1235,6 +1259,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1247,6 +1272,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 4
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1268,6 +1294,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1280,6 +1307,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 6
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1305,6 +1333,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1317,6 +1346,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1338,6 +1368,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1350,6 +1381,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 8
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1377,6 +1409,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1389,6 +1422,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 9
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1418,6 +1452,7 @@ Completed box being shipped out [3]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1430,6 +1465,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 10
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1630,6 +1666,7 @@ Completed box being shipped out [4]
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1642,6 +1679,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\penalty 10000
 ....\glue 0.0 plus 1.0fil
 ....\TU/texgyretermes(0)/m/n/12.045 1
@@ -1682,6 +1720,7 @@ Completed box being shipped out [4]
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -1694,6 +1733,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/09-main-postdoc.tlg
+++ b/testfiles/09-main-postdoc.tlg
@@ -2095,6 +2095,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2107,6 +2108,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2140,6 +2142,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2152,6 +2155,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 3
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2199,6 +2203,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2211,6 +2216,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2252,6 +2258,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2264,6 +2271,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 7
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2305,6 +2313,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2317,6 +2326,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 12
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2358,6 +2368,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2370,6 +2381,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 13
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2433,6 +2445,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2445,6 +2458,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 14
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2486,6 +2500,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2498,6 +2513,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 14
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2531,6 +2547,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2543,6 +2560,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 14
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2588,6 +2606,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2600,6 +2619,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 17
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2645,6 +2665,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2657,6 +2678,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 20
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2704,6 +2726,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2716,6 +2739,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 24
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2757,6 +2781,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2769,6 +2794,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 25
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2802,6 +2828,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2814,6 +2841,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 25
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2853,6 +2881,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2865,6 +2894,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 27
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2910,6 +2940,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2922,6 +2953,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 29
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2969,6 +3001,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -2981,6 +3014,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 30
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3032,6 +3066,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3044,6 +3079,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 33
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3097,6 +3133,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3109,6 +3146,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 36
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3146,6 +3184,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3158,6 +3197,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 38
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3199,6 +3239,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3211,6 +3252,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 39
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3272,6 +3314,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3284,6 +3327,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 39
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3333,6 +3377,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3345,6 +3390,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 41
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3390,6 +3436,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3402,6 +3449,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 41
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3435,6 +3483,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3447,6 +3496,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 41
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3504,6 +3554,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3516,6 +3567,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 51
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3549,6 +3601,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3561,6 +3614,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 51
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3598,6 +3652,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3610,6 +3665,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 52
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3659,6 +3715,7 @@ Completed box being shipped out [3]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3671,6 +3728,7 @@ Completed box being shipped out [3]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 83
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3837,6 +3895,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3849,6 +3908,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 84
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3882,6 +3942,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3894,6 +3955,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 84
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3933,6 +3995,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -3945,6 +4008,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 84
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4002,6 +4066,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4014,6 +4079,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 86
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4065,6 +4131,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4077,6 +4144,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 86
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4130,6 +4198,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4142,6 +4211,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 93
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4193,6 +4263,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4205,6 +4276,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 94
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4258,6 +4330,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4270,6 +4343,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 96
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4327,6 +4401,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4339,6 +4414,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 98
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4392,6 +4468,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4404,6 +4481,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 98
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4447,6 +4525,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4459,6 +4538,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 100
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4498,6 +4578,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4510,6 +4591,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 102
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4559,6 +4641,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4571,6 +4654,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 116
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4604,6 +4688,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4616,6 +4701,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 116
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4665,6 +4751,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4677,6 +4764,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 117
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4726,6 +4814,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4738,6 +4827,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 121
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4783,6 +4873,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4795,6 +4886,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 121
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4846,6 +4938,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4858,6 +4951,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 124
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4897,6 +4991,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4909,6 +5004,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 125
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4970,6 +5066,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -4982,6 +5079,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 126
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5015,6 +5113,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5027,6 +5126,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 126
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5072,6 +5172,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5084,6 +5185,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 127
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5129,6 +5231,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5141,6 +5244,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 129
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5178,6 +5282,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5190,6 +5295,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 138
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5217,6 +5323,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5229,6 +5336,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 148
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5252,6 +5360,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5264,6 +5373,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 149
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5315,6 +5425,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5327,6 +5438,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 149
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5378,6 +5490,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5390,6 +5503,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 150
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5417,6 +5531,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5429,6 +5544,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 151
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5460,6 +5576,7 @@ Completed box being shipped out [4]
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
+....\penalty 10000
 ....\glue -4.015
 ....\glue 3.01125
 ....\leaders 0.0 plus 1.0fill
@@ -5472,6 +5589,7 @@ Completed box being shipped out [4]
 .......\kern 0.0002
 .......\special{color pop}
 ....\kern 0.0
+....\penalty 10000
 ....\TU/texgyretermes(0)/m/n/12.045 152
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/package-hyperref.tlg
+++ b/testfiles/package-hyperref.tlg
@@ -871,6 +871,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -883,6 +884,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 I
 .....\kern -0.0002
@@ -908,6 +910,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -920,6 +923,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 II
 .....\kern -0.0002
@@ -949,6 +953,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -961,6 +966,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 III
 .....\kern -0.0002
@@ -994,6 +1000,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1006,6 +1013,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 IV
 .....\kern -0.0002
@@ -1039,6 +1047,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1051,6 +1060,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 V
 .....\kern -0.0002
@@ -1090,6 +1100,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1102,6 +1113,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 1
 .....\kern -0.0002
@@ -1135,6 +1147,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1147,6 +1160,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 1
 .....\kern -0.0002
@@ -1180,6 +1194,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1192,6 +1207,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 1
 .....\kern -0.0002
@@ -1225,6 +1241,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1237,6 +1254,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 2
 .....\kern -0.0002
@@ -1270,6 +1288,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1282,6 +1301,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 2
 .....\kern -0.0002
@@ -1307,6 +1327,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1319,6 +1340,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 3
 .....\kern -0.0002
@@ -1356,6 +1378,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1368,6 +1391,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 4
 .....\kern -0.0002
@@ -1393,6 +1417,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1405,6 +1430,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 6
 .....\kern -0.0002
@@ -1434,6 +1460,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1446,6 +1473,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 7
 .....\kern -0.0002
@@ -1471,6 +1499,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1483,6 +1512,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 8
 .....\kern -0.0002
@@ -1514,6 +1544,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1526,6 +1557,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 9
 .....\kern -0.0002
@@ -1559,6 +1591,7 @@ Completed box being shipped out [3]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1571,6 +1604,7 @@ Completed box being shipped out [3]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 10
 .....\kern -0.0002
@@ -1792,6 +1826,7 @@ Completed box being shipped out [4]
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1804,6 +1839,7 @@ Completed box being shipped out [4]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\penalty 10000
 .....\glue 0.0 plus 1.0fil
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
@@ -1848,6 +1884,7 @@ Completed box being shipped out [4]
 .....\special{pdf:eann}
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
+.....\penalty 10000
 .....\glue -4.015
 .....\glue 3.01125
 .....\leaders 0.0 plus 1.0fill
@@ -1860,6 +1897,7 @@ Completed box being shipped out [4]
 ........\kern 0.0002
 ........\special{color pop}
 .....\kern 0.0
+.....\penalty 10000
 .....\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/G\ETC.}
 .....\TU/texgyretermes(0)/m/n/12.045 2
 .....\kern -0.0002

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -4067,7 +4067,7 @@
     default = arial,
   },
 }
-\newcommand\thu@leaders{\titlerule*[4bp]{.}}
+\newcommand\thu@leaders{\nobreak\titlerule*[4bp]{.}\nobreak}
 \newcommand\thu@set@toc@format{%
   \contentsmargin{\z@}%
 %    \end{macrocode}


### PR DESCRIPTION
修复 #963。

复现问题：

```latex
\documentclass[degree=doctor]{thuthesis}
\begin{document}
\frontmatter
\tableofcontents
\mainmatter
\chapter{不同时间窗口下行为变量对最低绩点回归的 Wald 检验结果-高学业风险}
\chapter{不同时间窗口下行为变量对最低绩点回归的 Wald 检验结果-高学业风}
\end{document}
```

<img width="750" alt="Screenshot 2024-07-02 at 18 35 22" src="https://github.com/tuna/thuthesis/assets/12290822/e79206b5-f8b0-40ec-bf68-f52c2a60400a">
