### PR TITLE
添加苏世民学院的特殊样式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- 添加苏世民学院格式（[#1037](https://github.com/tuna/thuthesis/discussions/1037)）。。
+
 ### Changed
 
 - `Biblatex` 的斜线不再默认使用等宽字体（[#1018](https://github.com/tuna/thuthesis/discussions/1018)）。

--- a/testfiles/09-schwarzman.tex
+++ b/testfiles/09-schwarzman.tex
@@ -1,0 +1,150 @@
+\input{regression-test.tex}
+\documentclass[degree=doctor]{thuthesis}
+
+\thusetup{
+  footnote-numbering = global,
+  footnote-style = plain,
+  figure-numbering = global,
+  table-numbering = global,
+  equation-numbering = global,
+}
+
+\begin{document}
+\START
+\showoutput
+
+\mainmatter
+
+
+\chapter{章标题}
+
+文字。\footnote{脚注内容1。}
+文字。\footnote{脚注内容2。}
+文字。\footnote{脚注内容3。}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{figure}
+  \caption{Figure caption 1}
+\end{figure}
+
+\begin{figure}
+  \caption{Figure caption 2}
+\end{figure}
+
+\begin{figure}
+  \caption{Figure caption 3}
+\end{figure}
+
+\begin{table}
+  \caption{Table caption 1}
+\end{table}
+
+\begin{table}
+  \caption{Table caption 2}
+\end{table}
+
+\begin{table}
+  \caption{Table caption 3}
+\end{table}
+
+
+\chapter{章标题}
+
+文字。\footnote{脚注内容1。}
+文字。\footnote{脚注内容2。}
+文字。\footnote{脚注内容3。}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{figure}
+  \caption{Figure caption 1}
+\end{figure}
+
+\begin{figure}
+  \caption{Figure caption 2}
+\end{figure}
+
+\begin{figure}
+  \caption{Figure caption 3}
+\end{figure}
+
+\begin{table}
+  \caption{Table caption 1}
+\end{table}
+
+\begin{table}
+  \caption{Table caption 2}
+\end{table}
+
+\begin{table}
+  \caption{Table caption 3}
+\end{table}
+
+
+\chapter{章标题}
+
+文字。\footnote{脚注内容1。}
+文字。\footnote{脚注内容2。}
+文字。\footnote{脚注内容3。}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{equation}
+  E=mc^2
+\end{equation}
+
+\begin{figure}
+  \caption{Figure caption 1}
+\end{figure}
+
+\begin{figure}
+  \caption{Figure caption 2}
+\end{figure}
+
+\begin{figure}
+  \caption{Figure caption 3}
+\end{figure}
+
+\begin{table}
+  \caption{Table caption 1}
+\end{table}
+
+\begin{table}
+  \caption{Table caption 2}
+\end{table}
+
+\begin{table}
+  \caption{Table caption 3}
+\end{table}
+
+
+\clearpage
+\OMIT
+\end{document}

--- a/testfiles/09-schwarzman.tex
+++ b/testfiles/09-schwarzman.tex
@@ -1,13 +1,5 @@
 \input{regression-test.tex}
-\documentclass[degree=doctor]{thuthesis}
-
-\thusetup{
-  footnote-numbering = global,
-  footnote-style = plain,
-  figure-numbering = global,
-  table-numbering = global,
-  equation-numbering = global,
-}
+\documentclass[degree=doctor, style-override=schwarzman]{thuthesis}
 
 \begin{document}
 \START
@@ -102,6 +94,7 @@
 \end{table}
 
 
+\appendix
 \chapter{章标题}
 
 文字。\footnote{脚注内容1。}

--- a/testfiles/09-schwarzman.tlg
+++ b/testfiles/09-schwarzman.tlg
@@ -1,0 +1,2811 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+第1章
+Package fontspec Info: 
+(fontspec)             Font family 'FandolHei(0)' created for font 'FandolHei' with options [Extension={.otf},UprightFont={*-Regular},BoldFont={*-Bold}].
+(fontspec)              
+(fontspec)              This font family consists of the following NFSS series/shapes:
+(fontspec)              
+(fontspec)             - 'normal' (m/n) with NFSS spec.: <->"[FandolHei-Regular.otf]/OT:language=dflt;"
+(fontspec)             - 'bold' (b/n) with NFSS spec.: <->"[FandolHei-Bold.otf]/OT:language=dflt;"
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 12.04628pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 9.03471pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 7.22777pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 12.0437pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 9.03278pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 7.22623pt on input line ....
+Completed box being shipped out [1]
+\vbox(710.18088+4.1104)x439.87962
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue -72.26997
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
+...\glue 0.0 plus 1.0fil
+...\hbox(13.70119+0.0)x426.79135
+....\special{color push gray 0}
+....\hbox(13.70119+0.0)x426.79135
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 第
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/texgyretermes(0)/m/n/10.53937 1
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 标
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 题
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\special{color pop}
+..\glue 8.5359
+..\glue(\lineskip) 0.0
+..\vbox(674.33032+0.0)x426.79135, glue set 258.6048fil
+...\write-{}
+...\special{color push gray 0}
+...\write-{}
+...\write-{}
+...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\marks1{\__mark_value:nn {1}{第1章\hskip 1em\relax 章标题}}
+...\marks2{\__mark_value:nn {2}{}}
+...\glue(\topskip) 12.0
+...\rule(0.0+0.0)x*
+...\penalty 10000
+...\glue 15.10124 plus -1.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\hbox(12.55891+2.8426)x426.79135, glue set 156.28633fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\TU/FandolHei(0)/m/n/16.06 第
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 1
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/FandolHei(0)/m/n/16.06 章
+....\kern -0.00017
+....\kern 0.00017
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 章
+....\glue 0.0 plus 1.0538
+....\TU/FandolHei(0)/m/n/16.06 标
+....\glue 0.0 plus 1.0538
+....\TU/FandolHei(0)/m/n/16.06 题
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty 10000
+...\glue 27.10124 plus -1.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\hbox(10.92532+2.10786)x426.79135, glue set 273.22325fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 1
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 2
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.12646)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 3
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.96713
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 1
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.66602
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 2
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.66602
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 3
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\penalty 10000
+...\penalty 0
+...\penalty 10000
+...\penalty 0
+...\penalty 10000
+...\glue 0.0 plus 1.0fil
+...\glue 10.8 plus 4.0 minus 2.0
+...\special{color push gray 0}
+...\glue -3.0
+...\rule(0.4+0.0)x128.0387
+...\glue 2.6
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.0)x13.55061
+......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.0)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 1
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 1
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.0)x13.55061
+......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.0)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 2
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 2
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.12645)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.12645)x13.55061
+......\hbox(6.10681+0.12645)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.12645)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 3
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 3
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\special{color pop}
+...\glue -3.5232
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
+...\special{color push gray 0}
+...\hbox(15.61334+4.1104)x426.79135
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 1
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\special{color pop}
+.\kern -714.29128
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\kern 714.29128
+.\kern 0.0
+Completed box being shipped out [2]
+\vbox(710.18088+4.1104)x439.87962
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue -72.26997
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
+...\glue 0.0 plus 1.0fil
+...\hbox(13.70119+0.0)x426.79135
+....\special{color push gray 0}
+....\hbox(13.70119+0.0)x426.79135
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 第
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/texgyretermes(0)/m/n/10.53937 1
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 标
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 题
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+....\special{color pop}
+..\glue 8.5359
+..\glue(\lineskip) 0.0
+..\vbox(674.33032+0.0)x426.79135, glue set 98.18533fil
+...\glue 0.0 plus 1.0fil
+...\glue -12.045 plus -2.0fil
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 0.0 plus 1.0fil
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
+...\special{color push gray 0}
+...\hbox(15.61334+4.1104)x426.79135
+....\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 2
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+...\special{color pop}
+.\kern -714.29128
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\kern 714.29128
+.\kern 0.0
+第2章
+Completed box being shipped out [3]
+\vbox(710.18088+4.1104)x439.87962
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue -72.26997
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
+...\glue 0.0 plus 1.0fil
+...\hbox(13.70119+0.0)x426.79135
+....\special{color push gray 0}
+....\hbox(13.70119+0.0)x426.79135
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 第
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/texgyretermes(0)/m/n/10.53937 2
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 标
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 题
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\special{color pop}
+..\glue 8.5359
+..\glue(\lineskip) 0.0
+..\vbox(674.33032+0.0)x426.79135, glue set 258.6048fil
+...\write-{}
+...\write1{\pp@pagectr{footnote}{5}{\theabspage }{\thepage }}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\marks1{\__mark_value:nn {3}{第2章\hskip 1em\relax 章标题}}
+...\marks2{\__mark_value:nn {4}{}}
+...\glue(\topskip) 12.0
+...\rule(0.0+0.0)x*
+...\penalty 10000
+...\glue 15.10124 plus -1.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\hbox(12.55891+2.8426)x426.79135, glue set 156.28633fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\TU/FandolHei(0)/m/n/16.06 第
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 2
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/FandolHei(0)/m/n/16.06 章
+....\kern -0.00017
+....\kern 0.00017
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 章
+....\glue 0.0 plus 1.0538
+....\TU/FandolHei(0)/m/n/16.06 标
+....\glue 0.0 plus 1.0538
+....\TU/FandolHei(0)/m/n/16.06 题
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty 10000
+...\glue 27.10124 plus -1.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\hbox(10.92532+2.10786)x426.79135, glue set 273.22325fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{6}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 1
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{7}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 2
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{8}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.12646)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 3
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.96713
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 4
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.66602
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 5
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.66602
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 6
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 4
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 5
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 6
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\penalty 10000
+...\penalty 0
+...\penalty 10000
+...\penalty 0
+...\penalty 10000
+...\glue 0.0 plus 1.0fil
+...\glue 10.8 plus 4.0 minus 2.0
+...\special{color push gray 0}
+...\glue -3.0
+...\rule(0.4+0.0)x128.0387
+...\glue 2.6
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.0)x13.55061
+......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.0)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 1
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 1
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.0)x13.55061
+......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.0)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 2
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 2
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.12645)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.12645)x13.55061
+......\hbox(6.10681+0.12645)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.12645)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 3
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 3
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\special{color pop}
+...\glue -3.5232
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
+...\special{color push gray 0}
+...\hbox(15.61334+4.1104)x426.79135
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 3
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\special{color pop}
+.\kern -714.29128
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\kern 714.29128
+.\kern 0.0
+Completed box being shipped out [4]
+\vbox(710.18088+4.1104)x439.87962
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue -72.26997
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
+...\glue 0.0 plus 1.0fil
+...\hbox(13.70119+0.0)x426.79135
+....\special{color push gray 0}
+....\hbox(13.70119+0.0)x426.79135
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 第
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/texgyretermes(0)/m/n/10.53937 2
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 标
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 题
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+....\special{color pop}
+..\glue 8.5359
+..\glue(\lineskip) 0.0
+..\vbox(674.33032+0.0)x426.79135, glue set 98.18533fil
+...\glue 0.0 plus 1.0fil
+...\glue -12.045 plus -2.0fil
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 4
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 5
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 6
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 0.0 plus 1.0fil
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
+...\special{color push gray 0}
+...\hbox(15.61334+4.1104)x426.79135
+....\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 4
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+...\special{color pop}
+.\kern -714.29128
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\kern 714.29128
+.\kern 0.0
+第3章
+Completed box being shipped out [5]
+\vbox(710.18088+4.1104)x439.87962
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue -72.26997
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
+...\glue 0.0 plus 1.0fil
+...\hbox(13.70119+0.0)x426.79135
+....\special{color push gray 0}
+....\hbox(13.70119+0.0)x426.79135
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 第
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/texgyretermes(0)/m/n/10.53937 3
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 标
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 题
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\special{color pop}
+..\glue 8.5359
+..\glue(\lineskip) 0.0
+..\vbox(674.33032+0.0)x426.79135, glue set 258.6048fil
+...\write-{}
+...\write1{\pp@pagectr{footnote}{9}{\theabspage }{\thepage }}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\marks1{\__mark_value:nn {5}{第3章\hskip 1em\relax 章标题}}
+...\marks2{\__mark_value:nn {6}{}}
+...\glue(\topskip) 12.0
+...\rule(0.0+0.0)x*
+...\penalty 10000
+...\glue 15.10124 plus -1.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\hbox(12.55891+2.8426)x426.79135, glue set 156.28633fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\TU/FandolHei(0)/m/n/16.06 第
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 3
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/FandolHei(0)/m/n/16.06 章
+....\kern -0.00017
+....\kern 0.00017
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 章
+....\glue 0.0 plus 1.0538
+....\TU/FandolHei(0)/m/n/16.06 标
+....\glue 0.0 plus 1.0538
+....\TU/FandolHei(0)/m/n/16.06 题
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty 10000
+...\glue 27.10124 plus -1.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\hbox(10.92532+2.10786)x426.79135, glue set 273.22325fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{10}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 1
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{11}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 2
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\write1{\pp@pagectr{footnote}{12}{\theabspage }{\thepage }}
+....\penalty 10000
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.12646)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 3
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.96713
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 7
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.66602
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 8
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.66602
+...\hbox(0.0+0.0)x426.79135, glue set 402.70135fil
+....\hbox(0.0+0.0)x24.09
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 6.02249
+...\glue(\baselineskip) 9.14967
+...\hbox(10.92532+2.40898)x235.11356, shifted 191.6778
+....\hbox(10.92532+0.13249)x43.43576, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2480
+.....\kern0.7227
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.34618 plus 3.34618
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2513
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2504
+.....\kern0.60225
+.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+....\kern169.20183
+....\hbox(9.636+2.40898)x22.47597, display
+.....\hbox(9.636+2.40898)x22.47597
+......\glue 0.0
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 9
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+...\penalty 0
+...\glue(\belowdisplayshortskip) 6.02249
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 7
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 8
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\glue 12.0 plus 2.0 minus 2.0
+...\glue 0.0 plus 1.0
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\rule(0.0+0.0)x*
+.....\glue 6.02249
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 162.10909fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 图
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 9
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Figure
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 0.0
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 12.0 plus 2.0 minus 2.0
+...\penalty 0
+...\penalty 10000
+...\penalty 0
+...\penalty 10000
+...\penalty 0
+...\penalty 10000
+...\glue 0.0 plus 1.0fil
+...\glue 10.8 plus 4.0 minus 2.0
+...\special{color push gray 0}
+...\glue -3.0
+...\rule(0.4+0.0)x128.0387
+...\glue 2.6
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.0)x13.55061
+......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.0)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 1
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 1
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.0)x13.55061
+......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.0)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 2
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 2
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
+....\hbox(0.0+0.0)x0.0
+....\hbox(6.10681+0.12645)x0.0, glue set - 13.55061fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(6.10681+0.12645)x13.55061
+......\hbox(6.10681+0.12645)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.12645)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 3
+........\kern -0.0002
+........\kern 0.0002
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(8.4+0.0)x0.0
+.....\rule(8.4+0.0)x0.0
+....\TU/FandolSong(0)/m/n/9.03374 脚
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 注
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 内
+....\glue 0.0 plus 0.36642
+....\TU/FandolSong(0)/m/n/9.03374 容
+....\glue 2.25844 plus 1.12921 minus 0.7528
+....\TU/texgyretermes(0)/m/n/9.03374 3
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/9.03374 。
+....\rule(0.0+0.0)x-5.81773
+....\kern 0.00035
+....\kern -0.00035
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\rule(0.0+3.5232)x0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\special{color pop}
+...\glue -3.5232
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
+...\special{color push gray 0}
+...\hbox(15.61334+4.1104)x426.79135
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 5
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\special{color pop}
+.\kern -714.29128
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\kern 714.29128
+.\kern 0.0
+Completed box being shipped out [6]
+\vbox(710.18088+4.1104)x439.87962
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue -72.26997
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
+...\glue 0.0 plus 1.0fil
+...\hbox(13.70119+0.0)x426.79135
+....\special{color push gray 0}
+....\hbox(13.70119+0.0)x426.79135
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 第
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/texgyretermes(0)/m/n/10.53937 3
+..........\glue 2.63484 plus 1.31741 minus 0.87828
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 章
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 标
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 题
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+....\special{color pop}
+..\glue 8.5359
+..\glue(\lineskip) 0.0
+..\vbox(674.33032+0.0)x426.79135, glue set 98.18533fil
+...\glue 0.0 plus 1.0fil
+...\glue -12.045 plus -2.0fil
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 7
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 1
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 8
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 2
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 12.045 plus 2.0fil
+...\vbox(20.3761+0.0)x426.79135
+....\special{color push gray 0}
+....\vbox(20.3761+0.0)x426.79135
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\special{color push gray 0}
+.....\glue 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.04749+4.30612)x426.79135
+......\hbox(0.0+0.0)x0.0
+......\glue 0.0
+......\vbox(10.04749+4.30612)x426.79135
+.......\hbox(10.04749+4.30612)x426.79135, glue set 164.28421fil
+........\glue(\leftskip) 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+........\TU/FandolSong(0)/m/n/11.04124 表
+........\kern -0.00017
+........\kern 0.00017
+........\penalty 10000
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 9
+........\kern -0.0002
+........\kern 0.0002
+........\glue 11.04124
+........\rule(10.04749+*)x0.0
+........\penalty 10000
+........\glue 0.0
+........\TU/texgyretermes(0)/m/n/11.04124 Table
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 caption
+........\glue 2.76031 plus 1.38016 minus 0.9201
+........\TU/texgyretermes(0)/m/n/11.04124 3
+........\kern -0.0002
+........\kern 0.0002
+........\penalty 10000
+........\rule(0.0+4.30612)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0
+........\glue(\rightskip) 0.0 plus 1.0fil
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+.....\glue 6.02249
+.....\rule(0.0+0.0)x*
+.....\special{color pop}
+.....\glue 0.0
+....\special{color pop}
+...\glue 0.0 plus 1.0fil
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
+...\special{color push gray 0}
+...\hbox(15.61334+4.1104)x426.79135
+....\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 6
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+...\special{color pop}
+.\kern -714.29128
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, shifted 845.04684
+.....\kern 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\kern 714.29128
+.\kern 0.0

--- a/testfiles/09-schwarzman.tlg
+++ b/testfiles/09-schwarzman.tlg
@@ -96,7 +96,6 @@ Completed box being shipped out [1]
 ...\special{color push gray 0}
 ...\write-{}
 ...\write-{}
-...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
 ...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
 ...\marks1{\__mark_value:nn {1}{第1章\hskip 1em\relax 章标题}}
 ...\marks2{\__mark_value:nn {2}{}}
@@ -144,8 +143,6 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-....\penalty 10000
 ....\penalty 10000
 ....\hbox(10.92532+0.0)x5.01688
 .....\mathon
@@ -166,8 +163,6 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-....\penalty 10000
 ....\penalty 10000
 ....\hbox(10.92532+0.0)x5.01688
 .....\mathon
@@ -188,8 +183,6 @@ Completed box being shipped out [1]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
-....\penalty 10000
 ....\penalty 10000
 ....\hbox(10.92532+0.0)x5.01688
 .....\mathon
@@ -952,6 +945,7 @@ Completed box being shipped out [2]
 .\kern 714.29128
 .\kern 0.0
 第2章
+No file bu.aux.
 Completed box being shipped out [3]
 \vbox(710.18088+4.1104)x439.87962
 .\hbox(0.0+0.0)x0.0
@@ -1023,9 +1017,8 @@ Completed box being shipped out [3]
 ....\special{color pop}
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
-..\vbox(674.33032+0.0)x426.79135, glue set 258.6048fil
+..\vbox(674.33032+0.0)x426.79135, glue set 258.4964fil
 ...\write-{}
-...\write1{\pp@pagectr{footnote}{5}{\theabspage }{\thepage }}
 ...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
 ...\marks1{\__mark_value:nn {3}{第2章\hskip 1em\relax 章标题}}
 ...\marks2{\__mark_value:nn {4}{}}
@@ -1060,7 +1053,7 @@ Completed box being shipped out [3]
 ...\glue 27.10124 plus -1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
-...\hbox(10.92532+2.10786)x426.79135, glue set 273.22325fil
+...\hbox(11.03374+2.10786)x426.79135, glue set 273.22325fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 文
 ....\glue 0.0 plus 0.52307
@@ -1073,13 +1066,11 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{6}{\theabspage }{\thepage }}
-....\penalty 10000
 ....\penalty 10000
 ....\hbox(10.92532+0.0)x5.01688
 .....\mathon
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
-......\TU/texgyretermes(0)/m/n/9.03375 1
+......\TU/texgyretermes(0)/m/n/9.03375 4
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -1095,13 +1086,11 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{7}{\theabspage }{\thepage }}
 ....\penalty 10000
-....\penalty 10000
-....\hbox(10.92532+0.0)x5.01688
+....\hbox(11.03374+0.0)x5.01688
 .....\mathon
-.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
-......\TU/texgyretermes(0)/m/n/9.03375 2
+.....\hbox(6.21523+0.12646)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 5
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -1117,13 +1106,11 @@ Completed box being shipped out [3]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{8}{\theabspage }{\thepage }}
 ....\penalty 10000
-....\penalty 10000
-....\hbox(10.92532+0.0)x5.01688
+....\hbox(10.9976+0.0)x5.01688
 .....\mathon
-.....\hbox(6.10681+0.12646)x5.01688, shifted -4.81851
-......\TU/texgyretermes(0)/m/n/9.03375 3
+.....\hbox(6.1791+0.12646)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 6
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -1442,6 +1429,10 @@ Completed box being shipped out [3]
 ...\penalty 10000
 ...\penalty 0
 ...\penalty 10000
+...\write1{\ttl@writefile{toc}{\protect \setcounter {tocdepth}{0}}}
+...\write1{\@writefile{lof}{\let\contentsline\ttl@gobblecontents}}
+...\write1{\@writefile{lot}{\let\contentsline\ttl@gobblecontents}}
+...\write1{\@writefile{loe}{\let\contentsline\ttl@gobblecontents}}
 ...\glue 0.0 plus 1.0fil
 ...\glue 10.8 plus 4.0 minus 2.0
 ...\special{color push gray 0}
@@ -1455,7 +1446,7 @@ Completed box being shipped out [3]
 .....\hbox(6.10681+0.0)x13.55061
 ......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
 .......\hbox(6.10681+0.0)x4.51688
-........\TU/texgyretermes(0)/m/n/9.03374 1
+........\TU/texgyretermes(0)/m/n/9.03374 4
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1484,12 +1475,12 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+....\hbox(6.21521+0.12645)x0.0, glue set - 13.55061fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.0)x13.55061
-......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
-.......\hbox(6.10681+0.0)x4.51688
-........\TU/texgyretermes(0)/m/n/9.03374 2
+.....\hbox(6.21521+0.12645)x13.55061
+......\hbox(6.21521+0.12645)x13.55061, glue set 9.03374fil
+.......\hbox(6.21521+0.12645)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 5
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1518,12 +1509,12 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.12645)x0.0, glue set - 13.55061fil
+....\hbox(6.17908+0.12645)x0.0, glue set - 13.55061fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.12645)x13.55061
-......\hbox(6.10681+0.12645)x13.55061, glue set 9.03374fil
-.......\hbox(6.10681+0.12645)x4.51688
-........\TU/texgyretermes(0)/m/n/9.03374 3
+.....\hbox(6.17908+0.12645)x13.55061
+......\hbox(6.17908+0.12645)x13.55061, glue set 9.03374fil
+.......\hbox(6.17908+0.12645)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 6
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1880,7 +1871,7 @@ Completed box being shipped out [4]
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\kern 714.29128
 .\kern 0.0
-第3章
+附录 A
 Completed box being shipped out [5]
 \vbox(710.18088+4.1104)x439.87962
 .\hbox(0.0+0.0)x0.0
@@ -1913,16 +1904,16 @@ Completed box being shipped out [5]
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\glue 0.0 plus 1.0fill
 ........\vbox(9.59079+4.1104)x426.79135
-.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.65544fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong(0)/m/n/10.53937 第
-..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/texgyretermes(0)/m/n/10.53937 3
-..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong(0)/m/n/10.53937 章
-..........\kern -0.00017
-..........\kern 0.00017
+..........\TU/FandolSong(0)/m/n/10.53937 附
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 录
+..........\glue 2.63484 plus 1.31609 minus 0.87915
+..........\TU/texgyretermes(0)/m/n/10.53937 A
+..........\kern -0.0002
+..........\kern 0.0002
 ..........\glue 10.53937
 ..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\glue 0.0 plus 0.41463
@@ -1952,11 +1943,10 @@ Completed box being shipped out [5]
 ....\special{color pop}
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
-..\vbox(674.33032+0.0)x426.79135, glue set 258.6048fil
+..\vbox(674.33032+0.0)x426.79135, glue set 258.79749fil
 ...\write-{}
-...\write1{\pp@pagectr{footnote}{9}{\theabspage }{\thepage }}
 ...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
-...\marks1{\__mark_value:nn {5}{第3章\hskip 1em\relax 章标题}}
+...\marks1{\__mark_value:nn {5}{附录 A\hskip 1em\relax 章标题}}
 ...\marks2{\__mark_value:nn {6}{}}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
@@ -1965,15 +1955,17 @@ Completed box being shipped out [5]
 ...\glue 0.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
-...\hbox(12.55891+2.8426)x426.79135, glue set 156.28633fil
+...\hbox(12.41438+2.79442)x426.79135, glue set 157.62733fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/16.06 第
+....\TU/FandolHei(0)/m/n/16.06 附
+....\glue 0.0 plus 1.0538
+....\TU/FandolHei(0)/m/n/16.06 录
+....\kern -0.00018
+....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/texgyreheros(0)/m/n/16.06 3
-....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/FandolHei(0)/m/n/16.06 章
-....\kern -0.00017
-....\kern 0.00017
+....\TU/texgyreheros(0)/m/n/16.06 A
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 16.06
 ....\TU/FandolHei(0)/m/n/16.06 章
 ....\glue 0.0 plus 1.0538
@@ -2002,13 +1994,11 @@ Completed box being shipped out [5]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{10}{\theabspage }{\thepage }}
 ....\penalty 10000
-....\penalty 10000
-....\hbox(10.92532+0.0)x5.01688
+....\hbox(10.79886+0.0)x5.01688
 .....\mathon
-.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
-......\TU/texgyretermes(0)/m/n/9.03375 1
+.....\hbox(5.98035+0.07225)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 7
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -2024,35 +2014,31 @@ Completed box being shipped out [5]
 ....\kern -0.18753
 ....\kern 0.18753
 ....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{11}{\theabspage }{\thepage }}
-....\penalty 10000
-....\penalty 10000
-....\hbox(10.92532+0.0)x5.01688
-.....\mathon
-.....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
-......\TU/texgyretermes(0)/m/n/9.03375 2
-......\kern -0.0002
-......\kern 0.0002
-.....\mathoff
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 文
-....\glue 0.0 plus 0.52307
-....\TU/FandolSong(0)/m/n/12.045 字
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
-....\glue 7.75697 minus 6.02249
-....\write1{\pp@pagectr{footnote}{12}{\theabspage }{\thepage }}
-....\penalty 10000
 ....\penalty 10000
 ....\hbox(10.92532+0.0)x5.01688
 .....\mathon
 .....\hbox(6.10681+0.12646)x5.01688, shifted -4.81851
-......\TU/texgyretermes(0)/m/n/9.03375 3
+......\TU/texgyretermes(0)/m/n/9.03375 8
+......\kern -0.0002
+......\kern 0.0002
+.....\mathoff
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.52307
+....\TU/FandolSong(0)/m/n/12.045 字
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\glue 7.75697 minus 6.02249
+....\penalty 10000
+....\hbox(10.92532+0.0)x5.01688
+.....\mathon
+.....\hbox(6.10681+0.19873)x5.01688, shifted -4.81851
+......\TU/texgyretermes(0)/m/n/9.03375 9
 ......\kern -0.0002
 ......\kern 0.0002
 .....\mathoff
@@ -2379,12 +2365,12 @@ Completed box being shipped out [5]
 ...\glue 2.6
 ...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+....\hbox(5.98033+0.07225)x0.0, glue set - 13.55061fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.0)x13.55061
-......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
-.......\hbox(6.10681+0.0)x4.51688
-........\TU/texgyretermes(0)/m/n/9.03374 1
+.....\hbox(5.98033+0.07225)x13.55061
+......\hbox(5.98033+0.07225)x13.55061, glue set 9.03374fil
+.......\hbox(5.98033+0.07225)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 7
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2413,12 +2399,12 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.0)x0.0, glue set - 13.55061fil
+....\hbox(6.10681+0.12645)x0.0, glue set - 13.55061fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.0)x13.55061
-......\hbox(6.10681+0.0)x13.55061, glue set 9.03374fil
-.......\hbox(6.10681+0.0)x4.51688
-........\TU/texgyretermes(0)/m/n/9.03374 2
+.....\hbox(6.10681+0.12645)x13.55061
+......\hbox(6.10681+0.12645)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.12645)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 8
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2447,12 +2433,12 @@ Completed box being shipped out [5]
 ....\glue(\rightskip) 0.0
 ...\hbox(8.4+3.5232)x413.24074, glue set 367.11447fil, shifted 13.55061
 ....\hbox(0.0+0.0)x0.0
-....\hbox(6.10681+0.12645)x0.0, glue set - 13.55061fil
+....\hbox(6.10681+0.19873)x0.0, glue set - 13.55061fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(6.10681+0.12645)x13.55061
-......\hbox(6.10681+0.12645)x13.55061, glue set 9.03374fil
-.......\hbox(6.10681+0.12645)x4.51688
-........\TU/texgyretermes(0)/m/n/9.03374 3
+.....\hbox(6.10681+0.19873)x13.55061
+......\hbox(6.10681+0.19873)x13.55061, glue set 9.03374fil
+.......\hbox(6.10681+0.19873)x4.51688
+........\TU/texgyretermes(0)/m/n/9.03374 9
 ........\kern -0.0002
 ........\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2569,16 +2555,16 @@ Completed box being shipped out [6]
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\glue 0.0 plus 1.0fill
 ........\vbox(9.59079+4.1104)x426.79135
-.........\hbox(9.59079+4.1104)x426.79135, glue set 176.50789fil
+.........\hbox(9.59079+4.1104)x426.79135, glue set 176.65544fil
 ..........\glue(\leftskip) 0.0 plus 1.0fil
 ..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong(0)/m/n/10.53937 第
-..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/texgyretermes(0)/m/n/10.53937 3
-..........\glue 2.63484 plus 1.31741 minus 0.87828
-..........\TU/FandolSong(0)/m/n/10.53937 章
-..........\kern -0.00017
-..........\kern 0.00017
+..........\TU/FandolSong(0)/m/n/10.53937 附
+..........\glue 0.0 plus 0.41463
+..........\TU/FandolSong(0)/m/n/10.53937 录
+..........\glue 2.63484 plus 1.31609 minus 0.87915
+..........\TU/texgyretermes(0)/m/n/10.53937 A
+..........\kern -0.0002
+..........\kern 0.0002
 ..........\glue 10.53937
 ..........\TU/FandolSong(0)/m/n/10.53937 章
 ..........\glue 0.0 plus 0.41463

--- a/testfiles/09-schwarzman.tlg
+++ b/testfiles/09-schwarzman.tlg
@@ -218,10 +218,11 @@ Completed box being shipped out [1]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -267,10 +268,11 @@ Completed box being shipped out [1]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -316,10 +318,11 @@ Completed box being shipped out [1]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -1141,10 +1144,11 @@ Completed box being shipped out [3]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -1190,10 +1194,11 @@ Completed box being shipped out [3]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -1239,10 +1244,11 @@ Completed box being shipped out [3]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -2069,10 +2075,11 @@ Completed box being shipped out [5]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -2118,10 +2125,11 @@ Completed box being shipped out [5]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009
@@ -2167,10 +2175,11 @@ Completed box being shipped out [5]
 .....\kern0.60225
 .....\hbox(6.10681+0.0)x5.01688, shifted -4.81851
 ......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-....\kern169.20183
-....\hbox(9.636+2.40898)x22.47597, display
-.....\hbox(9.636+2.40898)x22.47597
-......\glue 0.0
+....\kern161.56529
+....\hbox(9.636+2.40898)x30.1125, display
+.....\hbox(9.636+2.40898)x30.1125
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
 ......\rule(0.0+0.0)x-7.63654
 ......\TU/FandolSong(0)/m/n/12.045 （
 ......\kern 0.00009

--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -7,6 +7,8 @@
   %   doctor | master | bachelor | postdoc
   % 学位类型 degree-type:
   %   academic（默认）| professional
+  % 特殊格式 style-override:
+  %   none（默认）| schwarzman（苏世民学院）
   % 语言 language
   %   chinese（默认）| english
   % 字体库 fontset

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -313,6 +313,14 @@
 %   \documentclass[degree=master, degree-type=professional]{thuthesis}
 % \end{latex}
 %
+% \subsubsection{学院特殊格式}
+% \label{sec:style-override}
+% \DescribeOption{style-override}
+% 选择苏世民学院的特殊格式，可选：\option{none}（默认）、\option{schwarzman}。
+% \begin{latex}
+%   \documentclass[degree=master, style-override=schwarzman]{thuthesis}
+% \end{latex}
+%
 % \subsubsection{字体配置}
 % \label{sec:font-config}
 % \DescribeOption{fontset}
@@ -1645,6 +1653,54 @@
       half,
     }
   },
+%    \end{macrocode}
+%
+% 苏世民学院的格式相比学校有如下变动：全文的脚注都连续编号（包括到附录中），不使用带圈数字；
+% 全文图、表、公式连续编号。
+%    \begin{macrocode}
+  style-override = {
+    name    = style@override,
+    choices = {
+      none,
+      schwarzman,
+    },
+  },
+  footnote-numbering = {
+    name    = footnote@numbering,
+    choices = {
+      page,
+      chapter,
+      global,
+    },
+  },
+  footnote-style = {
+    name    = footnote@style,
+    choices = {
+      circled,
+      plain,
+    },
+  },
+  figure-numbering = {
+    name    = figure@numbering,
+    choices = {
+      chapter,
+      global,
+    },
+  },
+  table-numbering = {
+    name    = table@numbering,
+    choices = {
+      chapter,
+      global,
+    },
+  },
+  equation-numbering = {
+    name    = equation@numbering,
+    choices = {
+      chapter,
+      global,
+    },
+  },
 }
 \newif\ifthu@degree@graduate
 \newcommand\thu@set@graduate{%
@@ -1695,6 +1751,28 @@
 % \pkg{unicode-math} 和 \pkg{newtx} 都不需要 \pkg{fontspec} 设置数学字体。
 %    \begin{macrocode}
 \PassOptionsToPackage{no-math}{fontspec}
+%    \end{macrocode}
+%
+% 处理苏世民学院的格式。
+%    \begin{macrocode}
+\ifthu@style@override@schwarzman
+  \thusetup{
+    footnote-numbering = global,
+    footnote-style     = plain,
+    figure-numbering   = global,
+    table-numbering    = global,
+    equation-numbering = global,
+  }
+\fi
+\thu@option@hook{style-override}{\thu@error{%
+  The 'style-override' option is only valid in class options.%
+}}%
+\thu@option@hook{footnote-numbering}{\thu@error{%
+  The 'footnote-numbering' option is only valid in class options.%
+}}%
+\ifthu@footnote@numbering@page
+  \PassOptionsToPackage{perpage}{footmisc}%
+\fi
 %    \end{macrocode}
 %
 % 使用 \pkg{ctexbook} 类，优于调用 \pkg{ctex} 宏包。
@@ -1774,10 +1852,10 @@
 % 脚注按页编号。
 %    \begin{macrocode}
 \ifthu@raggedbottom
-  \RequirePackage[bottom,perpage,hang]{footmisc}
+  \RequirePackage[bottom,hang]{footmisc}
   \raggedbottom
 \else
-  \RequirePackage[perpage,hang]{footmisc}
+  \RequirePackage[hang]{footmisc}
 \fi
 %    \end{macrocode}
 %
@@ -3387,41 +3465,9 @@
 %
 % 苏世民学院的格式与学校不同，全文的脚注都连续编号（包括到附录中），并且不使用带圈数字。
 %    \begin{macrocode}
-\thu@define@key{
-  footnote-numbering = {
-    name    = footnote@numbering,
-    choices = {
-      page,
-      chapter,
-      global,
-    },
-  },
-  footnote-style = {
-    name    = footnote@style,
-    choices = {
-      circled,
-      plain,
-    },
-  },
-}
-\newcommand\thu@set@footnote@numbering{%
-  % \ifthu@footnote@numbering@page
-  %   \@removefromreset{footnote}{chapter}%
-  %   \@addtoreset{pchk@footnot}{footnote}%
-  % \else
-  %   \ifthu@footnote@numbering@chapter
-  %     \@removefromreset{pchk@footnote}{footnote}%
-  %     \@addtoreset{chapter}{footnote}%
-  %   \else
-  %     \ifthu@footnote@numbering@global
-  %       \@removefromreset{footnote}{chapter}%
-  %       \@removefromreset{pchk@footnote}{footnote}%
-  %     \fi
-  %   \fi
-  % \fi
-}
-\thu@set@footnote@numbering
-\thu@option@hook{footnote-numbering}{\thu@set@footnote@numbering}
+\ifthu@footnote@numbering@global
+  \@removefromreset{footnote}{chapter}%
+\fi
 %    \end{macrocode}
 %
 % 脚注序号使用带圈数字。
@@ -3437,17 +3483,13 @@
   \fi
   {\symbol{\the\numexpr#1+"245F\relax}}%
 }
-\newcommand\thu@set@footnote@style{%
-  \ifthu@footnote@style@circled
-    \renewcommand{\thefootnote}{\thu@circled{\c@footnote}}%
-    \renewcommand{\thempfootnote}{\thu@circled{\c@mpfootnote}}%
-  \else
-    \renewcommand{\thefootnote}{\arabic{footnote}}%
-    \renewcommand{\thempfootnote}{\arabic{mpfootnote}}%
-  \fi
-}
-\thu@set@footnote@style
-\thu@option@hook{footnote-style}{\thu@set@footnote@style}
+\ifthu@footnote@style@circled
+  \renewcommand{\thefootnote}{\thu@circled{\c@footnote}}%
+  \renewcommand{\thempfootnote}{\thu@circled{\c@mpfootnote}}%
+\else
+  \renewcommand{\thefootnote}{\arabic{footnote}}%
+  \renewcommand{\thempfootnote}{\arabic{mpfootnote}}%
+\fi
 %    \end{macrocode}
 % \end{macro}
 %
@@ -3616,38 +3658,15 @@
 %    \end{macrocode}
 %
 % 允许用户设置图表编号和连接符。
-%
-% 苏世民学院的格式与学校不同，全文的脚注都连续编号（包括到附录中），并且不使用带圈数字。
 %    \begin{macrocode}
 \thu@define@key{
-  figure-numbering = {
-    name    = figure@numbering,
-    choices = {
-      chapter,
-      global,
-    },
-  },
   figure-number-separator = {
     name    = figure@number@separator,
     default = {.},
   },
-  table-numbering = {
-    name    = table@numbering,
-    choices = {
-      chapter,
-      global,
-    },
-  },
   table-number-separator = {
     name    = table@number@separator,
     default = {.},
-  },
-  equation-numbering = {
-    name    = equation@numbering,
-    choices = {
-      chapter,
-      global,
-    },
   },
   equation-number-separator = {
     name    = equation@number@separator,

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -3385,6 +3385,45 @@
 % 脚注的段落格式为：单倍行距，段前空 0 磅，段后空 0 磅，悬挂缩进 1.5 字符；
 % 字号为小五号字，汉字用宋体，外文用 Times New Roman 体。
 %
+% 苏世民学院的格式与学校不同，全文的脚注都连续编号（包括到附录中），并且不使用带圈数字。
+%    \begin{macrocode}
+\thu@define@key{
+  footnote-numbering = {
+    name    = footnote@numbering,
+    choices = {
+      page,
+      chapter,
+      global,
+    },
+  },
+  footnote-style = {
+    name    = footnote@style,
+    choices = {
+      circled,
+      plain,
+    },
+  },
+}
+\newcommand\thu@set@footnote@numbering{%
+  % \ifthu@footnote@numbering@page
+  %   \@removefromreset{footnote}{chapter}%
+  %   \@addtoreset{pchk@footnot}{footnote}%
+  % \else
+  %   \ifthu@footnote@numbering@chapter
+  %     \@removefromreset{pchk@footnote}{footnote}%
+  %     \@addtoreset{chapter}{footnote}%
+  %   \else
+  %     \ifthu@footnote@numbering@global
+  %       \@removefromreset{footnote}{chapter}%
+  %       \@removefromreset{pchk@footnote}{footnote}%
+  %     \fi
+  %   \fi
+  % \fi
+}
+\thu@set@footnote@numbering
+\thu@option@hook{footnote-numbering}{\thu@set@footnote@numbering}
+%    \end{macrocode}
+%
 % 脚注序号使用带圈数字。
 % \begin{macro}{\thu@circled}
 % 生成带圈的脚注数字，最多处理到 10。
@@ -3398,8 +3437,17 @@
   \fi
   {\symbol{\the\numexpr#1+"245F\relax}}%
 }
-\renewcommand{\thefootnote}{\thu@circled{\c@footnote}}
-\renewcommand{\thempfootnote}{\thu@circled{\c@mpfootnote}}
+\newcommand\thu@set@footnote@style{%
+  \ifthu@footnote@style@circled
+    \renewcommand{\thefootnote}{\thu@circled{\c@footnote}}%
+    \renewcommand{\thempfootnote}{\thu@circled{\c@mpfootnote}}%
+  \else
+    \renewcommand{\thefootnote}{\arabic{footnote}}%
+    \renewcommand{\thempfootnote}{\arabic{mpfootnote}}%
+  \fi
+}
+\thu@set@footnote@style
+\thu@option@hook{footnote-style}{\thu@set@footnote@style}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -3567,16 +3615,39 @@
 \renewcommand{\floatpagefraction}{0.60}
 %    \end{macrocode}
 %
-% 允许用户设置图表编号的连接符。
+% 允许用户设置图表编号和连接符。
+%
+% 苏世民学院的格式与学校不同，全文的脚注都连续编号（包括到附录中），并且不使用带圈数字。
 %    \begin{macrocode}
 \thu@define@key{
+  figure-numbering = {
+    name    = figure@numbering,
+    choices = {
+      chapter,
+      global,
+    },
+  },
   figure-number-separator = {
     name    = figure@number@separator,
     default = {.},
   },
+  table-numbering = {
+    name    = table@numbering,
+    choices = {
+      chapter,
+      global,
+    },
+  },
   table-number-separator = {
     name    = table@number@separator,
     default = {.},
+  },
+  equation-numbering = {
+    name    = equation@numbering,
+    choices = {
+      chapter,
+      global,
+    },
   },
   equation-number-separator = {
     name    = equation@number@separator,
@@ -3587,24 +3658,57 @@
     default = {.},
   },
 }
+\newcommand\thu@set@figure@numbering{%
+  \ifthu@figure@numbering@chapter
+    \@addtoreset{figure}{chapter}%
+  \else
+    \@removefromreset{figure}{chapter}%
+  \fi
+}
+\thu@set@figure@numbering
+\thu@option@hook{figure-numbering}{\thu@set@figure@numbering}
 \renewcommand\thefigure{%
-  \ifnum\c@chapter>\z@
-    \thechapter
-    \thu@figure@number@separator
+  \ifthu@figure@numbering@chapter
+    \ifnum\c@chapter>\z@
+      \thechapter
+      \thu@figure@number@separator
+    \fi
   \fi
   \@arabic\c@figure
 }
+\newcommand\thu@set@table@numbering{%
+  \ifthu@table@numbering@chapter
+    \@addtoreset{table}{chapter}%
+  \else
+    \@removefromreset{table}{chapter}%
+  \fi
+}
+\thu@set@table@numbering
+\thu@option@hook{table-numbering}{\thu@set@table@numbering}
 \renewcommand\thetable{%
-  \ifnum\c@chapter>\z@
-    \thechapter
-    \thu@table@number@separator
+  \ifthu@table@numbering@chapter
+    \ifnum\c@chapter>\z@
+      \thechapter
+      \thu@table@number@separator
+    \fi
   \fi
   \@arabic\c@table
 }
+\newcommand\thu@set@equation@numbering{%
+  \ifthu@equation@numbering@chapter
+    \@addtoreset{equation}{chapter}%
+  \else
+    \@removefromreset{equation}{chapter}%
+  \fi
+}
+\thu@set@equation@numbering
+\thu@option@hook{equation-numbering}{\thu@set@equation@numbering}
 \renewcommand\theequation{%
-  \ifnum\c@chapter>\z@
-    \thechapter
-    \thu@equation@number@separator
+  \ifthu@equation@numbering@chapter
+    \ifnum\c@chapter>\z@
+      \thechapter
+      \thu@equation@number@separator
+    \fi
   \fi
   \@arabic\c@equation
 }


### PR DESCRIPTION
见 #1037 的讨论。

目前已完成：

- [x]  `footnote-style`: **`circled`** / `plain`
- [x]  `figure-numbering`: **`chapter`** / `global`
- [x]  `table-numbering`: **`chapter`** / `global`
- [x] `equation-numbering`: **`chapter`** / `global` 我想公式编号应该也需要吧？

- [x] `footnote-numbering`: **`page`** / `chapter` / `global`
脚注编号比较复杂。目前默认的 `footnote-numbering = page` 是通过传 `perpage` 参数给 `footmisc`宏包实现的，后者在内部调用 `perpage` 宏包。如果限制 `footnote-numbering` 选项只在 `\documentclass` 中，可以简单地通过控制 `perpage` 参数实现。但如果要允许在 `\documentclass` 以外设置该选项，需要修改底层命令。这部分比较复杂，我还没完全搞懂。

- [x] `style-override`: **`none`** / `schwarzman`