### PR TITLE
在biblatex中也去除“人名”和“等”之间的空格。

### DIFF
--- a/testfiles/10-biblatex/10-biblatex-numeric.tlg
+++ b/testfiles/10-biblatex/10-biblatex-numeric.tlg
@@ -38,7 +38,7 @@ Completed box being shipped out [1]
 ...\write-{}
 ...\special{color push gray 0}
 ...\glue(\topskip) 1.07468
-...\hbox(10.92532+2.144)x426.79135, glue set 304.51926fil
+...\hbox(10.92532+2.144)x426.79135, glue set 307.5305fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
@@ -47,9 +47,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 昆
-....\kern -0.00017
-....\kern 0.00017
-....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 等
 ....\kern -0.00017
 ....\kern 0.00017
@@ -86,7 +84,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.00568
-...\hbox(10.92532+2.144)x426.79135, glue set 290.96863fil
+...\hbox(10.92532+2.144)x426.79135, glue set 293.97987fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
@@ -95,9 +93,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 张
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 昆
-....\kern -0.00017
-....\kern 0.00017
-....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 等
 ....\kern -0.00017
 ....\kern 0.00017
@@ -630,21 +626,22 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\kern 710.18088
 .\kern 0.0
-Package fontspec Info: 
-(fontspec)             Font family 'FandolHei(0)' created for font 'FandolHei' with options [Extension={.otf},UprightFont={*-Regular},BoldFont={*-Bold}].
+Package fontspec Info: Font family 'FandolHei(0)' created for font 'FandolHei' with options [Extension={.otf},UprightFont={*-Regular},BoldFont={*-Bold}].
 (fontspec)              
 (fontspec)              This font family consists of the following NFSS series/shapes:
 (fontspec)              
 (fontspec)             - 'normal' (m/n) with NFSS spec.: <->"[FandolHei-Regular.otf]/OT:language=dflt;"
+(fontspec)             - 'small caps'  (m/sc) with NFSS spec.: 
 (fontspec)             - 'bold' (b/n) with NFSS spec.: <->"[FandolHei-Bold.otf]/OT:language=dflt;"
+(fontspec)             - 'bold small caps'  (b/sc) with NFSS spec.: 
 LaTeX Font Info:    Font shape `TU/texgyrecursor(0)/m/n' will be
 (Font)              scaled to size 12.99814pt on input line ....
-Package fontspec Info: 
-(fontspec)             Font family 'FandolFang(0)' created for font 'FandolFang' with options [Extension={.otf},UprightFont={*-Regular}].
+Package fontspec Info: Font family 'FandolFang(0)' created for font 'FandolFang' with options [Extension={.otf},UprightFont={*-Regular}].
 (fontspec)              
 (fontspec)              This font family consists of the following NFSS series/shapes:
 (fontspec)              
 (fontspec)             - 'normal' (m/n) with NFSS spec.: <->"[FandolFang-Regular.otf]/OT:language=dflt;"
+(fontspec)             - 'small caps'  (m/sc) with NFSS spec.: 
 LaTeX Font Info:    Font shape `TU/texgyrecursor(0)/m/n' will be
 (Font)              scaled to size 11.37337pt on input line ....
 LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be

--- a/testfiles/10-biblatex/10-biblatex-numeric.tlg
+++ b/testfiles/10-biblatex/10-biblatex-numeric.tlg
@@ -626,22 +626,21 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\kern 710.18088
 .\kern 0.0
-Package fontspec Info: Font family 'FandolHei(0)' created for font 'FandolHei' with options [Extension={.otf},UprightFont={*-Regular},BoldFont={*-Bold}].
+Package fontspec Info: 
+(fontspec)             Font family 'FandolHei(0)' created for font 'FandolHei' with options [Extension={.otf},UprightFont={*-Regular},BoldFont={*-Bold}].
 (fontspec)              
 (fontspec)              This font family consists of the following NFSS series/shapes:
 (fontspec)              
 (fontspec)             - 'normal' (m/n) with NFSS spec.: <->"[FandolHei-Regular.otf]/OT:language=dflt;"
-(fontspec)             - 'small caps'  (m/sc) with NFSS spec.: 
 (fontspec)             - 'bold' (b/n) with NFSS spec.: <->"[FandolHei-Bold.otf]/OT:language=dflt;"
-(fontspec)             - 'bold small caps'  (b/sc) with NFSS spec.: 
 LaTeX Font Info:    Font shape `TU/texgyrecursor(0)/m/n' will be
 (Font)              scaled to size 12.99814pt on input line ....
-Package fontspec Info: Font family 'FandolFang(0)' created for font 'FandolFang' with options [Extension={.otf},UprightFont={*-Regular}].
+Package fontspec Info: 
+(fontspec)             Font family 'FandolFang(0)' created for font 'FandolFang' with options [Extension={.otf},UprightFont={*-Regular}].
 (fontspec)              
 (fontspec)              This font family consists of the following NFSS series/shapes:
 (fontspec)              
 (fontspec)             - 'normal' (m/n) with NFSS spec.: <->"[FandolFang-Regular.otf]/OT:language=dflt;"
-(fontspec)             - 'small caps'  (m/sc) with NFSS spec.: 
 LaTeX Font Info:    Font shape `TU/texgyrecursor(0)/m/n' will be
 (Font)              scaled to size 11.37337pt on input line ....
 LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be

--- a/thuthesis-numeric.cbx
+++ b/thuthesis-numeric.cbx
@@ -11,7 +11,9 @@
       \mkbibbrackets{##1}}%
     #1\endgroup}\kern\z@}
 
-\DefineBibliographyStrings{english}{
-  andothersincitecn={\unspace 等},%
-  andothersincite = {等}
-}
+\ifthu@main@language@chinese
+  \DefineBibliographyStrings{english}{
+    andothersincitecn={\unspace 等},%
+    andothersincite = {等}
+  }
+\fi

--- a/thuthesis-numeric.cbx
+++ b/thuthesis-numeric.cbx
@@ -10,3 +10,8 @@
       \blx@warning{Nested superscript}%
       \mkbibbrackets{##1}}%
     #1\endgroup}\kern\z@}
+
+\DefineBibliographyStrings{english}{
+  andothersincitecn={\unspace 等},%
+  andothersincite = {等}
+}


### PR DESCRIPTION
参见 https://github.com/tuna/thuthesis/issues/303#issuecomment-2746042912

写作指南里3.4.1节有关于“顺序编码制”的示范，采用的是

> 多次引用同一著者的同一文献时，在正文中标注首次引用的文献序号，并在序号的“[]”外著录引文页码。例如：
> 张中国等[4]15-17......，张中国等[4]55认为......。

其中，姓名和等之间没有空格。