### PR TITLE
声明页改为默认带页眉页脚

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Biblatex` 的斜线不再默认使用等宽字体（[#1018](https://github.com/tuna/thuthesis/discussions/1018)）。
 - 使用“学科”作为 PDF 文档属性的“主题”（[#1025](https://github.com/tuna/thuthesis/issues/1025)）。
 - 中文著者-出版年制引用标注的括号改为全角（[#1054](https://github.com/tuna/thuthesis/issues/1054)）。
+- 声明页改为默认带页眉页脚（[#1056](https://github.com/tuna/thuthesis/pull/1056)）。
 
 ### Fixed
 

--- a/testfiles/09-main-bachelor-en.tlg
+++ b/testfiles/09-main-bachelor-en.tlg
@@ -15048,7 +15048,7 @@ LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
 LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
 (Font)              scaled to size 7.22623pt on input line ....
 Completed box being shipped out [14]
-\vbox(730.09772+0.0)x439.87962
+\vbox(730.09772+6.02255)x439.87962
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -15060,12 +15060,45 @@ Completed box being shipped out [14]
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\glue -18.78552
-.\vbox(748.88324+0.0)x426.79135, shifted 13.08827
+.\vbox(748.88324+6.02255)x426.79135, shifted 13.08827
 ..\vbox(12.0+0.0)x426.79135, glue set 12.0fil
 ...\glue 0.0 plus 1.0fil
 ...\hbox(0.0+0.0)x426.79135
 ....\special{color push gray 0}
 ....\hbox(0.0+0.0)x426.79135
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(0.0+0.0)x426.79135
+......\vbox(0.0+0.0)x426.79135
+.......\hbox(0.0+0.0)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.0+0.0)x426.79135
+.......\glue 0.0
 ....\special{color pop}
 ..\glue 19.8738
 ..\glue(\lineskip) 0.0
@@ -15453,12 +15486,48 @@ C.}
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 42.67912
-..\hbox(0.0+0.0)x426.79135
+..\glue(\baselineskip) 22.60414
+..\hbox(20.07498+6.02255)x426.79135
 ...\special{color push gray 0}
-...\hbox(0.0+0.0)x426.79135
+...\hbox(20.07498+6.02255)x426.79135
+....\glue 0.0 plus 1.0fil minus 1.0fil
+....\hbox(20.07498+6.02255)x426.79135
+.....\vbox(20.07498+6.02255)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(14.05243+6.02255)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(14.05243+6.02255)x426.79135
+........\hbox(14.05243+6.02255)x426.79135, glue set 207.37318fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/12.045 14
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(14.05243+6.02255)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
 ...\special{color pop}
-.\kern -730.09772
+.\kern -736.12027
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -15469,7 +15538,7 @@ C.}
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
-.\kern 730.09772
+.\kern 736.12027
 .\kern 0.0
 APPENDIX A
 Completed box being shipped out [15]

--- a/testfiles/09-main-bachelor.tlg
+++ b/testfiles/09-main-bachelor.tlg
@@ -9672,7 +9672,7 @@ Underfull \hbox (badness 10000) in paragraph at lines ...
 .\glue(\rightskip) 0.0
 No file bu.aux.
 Completed box being shipped out [7]
-\vbox(730.09772+0.0)x439.87962
+\vbox(730.09772+3.63611)x439.87962
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -9684,12 +9684,45 @@ Completed box being shipped out [7]
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\glue -18.78552
-.\vbox(748.88324+0.0)x426.79135, shifted 13.08827
+.\vbox(748.88324+3.63611)x426.79135, shifted 13.08827
 ..\vbox(12.0+0.0)x426.79135, glue set 12.0fil
 ...\glue 0.0 plus 1.0fil
 ...\hbox(0.0+0.0)x426.79135
 ....\special{color push gray 0}
 ....\hbox(0.0+0.0)x426.79135
+.....\hbox(0.0+0.0)x426.79135
+......\vbox(0.0+0.0)x426.79135
+.......\hbox(0.0+0.0)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.0+0.0)x426.79135
+.......\glue 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\special{color pop}
 ..\glue 19.8738
 ..\glue(\lineskip) 0.0
@@ -10069,12 +10102,48 @@ C.}
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 42.67912
-..\hbox(0.0+0.0)x426.79135
+..\glue(\baselineskip) 28.17242
+..\hbox(14.5067+3.63611)x426.79135
 ...\special{color push gray 0}
-...\hbox(0.0+0.0)x426.79135
+...\hbox(14.5067+3.63611)x426.79135
+....\hbox(14.5067+3.63611)x426.79135
+.....\vbox(14.5067+3.63611)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(8.48415+3.63611)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(8.48415+3.63611)x426.79135
+........\hbox(8.48415+3.63611)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 7
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(8.48415+3.63611)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-.\kern -730.09772
+.\kern -733.73383
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -10085,7 +10154,7 @@ C.}
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
-.\kern 730.09772
+.\kern 733.73383
 .\kern 0.0
 Completed box being shipped out [8]
 \vbox(730.09772+3.63611)x439.87962

--- a/testfiles/09-main-en.tlg
+++ b/testfiles/09-main-en.tlg
@@ -7427,7 +7427,7 @@ LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
 (Font)              scaled to size 6.52367pt on input line ....
 No file bu.aux.
 Completed box being shipped out [7]
-\vbox(710.18088+0.0)x439.87962
+\vbox(710.18088+4.1104)x439.87962
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -7439,12 +7439,53 @@ Completed box being shipped out [7]
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 .\glue -72.26997
-.\vbox(782.45085+0.0)x426.79135, shifted 13.08827
-..\vbox(76.82234+0.0)x426.79135, glue set 76.82234fil
+.\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+..\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
 ...\glue 0.0 plus 1.0fil
-...\hbox(0.0+0.0)x426.79135
+...\hbox(13.70119+0.0)x426.79135
 ....\special{color push gray 0}
-....\hbox(0.0+0.0)x426.79135
+....\hbox(13.70119+0.0)x426.79135
+.....\hbox(13.70119+0.0)x426.79135
+......\vbox(13.70119+0.0)x426.79135
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/FandolSong(0)/m/n/10.53937 声
+..........\kern -0.00017
+..........\kern 0.00017
+..........\glue 10.53937
+..........\TU/FandolSong(0)/m/n/10.53937 明
+..........\kern -0.00017
+..........\kern 0.00017
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.......\glue 0.0
+.......\rule(0.7528+0.0)x426.79135
+.......\glue -0.7528
+.....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\special{color pop}
 ..\glue 8.5359
 ..\glue(\lineskip) 0.0
@@ -7855,12 +7896,48 @@ Completed box being shipped out [7]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 22.76228
-..\hbox(0.0+0.0)x426.79135
+..\glue(\baselineskip) 7.14894
+..\hbox(15.61334+4.1104)x426.79135
 ...\special{color push gray 0}
-...\hbox(0.0+0.0)x426.79135
+...\hbox(15.61334+4.1104)x426.79135
+....\hbox(15.61334+4.1104)x426.79135
+.....\vbox(15.61334+4.1104)x426.79135
+......\rule(0.0+0.0)x426.79135
+......\glue 6.02255
+......\hbox(9.59079+4.1104)x426.79135
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\vbox(9.59079+4.1104)x426.79135
+........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+.........\glue(\leftskip) 0.0 plus 1.0fil
+.........\hbox(0.0+0.0)x0.0
+.........\TU/texgyretermes(0)/m/n/10.53937 7
+.........\kern -0.0002
+.........\kern 0.0002
+.........\rule(9.59079+4.1104)x0.0
+.........\penalty 10000
+.........\glue(\parfillskip) 0.0
+.........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fill
+.......\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(0.0+0.0)x426.79135
+.........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-.\kern -710.18088
+.\kern -714.29128
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -7871,7 +7948,7 @@ Completed box being shipped out [7]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
-.\kern 710.18088
+.\kern 714.29128
 .\kern 0.0
 No file bu.aux.
 Completed box being shipped out [8]

--- a/testfiles/13-1-statement.tex
+++ b/testfiles/13-1-statement.tex
@@ -7,7 +7,7 @@
 
 \backmatter
 \setcounter{page}{116}
-\statement[page-style=plain]
+\statement
 
 \clearpage
 \OMIT

--- a/testfiles/13-2-statement.tex
+++ b/testfiles/13-2-statement.tex
@@ -12,7 +12,7 @@
 
 \backmatter
 \setcounter{page}{116}
-\statement[page-style=plain]
+\statement
 
 \clearpage
 \OMIT

--- a/testfiles/package-hyperref.tlg
+++ b/testfiles/package-hyperref.tlg
@@ -5705,7 +5705,7 @@ LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
 (Font)              scaled to size 6.52367pt on input line ....
 No file bu.aux.
 Completed box being shipped out [7]
-\vbox(710.18088+0.0)x439.87962
+\vbox(710.18088+4.1104)x439.87962
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -5729,14 +5729,55 @@ Completed box being shipped out [7]
 ...\glue 0.0 plus 1.0fil minus 1.0fil
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\glue(\lineskip) 0.0
-.\vbox(710.18088+0.0)x439.87962
+.\vbox(710.18088+4.1104)x439.87962
 ..\glue -72.26997
-..\vbox(782.45085+0.0)x426.79135, shifted 13.08827
-...\vbox(76.82234+0.0)x426.79135, glue set 76.82234fil
+..\vbox(782.45085+4.1104)x426.79135, shifted 13.08827
+...\vbox(76.82234+0.0)x426.79135, glue set 63.12115fil
 ....\glue 0.0 plus 1.0fil
-....\hbox(0.0+0.0)x426.79135
+....\hbox(13.70119+0.0)x426.79135
 .....\special{color push gray 0}
-.....\hbox(0.0+0.0)x426.79135
+.....\hbox(13.70119+0.0)x426.79135
+......\hbox(13.70119+0.0)x426.79135
+.......\vbox(13.70119+0.0)x426.79135
+........\hbox(9.59079+4.1104)x426.79135
+.........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+..........\vbox(0.0+0.0)x426.79135
+...........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+............\hbox(0.0+0.0)x0.0
+............\penalty 10000
+............\glue(\parfillskip) 0.0 plus 1.0fil
+............\glue(\rightskip) 0.0 plus 1.0fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\glue 0.0 plus 1.0fill
+.........\vbox(9.59079+4.1104)x426.79135
+..........\hbox(9.59079+4.1104)x426.79135, glue set 197.58662fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\TU/FandolSong(0)/m/n/10.53937 声
+...........\kern -0.00017
+...........\kern 0.00017
+...........\glue 10.53937
+...........\TU/FandolSong(0)/m/n/10.53937 明
+...........\kern -0.00017
+...........\kern 0.00017
+...........\rule(9.59079+4.1104)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fill
+.........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\vbox(0.0+0.0)x426.79135
+...........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+............\glue(\leftskip) 0.0 plus 1.0fil
+............\hbox(0.0+0.0)x0.0
+............\penalty 10000
+............\glue(\parfillskip) 0.0
+............\glue(\rightskip) 0.0
+........\glue 0.0
+........\rule(0.7528+0.0)x426.79135
+........\glue -0.7528
+......\glue 0.0 plus 1.0fil minus 1.0fil
 .....\special{color pop}
 ...\glue 8.5359
 ...\glue(\lineskip) 0.0
@@ -6150,12 +6191,48 @@ Completed box being shipped out [7]
 ....\glue 0.0 plus 1.0fil
 ....\glue 0.0
 ....\glue 0.0 plus 0.0001fil
-...\glue(\baselineskip) 22.76228
-...\hbox(0.0+0.0)x426.79135
+...\glue(\baselineskip) 7.14894
+...\hbox(15.61334+4.1104)x426.79135
 ....\special{color push gray 0}
-....\hbox(0.0+0.0)x426.79135
+....\hbox(15.61334+4.1104)x426.79135
+.....\hbox(15.61334+4.1104)x426.79135
+......\vbox(15.61334+4.1104)x426.79135
+.......\rule(0.0+0.0)x426.79135
+.......\glue 6.02255
+.......\hbox(9.59079+4.1104)x426.79135
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 213.39568fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\vbox(9.59079+4.1104)x426.79135
+.........\hbox(9.59079+4.1104)x426.79135, glue set 210.76083fil
+..........\glue(\leftskip) 0.0 plus 1.0fil
+..........\hbox(0.0+0.0)x0.0
+..........\TU/texgyretermes(0)/m/n/10.53937 7
+..........\kern -0.0002
+..........\kern 0.0002
+..........\rule(9.59079+4.1104)x0.0
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0
+..........\glue(\rightskip) 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fill
+........\hbox(0.0+0.0)x0.0, glue set - 426.79135fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\vbox(0.0+0.0)x426.79135
+..........\hbox(0.0+0.0)x426.79135, glue set 426.79135fil
+...........\glue(\leftskip) 0.0 plus 1.0fil
+...........\hbox(0.0+0.0)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0
+...........\glue(\rightskip) 0.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\special{color pop}
-.\kern -710.18088
+.\kern -714.29128
 .\hbox(0.0+0.0)x0.0
 ..\kern -72.26999
 ..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
@@ -6166,7 +6243,7 @@ Completed box being shipped out [7]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\glue 0.0 plus 1.0fil minus 1.0fil
-.\kern 710.18088
+.\kern 714.29128
 .\kern 0.0
 No file bu.aux.
 Completed box being shipped out [8]

--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -75,11 +75,11 @@
 
 % 声明
 % 各类开题报告通常不需要
-\statement[page-style=empty]  % 编译生成的声明页默认不含页眉页脚，以避免页码变化带来问题
-% 在提交终稿时，插入签字后的扫描件 scan-statement.pdf，并添加页眉页脚
-% \statement[page-style=plain, file=scan-statement.pdf]
-% 如确实需要在电子版中直接页眉页脚，则使用
-% \statement[page-style=plain]
+\statement
+% 在提交终稿 PDF 时，先编译不含页眉页脚的声明页，以避免页码变化带来问题
+% \statement[page-style=empty]
+% 打印、签名、扫描为 PDF 文档后，将 scan-statement.pdf 替换原始页面，并生成页眉页脚
+% \statement[file=scan-statement.pdf]
 
 % 个人简历、在学期间完成的相关学术成果
 % 本科生可以附个人简历，也可以不附个人简历

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1068,16 +1068,19 @@
 %   \statement[file=scan-statement.pdf]
 % \end{latex}
 %
-% 由于正文篇幅可能有变化，以及电子版和打印版和有空白页的差别，声明的页码可能不同。
-% 所以为了避免重复打印扫描，编译生成声明页时默认\textsf{不含}页眉页脚，
-% 插入扫描页时默认加上页眉页脚。
+% 由于正文篇幅可能有变化，声明的页码可能不同。
+% 而且扫描件的页眉线可能有偏差
+% 所以为了避免重复打印扫描，
+% 在提交终稿 PDF 时，先编译不含页眉页脚的声明页。
+% 在打印、签名、扫描成 PDF 文档后，再插入 \file{scan-statement.pdf} 替换原始页面，
+% 并加上页眉页脚。
 %
-% 用户也可以通过 \option{page-style} 参数手动控制声明页是否含页眉页脚。
-% 例如编译生成声明页时要求包含页眉页脚：
+% 用户可以通过可选参数 \option{page-style} 手动控制声明页是否含页眉页脚。
+% 例如编译生成声明页时不含页眉页脚：
 % \begin{latex}
-%   \statement[page-style=plain]
+%   \statement[page-style=empty]
 % \end{latex}
-% 插入扫描页时不加页眉页脚：
+% 插入扫描页时加上页眉页脚：
 % \begin{latex}
 %   \statement[file=scan-statement.pdf, page-style=plain]
 % \end{latex}
@@ -5390,11 +5393,10 @@
   statement-page-style = {
     name = statement@page@style,
     choices = {
-      auto,
-      empty,
       plain,
+      empty,
     },
-    default = auto,
+    default = plain,
   }
 }
 \newcommand\statement[1][]{%
@@ -5411,13 +5413,6 @@
     \fi
   }%
   \kvsetkeys{thu@statement}{#1}%
-  \ifthu@statement@page@style@auto
-    \ifx\thu@statement@file\@empty
-      \thusetup{statement-page-style = empty}%
-    \else
-      \thusetup{statement-page-style = plain}%
-    \fi
-  \fi
   \ifx\thu@statement@file\@empty
     \thusetup{language=chinese}%
     \begingroup


### PR DESCRIPTION
研究生院姚飞老师反映：

> 能否查看论文Latex模板，最新的声明页，是不是没有页眉？好多同学都没有带。

> 目前教务老师提出在格式审查中出现了多个学生声明页不带页眉。
> 因为是用于论文送审，不是最终版，所以这个阶段是不需要签名的。

我提议将 `\statement` 命令改为带页眉页脚，让用户在最终稿再操作不带页眉的扫描页。