### PR TITLE
Update test files to track LaTeX2e 2024-11-01 changes

### DIFF
--- a/testfiles/09-main-bachelor-en.tlg
+++ b/testfiles/09-main-bachelor-en.tlg
@@ -10885,7 +10885,7 @@ Completed box being shipped out [7]
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
 .....\write1{\providecommand*\caption@xref[2]{\@setref\relax\@undefined{#1}}}
-.....\write1{\newlabel{tab:frequencies-e-c}{{4.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:frequencies-e-c}{{4.1}{\thepage }{}{table.4.1}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(94.21227+88.69106)x421.10089
@@ -11939,7 +11939,7 @@ Completed box being shipped out [7]
 .....\glue 6.02249
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
-.....\write1{\newlabel{tab:percentages-e-c}{{4.2}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:percentages-e-c}{{4.2}{\thepage }{}{table.4.2}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(28.88416+23.36293)x421.10089, glue set 186.1502fil
@@ -12153,7 +12153,7 @@ Completed box being shipped out [8]
 .....\glue 6.02249
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
-.....\write1{\newlabel{tab:frequencies-c-e}{{4.3}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:frequencies-c-e}{{4.3}{\thepage }{}{table.4.3}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(28.88416+23.36293)x421.10089, glue set 186.1502fil
@@ -12249,7 +12249,7 @@ Completed box being shipped out [8]
 .....\glue 6.02249
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
-.....\write1{\newlabel{tab:percentages-c-e}{{4.4}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:percentages-c-e}{{4.4}{\thepage }{}{table.4.4}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(28.88416+23.36293)x421.10089, glue set 186.1502fil

--- a/testfiles/09-main-bachelor.tlg
+++ b/testfiles/09-main-bachelor.tlg
@@ -5080,7 +5080,7 @@ Completed box being shipped out [3]
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
 .....\write1{\providecommand*\caption@xref[2]{\@setref\relax\@undefined{#1}}}
-.....\write1{\newlabel{tab:beijing}{{2.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:beijing}{{2.1}{\thepage }{}{table.2.1}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(50.98317+45.46194)x421.10089, glue set 79.07031fil
@@ -6229,7 +6229,7 @@ Completed box being shipped out [4]
 ......\glue(\rightskip) 0.0
 .....\glue 0.0
 .....\special{color pop}
-.....\write1{\newlabel{fig:winter}{{2.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{fig:winter}{{2.1}{\thepage }{}{figure.2.1}{}}}
 .....\glue 0.0
 ....\special{color pop}
 ...\penalty 0

--- a/testfiles/09-main-en.tlg
+++ b/testfiles/09-main-en.tlg
@@ -2714,7 +2714,7 @@ Completed box being shipped out [1]
 .....\glue 0.0
 .....\special{color pop}
 .....\write1{\providecommand*\caption@xref[2]{\@setref\relax\@undefined{#1}}}
-.....\write1{\newlabel{fig:1.1}{{1.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{fig:1.1}{{1.1}{\thepage }{}{figure.1.1}{}}}
 .....\glue 0.0
 ....\special{color pop}
 ...\penalty 0
@@ -2927,7 +2927,7 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/m/n/12.045 )
 ......\kern -0.0002
 ......\kern 0.0002
-.....\write1{\newlabel{eq:1.1}{{1.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{eq:1.1}{{1.1}{\thepage }{}{equation.1.1}{}}}
 ...\penalty 0
 ...\glue(\belowdisplayskip) 6.02249
 ...\glue -12.02249
@@ -3183,7 +3183,7 @@ Completed box being shipped out [2]
 .....\glue 6.02249
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
-.....\write1{\newlabel{tab:1.1}{{1.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:1.1}{{1.1}{\thepage }{}{table.1.1}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(112.87744+107.35623)x426.79135, glue set 109.08162fil
@@ -6483,7 +6483,7 @@ Completed box being shipped out [4]
 ......\glue(\rightskip) 0.0
 .....\glue 0.0
 .....\special{color pop}
-.....\write1{\newlabel{fig:A.1}{{A.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{fig:A.1}{{A.1}{\thepage }{}{figure.1.1}{}}}
 .....\glue 0.0
 ....\special{color pop}
 ...\penalty 0
@@ -6704,7 +6704,7 @@ Completed box being shipped out [4]
 ......\TU/texgyretermes(0)/m/n/12.045 )
 ......\kern -0.0002
 ......\kern 0.0002
-.....\write1{\newlabel{eq:A.1}{{A.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{eq:A.1}{{A.1}{\thepage }{}{equation.1.1}{}}}
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue -12.02249
@@ -6994,7 +6994,7 @@ Completed box being shipped out [5]
 .....\glue 6.02249
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
-.....\write1{\newlabel{tab:A.1}{{A.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:A.1}{{A.1}{\thepage }{}{table.1.1}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(56.88191+51.3607)x426.79135, glue set 109.08162fil

--- a/testfiles/09-main.tlg
+++ b/testfiles/09-main.tlg
@@ -9648,7 +9648,7 @@ Completed box being shipped out [5]
 .....\rule(0.0+0.0)x*
 .....\special{color pop}
 .....\write1{\providecommand*\caption@xref[2]{\@setref\relax\@undefined{#1}}}
-.....\write1{\newlabel{tab:notations}{{3.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{tab:notations}{{3.1}{\thepage }{}{table.3.1}{}}}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
 .....\hbox(268.44019+262.91896)x426.79135, glue set 9.47826fil

--- a/testfiles/package-algorithms.tlg
+++ b/testfiles/package-algorithms.tlg
@@ -100,7 +100,7 @@ Completed box being shipped out [2]
 ....\vbox(270.52151+0.0)x426.79135
 .....\write1{\@writefile{loa}{\protect \contentsline {algorithm}{\protect \numberline \ETC.}
 .....\write1{\providecommand*\caption@xref[2]{\@setref\relax\@undefined{#1}}}
-.....\write1{\newlabel{alg1}{{1.1}{\thepage }{}{}{}}}
+.....\write1{\newlabel{alg1}{{1.1}{\thepage }{}{algorithm.1.1}{}}}
 .....\penalty -51
 .....\glue 2.2082
 .....\glue(\parskip) 0.0

--- a/testfiles/package-hyperref.tlg
+++ b/testfiles/package-hyperref.tlg
@@ -3184,7 +3184,7 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0
 .......\mathon
 .......\hbox(0.0+0.0)x0.0, shifted -20.075
-........\special{pdf:dest (equation.0.2.1) [@thispage /XYZ @xpos @ypos null]}
+........\special{pdf:dest (equation.0.1) [@thispage /XYZ @xpos @ypos null]}
 ........\penalty 10000
 .......\mathoff
 ......\hbox(0.0+0.0)x0.0
@@ -3294,7 +3294,7 @@ Completed box being shipped out [1]
 .......\TU/texgyretermes(0)/m/n/12.045 )
 .......\kern -0.0002
 .......\kern 0.0002
-......\write1{\newlabel{eq:1.1}{{1}{\thepage }{Title}{equation.0.2.1}{}}}
+......\write1{\newlabel{eq:1.1}{{1}{\thepage }{Title}{equation.0.1}{}}}
 ....\penalty 0
 ....\glue(\belowdisplayskip) 6.02249
 ....\glue -12.02249
@@ -4857,7 +4857,7 @@ Completed box being shipped out [4]
 ......\hbox(0.0+0.0)x0.0
 .......\mathon
 .......\hbox(0.0+0.0)x0.0, shifted -20.075
-........\special{pdf:dest (equation.A.1.1) [@thispage /XYZ @xpos @ypos null]}
+........\special{pdf:dest (equation.A.1) [@thispage /XYZ @xpos @ypos null]}
 ........\penalty 10000
 .......\mathoff
 ......\hbox(0.0+0.0)x0.0
@@ -4967,7 +4967,7 @@ Completed box being shipped out [4]
 .......\TU/texgyretermes(0)/m/n/12.045 )
 .......\kern -0.0002
 .......\kern 0.0002
-......\write1{\newlabel{eq:A.1}{{A.1}{\thepage }{Title}{equation.A.1.1}{}}}
+......\write1{\newlabel{eq:A.1}{{A.1}{\thepage }{Title}{equation.A.1}{}}}
 ....\penalty 0
 ....\glue(\belowdisplayshortskip) 6.02249
 ....\glue -12.02249


### PR DESCRIPTION
Track LaTeX2e 2024-11-01 changes:

- Previously provided by `hyperref`, `\theH<counter>` and `\@currentHref` are now defined/updated directly by LaTeX. Hence value of `\@currentHref`, the destination name, is seen in the 4th value of the 5-tuple written by `\label`.
- `\theHequation` now starts with its actual parent counter, not the unconditional `\theHsection` when it was defined in `hyperref`. Hence the changes in destination names for `equation` counters.

-----

BTW the `build` job may need some adaption to pass also in (general) fork repositories. It now always fails (e.g., [this run](https://github.com/muzimuzhi/thuthesis/actions/runs/11749772573)) in tag-free forks, as it runs the command `git describe --tags` which requires existence of tag(s).
https://github.com/tuna/thuthesis/blob/60661f7d140c192418cc9151b54a6c59a99fae23/.github/workflows/test.yml#L50-L54