### PR TITLE
Bump TeX-Live/setup-texlive-action from 3 to 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install TeX Live
-      uses: TeX-Live/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v4
       with:
         packages: >-
           ${{ env.XECJK_PKGS }} ${{ env.CTEX_PKGS }} ${{ env.BIBLATEX_PKGS }}
@@ -73,7 +73,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install TeX Live
-      uses: TeX-Live/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v4
       with:
         packages: >-
           ${{ env.XECJK_PKGS }} ${{ env.CTEX_PKGS }} ${{ env.BIBLATEX_PKGS }}

--- a/testfiles/package-longtable.tlg
+++ b/testfiles/package-longtable.tlg
@@ -2,7 +2,7 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 Package longtable Warning: Column widths have changed
 (longtable)                in table 1.1 on input line ....
-./package-longtable.tex:114: ignored error: Infinite glue shrinkage found in box being split
+ignored: Infinite glue shrinkage found in box being split
 Completed box being shipped out [2]
 \vbox(710.18088+0.0)x439.87962
 .\hbox(0.0+0.0)x0.0
@@ -1180,7 +1180,7 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\kern 710.18088
 .\kern 0.0
-./package-longtable.tex:114: ignored error: Infinite glue shrinkage found in box being split
+ignored: Infinite glue shrinkage found in box being split
 Completed box being shipped out [3]
 \vbox(710.18088+0.0)x439.87962
 .\hbox(0.0+0.0)x0.0
@@ -3238,7 +3238,7 @@ Completed box being shipped out [4]
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\kern 710.18088
 .\kern 0.0
-./package-longtable.tex:133: ignored error: Infinite glue shrinkage found in box being split
+ignored: Infinite glue shrinkage found in box being split
 Completed box being shipped out [5]
 \vbox(710.18088+0.0)x439.87962
 .\hbox(0.0+0.0)x0.0
@@ -4504,7 +4504,7 @@ Completed box being shipped out [5]
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\kern 710.18088
 .\kern 0.0
-./package-longtable.tex:133: ignored error: Infinite glue shrinkage found in box being split
+ignored: Infinite glue shrinkage found in box being split
 Completed box being shipped out [6]
 \vbox(710.18088+0.0)x439.87962
 .\hbox(0.0+0.0)x0.0


### PR DESCRIPTION
For TeX Live 2026 support.
https://github.com/TeX-Live/setup-texlive-action/releases/tag/v4.0.0

---

This should fix the CI.