### PR TITLE
latexmkrc: auto-bibtex bibunits appendix .aux files between latex passes

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -2,8 +2,52 @@
 
 $pdf_mode = 5;
 
-$xelatex = "xelatex -shell-escape -file-line-error -halt-on-error -interaction=nonstopmode -no-pdf -synctex=1 %O %S";
-$lualatex = "lualatex -shell-escape -file-line-error -halt-on-error -interaction=nonstopmode -synctex=1 %O %S";
+# Auto-run bibtex on the per-appendix .aux files produced by the bibunits
+# package (loaded automatically when natbib is active). thuthesis writes
+# one auxiliary file per appendix chapter named <jobname>-appendix-{a,b,
+# c,...}.aux (see \@bibunitname in thuthesis.cls); latexmk's built-in
+# bibtex rule only fires on the main .aux, so without this hook a single
+# latexmk invocation cannot resolve appendix bibliographies and users
+# have to run the manual sequence documented in thuthesis.dtx
+# (xelatex; bibtex <job>.aux; bibtex <job>-appendix-a.aux; xelatex...).
+#
+# After each (xe|lua)latex pass we run bibtex on every *-appendix-*.aux
+# file containing \bibdata; the next latex iteration then sees fresh
+# appendix .bbl files and resolves the citations, so `latexmk <jobname>`
+# converges in one invocation. The hook is a no-op when no appendix
+# bibliographies are present, so existing users see no change.
+#
+# Implemented in pure Perl and invoked via latexmk's "internal" command
+# mechanism so it works on Windows / macOS / Linux without depending on
+# a POSIX shell.
+sub run_appendix_bibtex_passes {
+    foreach my $aux (glob('*-appendix-*.aux')) {
+        next unless -f $aux;
+        open(my $fh, '<', $aux) or next;
+        my $has_bibdata = 0;
+        while (my $line = <$fh>) {
+            if ($line =~ /\\bibdata/) { $has_bibdata = 1; last; }
+        }
+        close($fh);
+        if ($has_bibdata) {
+            (my $base = $aux) =~ s/\.aux\z//;
+            system('bibtex', $base);
+        }
+    }
+    return 0;
+}
+sub xelatex_with_appendix_bibtex {
+    my $rc = system('xelatex', @_);
+    run_appendix_bibtex_passes();
+    return $rc;
+}
+sub lualatex_with_appendix_bibtex {
+    my $rc = system('lualatex', @_);
+    run_appendix_bibtex_passes();
+    return $rc;
+}
+$xelatex  = 'internal xelatex_with_appendix_bibtex -shell-escape -file-line-error -halt-on-error -interaction=nonstopmode -no-pdf -synctex=1 %O %S';
+$lualatex = 'internal lualatex_with_appendix_bibtex -shell-escape -file-line-error -halt-on-error -interaction=nonstopmode -synctex=1 %O %S';
 $xdvipdfmx = "xdvipdfmx -q -E -o %D %O %S";
 
 $bibtex_use = 1.5;


### PR DESCRIPTION
> **中文摘要**：本 PR 让 `latexmk <jobname>` 单条命令即可正确编译含
> `\printbibliography` 的附录参考文献，呼应 [#903][5] 中
> @zepinglee 提到的 "推荐使用 `latexmk` 自动处理编译过程"。
> 改动仅限于 `latexmkrc`（+46 / -2 行，纯 Perl，无 shell 依赖，
> Windows / macOS / Linux 通用），不引入任何新依赖，对没有附录
> 参考文献的论文行为不变。

## Summary

`latexmk <jobname>` currently fails with exit 12 on any thuthesis document
that uses `\printbibliography` inside an appendix chapter — including the
upstream demo `thuthesis-example.tex`. Users have to fall back to the manual
sequence documented at [`thuthesis.dtx:247-253`][1]:

```sh
$ xelatex thuthesis-example.tex
$ bibtex thuthesis-example.aux
$ bibtex thuthesis-example-appendix-a.aux
$ xelatex thuthesis-example.tex
$ xelatex thuthesis-example.tex
```

This PR teaches `latexmk` to handle the per-appendix `bibtex` passes
automatically, so a single `latexmk <jobname>` converges in one invocation.

## Root cause

The `bibunits` package (loaded automatically when `natbib` is active) writes
one auxiliary file per appendix chapter, named `<jobname>-appendix-{a,b,c,
...}.aux` (see [`\@bibunitname` in `thuthesis.cls`][2]). `latexmk`'s built-in
`bibtex` rule only fires on the main `.aux`, so the per-appendix `.aux`
files are never processed; `latexmk` reaches `max_runs` with appendix
citations still unresolved and gives up.

## History

Not a v7.7.0 regression. `\printbibliography` was added to the appendix
demo in commit [`1ab3762`][3] ([PR #875][4], 2023-05-12, first shipped in
`v7.4.0`) without a corresponding `latexmkrc` update, so plain
`latexmk <jobname>` has been failing on every tagged release since
(`v7.4.0`, `v7.5.0`, `v7.5.1`, `v7.5.2`, `v7.6.0`, `v7.7.0`). It likely
went unnoticed because the shipped `Makefile` runs `bibtex` for the main
job manually, and the documented workflow at [`thuthesis.dtx:247-253`][1]
already instructs users to invoke `bibtex` on each appendix `.aux` by
hand — so anyone following either path side-steps the bug.

## Reproduction (against `tuna/thuthesis@v7.7.0`)

```sh
git clone https://github.com/tuna/thuthesis.git
cd thuthesis
xetex thuthesis.ins                           # build the cls
latexmk thuthesis-example                     # ← exits 12, no PDF
```

`data/appendix.tex` already exercises this codepath via
`\printbibliography` and `\cite{...}`, so this is reproducible against the
upstream master with no edits to source files (the only thing needed for
non-Windows reviewers is `fontset=mac`/`fontset=fandol`/`fontset=ubuntu` to
sidestep the unrelated KaiTi font requirement).

## Fix

After every `(xe|lua)latex` pass, run `bibtex` on each `*-appendix-*.aux`
file that contains `\bibdata`. The next `latex` iteration in `latexmk`'s
own run loop then sees fresh appendix `.bbl` files and resolves the
citations naturally. The hook is a no-op when no appendix bibliographies
are present, so theses without `\printbibliography` in the appendix see
no behavioural change.

The hook is implemented in pure Perl and invoked via `latexmk`'s
`internal` command mechanism (see the `Run` subroutine's keyword
handling in the `latexmk` source), so it works on Windows / macOS /
Linux without depending on `bash`, `/bin/sh`, `grep`, `${var%suffix}`
parameter expansion, or `>/dev/null` redirection.

## Verification

| Build | latexmkrc | Result |
|---|---|---|
| Master | upstream | exit 12, no `.bbl`, no PDF |
| This PR | patched | exit 0, both `thuthesis-example.bbl` and `thuthesis-example-appendix-a.bbl` produced, full PDF |

Tested on macOS (TeX Live 2024) with `fontset=mac`. The hook is pure
Perl invoked via `latexmk -e` / `internal`, so behaviour should be
identical on Linux and Windows without a POSIX shell.

## Notes

- **Cross-platform.** Addressed @Harry-Chen's review feedback: the hook
  is now pure Perl invoked via `latexmk`'s `internal` command mechanism,
  so it no longer depends on `bash` / POSIX shell and works on
  `cmd.exe` / PowerShell / etc.
- **Scope.** This PR is intentionally minimal: only `latexmkrc`, no doc
  changes. If accepted, a follow-up to `thuthesis.dtx` (lines 247-253)
  noting that `latexmk <jobname>` now suffices on its own would close the
  loop.

[1]: https://github.com/tuna/thuthesis/blob/master/thuthesis.dtx#L247-L253
[2]: https://github.com/tuna/thuthesis/blob/master/thuthesis.cls
[3]: https://github.com/tuna/thuthesis/commit/1ab3762
[4]: https://github.com/tuna/thuthesis/pull/875
[5]: https://github.com/tuna/thuthesis/issues/903#issuecomment-1731632275
