### PR TITLE
Fix vscode setting for Latex-Workshop magic comments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "latex-workshop.latex.build.enableMagicComments": false,
     "latex-workshop.latex.recipes": [
         {
             "name": "latexmk (xelatex)",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "latex-workshop.latex.build.enableMagicComments": false,
     "latex-workshop.latex.recipes": [
         {
             "name": "latexmk (xelatex)",

--- a/data/abstract.tex
+++ b/data/abstract.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 % 中英文摘要和关键字
 

--- a/data/acknowledgements.tex
+++ b/data/acknowledgements.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{acknowledgements}
   衷心感谢导师×××教授和物理系××副教授对本人的精心指导。他们的言传身教将使我终生受益。

--- a/data/appendix-survey.tex
+++ b/data/appendix-survey.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{survey}
 \label{cha:survey}

--- a/data/appendix-translation.tex
+++ b/data/appendix-translation.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{translation}
 \label{cha:translation}

--- a/data/appendix.tex
+++ b/data/appendix.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \chapter{补充内容}
 

--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \chapter{论文主要部分的写法}
 

--- a/data/chap02.tex
+++ b/data/chap02.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \chapter{图表示例}
 

--- a/data/chap03.tex
+++ b/data/chap03.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \chapter{数学符号和公式}
 

--- a/data/chap04.tex
+++ b/data/chap04.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \chapter{引用文献的标注}
 

--- a/data/comments.tex
+++ b/data/comments.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{comments}
 % \begin{comments}[name = {指导小组评语}]

--- a/data/committee.tex
+++ b/data/committee.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{committee}[name={学位论文指导小组、公开评阅人和答辩委员会名单}]
 

--- a/data/denotation.tex
+++ b/data/denotation.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{denotation}[3cm]
   \item[PI] 聚酰亚胺

--- a/data/resolution.tex
+++ b/data/resolution.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{resolution}
 

--- a/data/resume.tex
+++ b/data/resume.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TEX root = ../thuthesis-example.tex
 
 \begin{resume}
 

--- a/thusetup.tex
+++ b/thusetup.tex
@@ -1,4 +1,4 @@
-% !TeX root = ./thuthesis-example.tex
+% !TEX root = ./thuthesis-example.tex
 
 % 论文基本信息配置
 

--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -1,5 +1,5 @@
 % !TeX encoding = UTF-8
-% !TeX program = xelatex
+% !TeX program = latexmk
 % !TeX spellcheck = en_US
 
 \documentclass[degree=master]{thuthesis}

--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -1,6 +1,6 @@
-% !TeX encoding = UTF-8
-% !TeX program = xelatex
-% !TeX spellcheck = en_US
+% !TEX encoding = UTF-8
+% !TEX program = xelatex
+% !TEX spellcheck = en_US
 
 \documentclass[degree=master]{thuthesis}
   % 学位 degree:

--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -1,5 +1,5 @@
 % !TeX encoding = UTF-8
-% !TeX program = latexmk
+% !TeX program = xelatex
 % !TeX spellcheck = en_US
 
 \documentclass[degree=master]{thuthesis}

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -208,7 +208,7 @@
 % 在撰写论文时，我们\textbf{不推荐}使用原有的 \file{thuthesis-example.tex} 这一名称。
 % 建议将其复制一份，改为其他的名字（如 \file{thesis.tex} 或者 \file{main.tex}）。
 % 需要注意，如果使用了来自 \file{data} 目录中的 \file{tex} 文件，
-% 则重命名主文件后，其顶端的 \texttt{!TeX root} 选项也需要相应修改。
+% 则重命名主文件后，其顶端的 \texttt{!TEX root} 选项也需要相应修改。
 %
 % \subsubsection{GNU make}
 % \label{sec:make}


### PR DESCRIPTION
Latex-Workshop 从 10.13.0 开始，默认使用 magic comments 而非 recipe 设置。当前默认的配置在vscode下编译会使用xelatex，而非完整编译链，导致PDF结果中引用全变？。

解决方案：显式设置 `enableMagicComments` 为 `false`。

参考链接：https://github.com/James-Yu/LaTeX-Workshop/issues/4813