### PR TITLE
添加 citation-style-language 支持与美术学院脚注引证样式 thuthesis-arts (#844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- 支持使用 `citation-style-language`（`citeproc-lua`）作为参考文献后端，并内置
+  美术学院的脚注引证样式 `thuthesis-arts`，适配《清华大学美术学院研究生学位论文
+  引证规范》的注释式（note）格式（[#844](https://github.com/tuna/thuthesis/issues/844)）。
+  该样式在 Zeping Lee 的原始 CSL 及 `csl` 分支（[#948](https://github.com/tuna/thuthesis/pull/948)）
+  的基础上增加了中英文双语支持。使用 `latexmk` 编译时会自动调用 `citeproc-lua`，
+  默认的 BibTeX / BibLaTeX 流程不受影响。
+
 ## [v7.7.1] - 2026-05-26
 
 ### Added

--- a/build.lua
+++ b/build.lua
@@ -12,8 +12,8 @@ docfiles = {
   "data",
   "ref",
 }
-installfiles = {"*.cls", "*.bst", "*.bbx", "*.cbx", "thu-*-logo.pdf"}
-sourcefiles = {"*.dtx", "*.ins", "*.bst", "*.bbx", "*.cbx", "thu-*-logo.pdf"}
+installfiles = {"*.cls", "*.bst", "*.bbx", "*.cbx", "*.csl", "thu-*-logo.pdf"}
+sourcefiles = {"*.dtx", "*.ins", "*.bst", "*.bbx", "*.cbx", "*.csl", "thu-*-logo.pdf"}
 tagfiles = {"*.dtx", "CHANGELOG.md", "package.json"}
 textfiles = {"*.md"}
 typesetdemofiles = {"thuthesis-example.tex"}

--- a/latexmkrc
+++ b/latexmkrc
@@ -8,7 +8,7 @@ $xdvipdfmx = "xdvipdfmx -q -E -o %D %O %S";
 
 $bibtex_use = 1.5;
 
-$clean_ext = "hd loe ptc run.xml synctex.gz thm xdv";
+$clean_ext = "hd loe ptc run.xml synctex.gz thm xdv ccf";
 
 $makeindex = "makeindex -s gind.ist %O -o %D %S";
 
@@ -17,3 +17,13 @@ sub nlo2nls {
     system("makeindex -s nomencl.ist -o \"$_[0].nls\" \"$_[0].nlo\"");
 }
 push @generated_exts, 'nlo', 'nls';
+
+# 使用 citation-style-language（citeproc-lua）时自动调用 citeproc-lua 生成参考文献。
+# 该宏包在非 LuaTeX 引擎下会写出 <jobname>.ccf 作为 latexmk 的触发标记，因此仅在文档
+# 真正使用了 citation-style-language 时（即存在 .ccf）才运行 citeproc-lua；默认的
+# bibtex / biber 流程完全不受影响，无需用户做任何额外配置。
+add_cus_dep('ccf', 'bbl', 0, 'csl2bbl');
+sub csl2bbl {
+    return system("citeproc-lua", "$_[0].aux");
+}
+push @generated_exts, 'ccf';

--- a/thusetup.tex
+++ b/thusetup.tex
@@ -180,6 +180,20 @@
 % 声明 BibLaTeX 的数据库
 % \addbibresource{ref/refs.bib}
 
+% 参考文献使用 citation-style-language（citeproc-lua）宏包
+% 需要 TeX Live 2023 及以上版本（citeproc-lua 已随 TeX Live 发行，无需另装）。
+% 直接用 latexmk 编译即可，会自动调用 citeproc-lua，无需额外配置。
+% 可支持注释（note）样式，如美术学院要求的脚注引证格式。
+% \usepackage{citation-style-language}
+% \cslsetup{style = thuthesis-numeric}
+% \cslsetup{style = thuthesis-author-year}
+% \cslsetup{style = apa}
+% \cslsetup{style = modern-language-association}
+% \cslsetup{style = cell}  % 生命科学学院
+% \cslsetup{style = thuthesis-arts}  % 美术学院（脚注引证）
+% 声明 CSL 的数据库
+% \addbibresource{ref/refs.bib}
+
 % 定义所有的图片文件在 figures 子目录下
 \graphicspath{{figures/}}
 

--- a/thuthesis-arts.csl
+++ b/thuthesis-arts.csl
@@ -1,0 +1,559 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" initialize-with=". ">
+  <info>
+    <title>清华大学 - 美术学院</title>
+    <id>http://www.zotero.org/styles/tsinghua-university-academy-of-arts-and-design</id>
+    <link href="http://www.zotero.org/styles/tsinghua-university-academy-of-arts-and-design" rel="self"/>
+    <link href="http://www.zotero.org/styles/social-sciences-in-china" rel="template"/>
+    <link href="https://www.ad.tsinghua.edu.cn/" rel="documentation"/>
+    <author>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </author>
+    <!-- Evie Mo：thuthesis csl 分支的整合与维护（PR #948）。 -->
+    <contributor>
+      <name>Evie Mo</name>
+    </contributor>
+    <!-- Dixiao-L：中英文双语 locale 支持。 -->
+    <contributor>
+      <name>Dixiao-L</name>
+    </contributor>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <summary>清华大学美术学院研究生学位论文引证规范（《引证规范》自 2022 年 8 月毕业批次起实行）。
+    注释式（note）脚注引证 + 方括号编号的参考文献表，支持中英文双语：
+    中文文献在 .bib 条目中设置 language = {zh-CN} 字段即可启用中文格式。</summary>
+    <updated>2026-06-06T00:00:00+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+
+  <!-- 全局 locale（无 xml:lang）：将 and-others 定义为"等"，供中文宏的 et-al 使用
+       注：citeproc-lua v0.9.1 不支持按条目切换 locale，需借助不同 term 名称区分中英文 et-al -->
+  <locale>
+    <terms>
+      <term name="and others">等</term>
+    </terms>
+  </locale>
+
+  <!-- 英文 locale：确保英文文献使用英文术语 -->
+  <locale xml:lang="en">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="editor" form="short">ed.</term>
+      <term name="translator" form="verb-short">trans. by</term>
+      <term name="in">in</term>
+    </terms>
+  </locale>
+
+  <!-- 中文 locale：中文文献使用中文术语（仅在 citeproc 支持 per-item locale 时生效） -->
+  <locale xml:lang="zh">
+    <terms>
+      <term name="et-al">等</term>
+      <term name="editor" form="short">编</term>
+      <term name="translator" form="short">译</term>
+      <term name="translator" form="verb-short">译</term>
+      <term name="in">见</term>
+    </terms>
+  </locale>
+
+  <!-- ============================================================
+       中文宏（Chinese macros）
+       适用于 bib 条目中含 language 字段的文献（如 language = {zh-CN}）
+       ============================================================ -->
+
+  <!-- 中文责任者：张昆、冯立群、余昌钰等 -->
+  <macro name="author-zh">
+    <names variable="author">
+      <name delimiter="、" delimiter-precedes-et-al="never" et-al-min="4" et-al-use-first="3" et-al-use-last="false"/>
+      <et-al term="and others"/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor">
+              <name delimiter="、"/>
+              <label form="short"/>
+            </names>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+
+  <!-- 中文题名：《书名》或《篇名》 -->
+  <macro name="title-zh">
+    <text variable="title" prefix="《" suffix="》"/>
+  </macro>
+
+  <!-- 中文译者：XXX译 -->
+  <macro name="secondary-contributors-zh">
+    <names variable="translator" suffix="译">
+      <name delimiter="、"/>
+    </names>
+  </macro>
+
+  <!-- 中文容器（期刊/报纸/文集） -->
+  <macro name="container-zh">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text macro="container-periodical-zh"/>
+      </if>
+      <else-if type="article-newspaper">
+        <text macro="container-newspaper-zh"/>
+      </else-if>
+      <else-if type="dataset post post-weblog software webpage" match="none">
+        <text macro="container-booklike-zh"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <!-- 中文期刊：《历史研究》2000年第6期 -->
+  <macro name="container-periodical-zh">
+    <group>
+      <text variable="container-title" prefix="《" suffix="》"/>
+      <date variable="issued">
+        <date-part name="year"/>
+      </date>
+      <text value="年"/>
+      <choose>
+        <if variable="issue">
+          <text value="第"/>
+          <number variable="issue"/>
+          <text value="期"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!-- 中文报纸：《四川工人日报》1986年8月22日，第2版 -->
+  <macro name="container-newspaper-zh">
+    <group>
+      <text variable="container-title" prefix="《" suffix="》"/>
+      <date variable="issued">
+        <date-part name="year" suffix="年"/>
+        <date-part name="month" form="numeric" suffix="月"/>
+        <date-part name="day" suffix="日"/>
+      </date>
+    </group>
+  </macro>
+
+  <!-- 中文文集：见编者编：《文集题名》 -->
+  <macro name="container-booklike-zh">
+    <choose>
+      <if variable="container-title" match="any">
+        <group>
+          <choose>
+            <if variable="editor">
+              <text value="见"/>
+              <names variable="editor">
+                <name delimiter="、"/>
+              </names>
+              <text value="编：《"/>
+              <text variable="container-title"/>
+              <text value="》"/>
+            </if>
+            <else>
+              <text variable="container-title" prefix="《" suffix="》"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 中文出版者：北京：中国社会科学出版社 -->
+  <macro name="publisher-zh">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="none">
+        <group delimiter="：">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 中文出版年：1984年 -->
+  <macro name="date-zh">
+    <choose>
+      <if type="dataset post post-weblog software webpage" match="any">
+        <date variable="issued">
+          <date-part name="year" suffix="年"/>
+          <date-part name="month" form="numeric" suffix="月"/>
+          <date-part name="day" suffix="日"/>
+        </date>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="none">
+        <date variable="issued">
+          <date-part name="year" suffix="年"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+
+  <!-- 中文页码：第6页 / 第382－391页 -->
+  <macro name="locators-or-pages-zh">
+    <choose>
+      <if locator="page">
+        <text macro="locators-zh"/>
+      </if>
+      <else-if variable="page">
+        <group>
+          <text value="第"/>
+          <text variable="page"/>
+          <text value="页"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="locators-zh">
+    <choose>
+      <if locator="page">
+        <group>
+          <text value="第"/>
+          <text variable="locator"/>
+          <text value="页"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 中文完整条目布局：作者：《题名》，译者译，见编者编：《文集》，出版地：出版者，XXXX年，第X页 -->
+  <macro name="entry-layout-zh">
+    <group>
+      <text macro="author-zh" suffix="："/>
+      <group delimiter="，">
+        <text macro="title-zh"/>
+        <text macro="secondary-contributors-zh"/>
+        <text macro="container-zh"/>
+        <text macro="publisher-zh"/>
+        <text macro="date-zh"/>
+        <text macro="locators-or-pages-zh"/>
+        <text macro="access-zh"/>
+      </group>
+    </group>
+  </macro>
+
+  <!-- 中文再次引证布局：作者：《题名》，第X页 -->
+  <macro name="note-layout-zh-subsequent">
+    <group>
+      <text macro="author-zh" suffix="："/>
+      <group delimiter="，">
+        <text macro="title-zh"/>
+        <text macro="container-zh"/>
+        <text macro="locators-zh"/>
+      </group>
+    </group>
+  </macro>
+
+  <!-- ============================================================
+       英文宏（English macros）
+       适用于无 language 字段的文献（默认为英文）
+       ============================================================ -->
+
+  <!-- 英文责任者 -->
+  <macro name="author-en">
+    <names variable="author">
+      <name initialize="true" and="text"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+
+  <!-- 英文题名 -->
+  <macro name="title-en">
+    <choose>
+      <if type="dataset post post-weblog software webpage" match="any">
+        <text variable="title" font-style="italic" text-case="title"/>
+      </if>
+      <else-if variable="container-title">
+        <text variable="title" quotes="true" text-case="title"/>
+      </else-if>
+      <else>
+        <text variable="title" font-style="italic" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+
+  <!-- 英文译者 -->
+  <macro name="secondary-contributors-en">
+    <names variable="translator">
+      <label form="verb-short" suffix=" "/>
+      <name initialize="false" and="text"/>
+    </names>
+  </macro>
+
+  <!-- 英文容器 -->
+  <macro name="container-en">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="container-periodical-en"/>
+      </if>
+      <else-if type="dataset post post-weblog software webpage" match="none">
+        <text macro="container-booklike-en"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <!-- 英文期刊：Journal, vol. X, no. X (Year) -->
+  <macro name="container-periodical-en">
+    <group delimiter=" ">
+      <group delimiter=", ">
+        <text variable="container-title" font-style="italic" text-case="title"/>
+        <group delimiter=" ">
+          <label variable="volume" form="short"/>
+          <number variable="volume"/>
+        </group>
+        <group delimiter=" ">
+          <label variable="issue" form="short"/>
+          <number variable="issue"/>
+        </group>
+      </group>
+      <date variable="issued" form="text" date-parts="year-month" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+
+  <!-- 英文文集：in Editor (ed.), Container Title -->
+  <macro name="container-booklike-en">
+    <choose>
+      <if variable="container-title" match="any">
+        <text term="in" suffix=" "/>
+        <group delimiter=", ">
+          <names variable="editor">
+            <name initialize="true" and="text"/>
+            <label form="short" prefix=" (" suffix=")"/>
+            <substitute>
+              <names variable="editorial-director"/>
+              <names variable="collection-editor"/>
+              <names variable="container-author"/>
+            </substitute>
+          </names>
+          <text variable="container-title" font-style="italic" text-case="title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 英文出版者：Place: Publisher -->
+  <macro name="publisher-en">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="none">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 英文出版年 -->
+  <macro name="date-en">
+    <choose>
+      <if type="dataset post post-weblog software webpage" match="any">
+        <date variable="issued" form="text"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="none">
+        <date variable="issued" form="text" date-parts="year"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <!-- 英文页码：pp. X-Y -->
+  <macro name="locators-or-pages-en">
+    <choose>
+      <if locator="page">
+        <text macro="locators-en"/>
+      </if>
+      <else-if is-numeric="page">
+        <label variable="page" form="short" suffix=" "/>
+        <number variable="page"/>
+      </else-if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="locators-en">
+    <choose>
+      <if locator="page">
+        <choose>
+          <if is-numeric="locator">
+            <label variable="locator" form="short" suffix=" "/>
+            <number variable="locator"/>
+          </if>
+          <else>
+            <text variable="locator"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 英文完整条目布局 -->
+  <macro name="entry-layout-en">
+    <group delimiter=", ">
+      <text macro="author-en"/>
+      <text macro="title-en"/>
+      <text macro="secondary-contributors-en"/>
+      <text macro="container-en"/>
+      <text macro="publisher-en"/>
+      <text macro="date-en"/>
+      <text macro="locators-or-pages-en"/>
+      <text macro="access"/>
+    </group>
+  </macro>
+
+  <!-- 英文再次引证布局 -->
+  <macro name="note-layout-en-subsequent">
+    <group delimiter=", ">
+      <text macro="author-en"/>
+      <text macro="title-en"/>
+      <text macro="container-en"/>
+      <text macro="locators-en"/>
+    </group>
+  </macro>
+
+  <!-- ============================================================
+       共用宏（获取路径、排序等）
+       ============================================================ -->
+
+  <!-- 中文获取和访问路径：URL，XXXX年X月X日 -->
+  <macro name="access-zh">
+    <choose>
+      <if type="dataset post post-weblog software webpage" match="any">
+        <group delimiter="，">
+          <text variable="URL"/>
+          <date variable="accessed">
+            <date-part name="year" suffix="年"/>
+            <date-part name="month" form="numeric" suffix="月"/>
+            <date-part name="day" suffix="日"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 英文获取和访问路径 -->
+  <macro name="access">
+    <choose>
+      <if type="dataset post post-weblog software webpage" match="any">
+        <group delimiter=", ">
+          <text variable="URL"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- 统一入口：根据 language 字段选择中文或英文布局 -->
+  <macro name="entry-layout">
+    <choose>
+      <if variable="language">
+        <text macro="entry-layout-zh"/>
+      </if>
+      <else>
+        <text macro="entry-layout-en"/>
+      </else>
+    </choose>
+  </macro>
+
+  <!-- 脚注布局（含首次/再次引证） -->
+  <macro name="note-layout">
+    <choose>
+      <if position="subsequent">
+        <!-- 同一文献再次引证时只需标注责任者、题名、页码，出版信息可以省略。 -->
+        <choose>
+          <if variable="language">
+            <text macro="note-layout-zh-subsequent"/>
+          </if>
+          <else>
+            <text macro="note-layout-en-subsequent"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text macro="entry-layout"/>
+      </else>
+    </choose>
+  </macro>
+
+  <!-- 排序：先中文后外文（《引证规范》要求），同语种再按类型分组。
+       含 language 字段的中文文献（如 language = {zh-CN}）排序值取 0，
+       排在无 language 字段的外文文献（取 1）之前。 -->
+  <macro name="language-sort">
+    <choose>
+      <if variable="language">
+        <text value="0"/>
+      </if>
+      <else>
+        <text value="1"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="type-sort">
+    <choose>
+      <if type="book">
+        <text value="01"/>
+      </if>
+      <else-if type="chapter paper-conference" match="any">
+        <text value="02"/>
+      </else-if>
+      <else-if type="classic">
+        <text value="03"/>
+      </else-if>
+      <else-if type="article-journal article-magazine" match="any">
+        <text value="04"/>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text value="05"/>
+      </else-if>
+      <else-if type="article manuscript report personal_communication" match="any">
+        <text value="06"/>
+      </else-if>
+      <else-if type="dataset post post-weblog software webpage" match="any">
+        <text value="07"/>
+      </else-if>
+      <else>
+        <text value="06"/>
+      </else>
+    </choose>
+  </macro>
+
+  <!-- ============================================================
+       Citation（脚注）和 Bibliography（参考文献表）
+       ============================================================ -->
+
+  <citation>
+    <layout delimiter="; " suffix=".">
+      <text macro="note-layout"/>
+    </layout>
+  </citation>
+
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <sort>
+      <key macro="language-sort"/>
+      <key macro="type-sort"/>
+      <key macro="author-zh"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout" suffix="."/>
+    </layout>
+  </bibliography>
+</style>

--- a/thuthesis-author-year.csl
+++ b/thuthesis-author-year.csl
@@ -1,0 +1,483 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
+  <info>
+    <title>清华大学（著者-出版年）</title>
+    <id>http://www.zotero.org/styles/tsinghua-university-author-date</id>
+    <link href="http://www.zotero.org/styles/tsinghua-university-author-date" rel="self"/>
+    <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-author-date" rel="template"/>
+    <link href="http://yjsy.cic.tsinghua.edu.cn/docinfo/board/boarddetail.jsp?columnId=001050603&amp;parentColumnId=0010506&amp;itemSeq=5365" rel="documentation"/>
+    <author>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>姓名取消全大写；专利文献增加“专利国别”。</summary>
+    <updated>2022-08-13T22:24:10+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
+    <terms>
+      <term name="anonymous" form="short">佚名</term>
+      <term name="edition" form="short">版</term>
+      <term name="space-et-al"> 等</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="space-et-al">et al.</term>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <!-- 主要责任者 -->
+  <macro name="author">
+    <names variable="author">
+      <name/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 参考文献表的著者姓名与出版年 -->
+  <macro name="author-date">
+    <group delimiter=", ">
+      <text macro="author"/>
+      <text macro="issued-year"/>
+    </group>
+  </macro>
+  <!-- 正文中引用，对欧美著者只标注第一个著者的姓 -->
+  <macro name="author-intext-en">
+    <names variable="author">
+      <name form="short"/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 正文中的引用，对中国著者标注第一著者的姓名 -->
+  <macro name="author-intext-zh">
+    <names variable="author">
+      <!-- 国标 10.2.2 节要求姓氏与“et al.”“等”之间留适当空隙 -->
+      <name form="long"/>
+      <et-al term="space-et-al"/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event-title"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
+      <choose>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if type="book chapter paper-conference periodical thesis" variable="publisher page" match="none">
+        <choose>
+          <if variable="URL DOI" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
+      <name/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
+          <group delimiter=", ">
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+            </choose>
+            <text variable="volume"/>
+          </group>
+          <text variable="issue" prefix="(" suffix=")"/>
+        </group>
+        <text variable="page"/>
+      </group>
+      <text macro="accessed-date"/>
+    </group>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="chapter paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="patent">
+              <group delimiter=", ">
+                <choose>
+                  <!-- 专利的国别应使用 `jurisdiction`，但 Zotero 没有对应的域，所以 `publisher-place` 作为备选 -->
+                  <if variable="jurisdiction">
+                    <text variable="jurisdiction"/>
+                  </if>
+                  <else>
+                    <text variable="publisher-place"/>
+                  </else>
+                </choose>
+                <text variable="number"/>
+              </group>
+            </if>
+            <else-if type="bill legal_case legislation regulation report standard" match="any">
+              <text variable="number"/>
+            </else-if>
+          </choose>
+        </group>
+      </group>
+      <choose>
+        <if variable="container-title" type="chapter paper-conference" match="none">
+          <choose>
+            <if variable="event-date">
+              <text variable="event-place"/>
+              <date variable="event-date" form="text"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if>
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="bill collection legal_case legislation regulation" match="any">
+          <text value="A"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DS"/>
+        </else-if>
+        <else-if type="map">
+          <text value="CM"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else>
+          <text value="Z"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
+          <text value="OL"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group>
+      <group delimiter=", ">
+        <text macro="issued-year"/>
+        <text variable="volume"/>
+      </group>
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 连续出版物 -->
+  <macro name="serial-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="serial-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="chapter paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+    <layout prefix="(" suffix=")" delimiter="; " locale="en">
+      <group delimiter=", ">
+        <text macro="author-intext-en"/>
+        <text macro="issued-year"/>
+      </group>
+    </layout>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-intext-zh"/>
+        <text macro="issued-year"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-year"/>
+      <key variable="title"/>
+    </sort>
+    <layout locale="en">
+      <text macro="entry-layout"/>
+    </layout>
+    <layout>
+      <text macro="entry-layout"/>
+    </layout>
+  </bibliography>
+</style>

--- a/thuthesis-example.tex
+++ b/thuthesis-example.tex
@@ -58,8 +58,8 @@
 \input{data/chap04}
 
 % 参考文献
-\bibliography{ref/refs}  % 参考文献使用 BibTeX 编译
-% \printbibliography       % 参考文献使用 BibLaTeX 编译
+\bibliography{ref/refs}  % 参考文献使用 BibTeX
+% \printbibliography       % 参考文献使用 BibLaTeX 或 citation-style-language
 
 % 附录
 \appendix

--- a/thuthesis-numeric.csl
+++ b/thuthesis-numeric.csl
@@ -1,0 +1,442 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
+  <info>
+    <title>清华大学（顺序编码）</title>
+    <id>http://www.zotero.org/styles/tsinghua-university-numeric</id>
+    <link href="http://www.zotero.org/styles/tsinghua-university-numeric" rel="self"/>
+    <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="template"/>
+    <link href="http://yjsy.cic.tsinghua.edu.cn/docinfo/board/boarddetail.jsp?columnId=001050603&amp;parentColumnId=0010506&amp;itemSeq=5365" rel="documentation"/>
+    <author>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <summary>姓名取消全大写；专利文献增加“专利国别”。</summary>
+    <updated>2022-12-02T17:49:28+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
+    <terms>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 主要责任者 -->
+  <macro name="author">
+    <names variable="author">
+      <name/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event-title"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
+      <choose>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <!-- 非电子资源显示“出版年” -->
+        <choose>
+          <if type="book chapter paper-conference periodical thesis" variable="publisher page" match="any">
+            <text macro="issued-year"/>
+          </if>
+          <else-if variable="URL DOI" match="none">
+            <text macro="issued-year"/>
+          </else-if>
+        </choose>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if type="book chapter paper-conference periodical thesis" variable="publisher page" match="none">
+        <choose>
+          <if variable="URL DOI" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
+      <name/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
+          <group delimiter=", ">
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+              <else>
+                <text macro="issued-year"/>
+              </else>
+            </choose>
+            <text variable="volume"/>
+          </group>
+          <text variable="issue" prefix="(" suffix=")"/>
+        </group>
+        <text variable="page"/>
+      </group>
+      <text macro="accessed-date"/>
+    </group>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="chapter paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="patent">
+              <group delimiter=", ">
+                <choose>
+                  <!-- 专利的国别应使用 `jurisdiction`，但 Zotero 没有对应的域，所以 `publisher-place` 作为备选 -->
+                  <if variable="jurisdiction">
+                    <text variable="jurisdiction"/>
+                  </if>
+                  <else>
+                    <text variable="publisher-place"/>
+                  </else>
+                </choose>
+                <text variable="number"/>
+              </group>
+            </if>
+            <else-if type="bill legal_case legislation regulation report standard" match="any">
+              <text variable="number"/>
+            </else-if>
+          </choose>
+        </group>
+      </group>
+      <choose>
+        <if variable="container-title" type="chapter paper-conference" match="none">
+          <choose>
+            <if variable="event-date">
+              <text variable="event-place"/>
+              <date variable="event-date" form="text"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if>
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="bill collection legal_case legislation regulation" match="any">
+          <text value="A"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DS"/>
+        </else-if>
+        <else-if type="map">
+          <text value="CM"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else>
+          <text value="Z"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
+          <text value="OL"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group>
+      <group delimiter=", ">
+        <text macro="issued-year"/>
+        <text variable="volume"/>
+      </group>
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 连续出版物 -->
+  <macro name="serial-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 正文中引用的文献标注格式 -->
+  <macro name="citation-layout">
+    <group>
+      <text variable="citation-number"/>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="serial-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="chapter paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter=",">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
+      <text macro="citation-layout"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <layout locale="en">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout"/>
+    </layout>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout"/>
+    </layout>
+  </bibliography>
+</style>

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1850,7 +1850,9 @@
 \AtEndPreamble{
   \@ifpackageloaded{biblatex}{}{
     \@ifpackageloaded{apacite}{}{
-      \RequirePackage{natbib}
+      \@ifpackageloaded{citation-style-language}{}{
+        \RequirePackage{natbib}
+      }
     }
   }
 }
@@ -5967,6 +5969,43 @@
       \fi
     \else
       \setlength{\bibhang}{21bp}%  2em
+    \fi
+  }
+  \thu@set@bibliography@format
+  \thu@option@hook{degree}{\thu@set@bibliography@format}
+  \thu@option@hook{main-language}{\thu@set@bibliography@format}
+}
+%    \end{macrocode}
+%
+% \subsubsection{\pkg{citation-style-language} 宏包}
+%
+% 使用 \pkg{citation-style-language}（\pkg{citeproc-lua}）作为参考文献后端，
+% 可支持注释（note）样式，如美术学院要求的脚注引证格式。
+%    \begin{macrocode}
+\AtEndOfPackageFile*{citation-style-language}{
+  \AtBeginDocument{
+    \ifthenelse{\equal{\csl@style}{apa}}{\def\bibname{REFERENCES}}{}
+    \ifthenelse{\equal{\csl@style}{modern-language-association}}{\def\bibname{WORKS CITED}}{}
+  }
+  \renewcommand\bibsection{\thu@chapter*{\bibname}}
+  \newcommand\thu@set@bibliography@format{%
+    \ifthu@degree@bachelor
+      \cslsetup{
+        bib-font     = \fontsize{10.5bp}{17bp}\selectfont,
+        bib-item-sep = 3bp \@plus 3bp \@minus 3bp,
+      }%
+      \ifthu@main@language@chinese
+        \cslsetup{bib-hang = 21bp}%
+      \else
+        \cslsetup{bib-hang = 0.5in}%
+      \fi
+    \else
+      \cslsetup{
+        bib-font     = \fontsize{10.5bp}{16bp}\selectfont,
+        bib-item-sep = 3bp \@plus 3bp \@minus 3bp,
+        bib-entry-page-break = false,
+        bib-hang     = 21bp,
+      }%
     \fi
   }
   \thu@set@bibliography@format


### PR DESCRIPTION
## 概述

本 PR 在 `master`（v7.7.1）上引入 `citation-style-language`（`citeproc-lua`）参考文献后端，并内置美术学院的脚注引证样式 **`thuthesis-arts`**，落实 #844 的需求。

美术学院《研究生学位论文引证规范》要求采用**注释式（note）**引证：正文用带圈上标序号 ①②③，引文以脚注形式置于当页下，参考文献表用方括号 `[n]` 连续编号、悬挂缩进。这类样式用 BibTeX 难以实现，宜用 CSL（见 #844 中 @zepinglee 的讨论）。

相关功能此前已由 @zepinglee 在 [`csl` 分支](https://github.com/tuna/thuthesis/tree/csl) 实现（另见 #948，由 @evie-mo 维护），但一直未并入 `master`。本 PR 将该集成层重建到当前 `master`，并在原 CSL 基础上增加了**中英文双语**支持（补上当年“目前只支持英文格式”的缺口）。

## 改动

- **`thuthesis.dtx`**
  - 参考文献后端回退逻辑增加对 `citation-style-language` 的判断，避免在已加载 CSL 时仍自动加载 `natbib` 而冲突。
  - 新增 `\AtEndOfPackageFile*{citation-style-language}` 钩子，按学位/语言配置参考文献表的字体、条目间距与悬挂缩进。
- **内置三个 CSL 样式**：`thuthesis-numeric`、`thuthesis-author-year`（@zepinglee 原作）、`thuthesis-arts`（美术学院，中英双语，注释式）。
- **`latexmkrc`**：新增基于 `.ccf` 的 `cus_dep`，使用 CSL 时自动调用 `citeproc-lua`；**对默认 BibTeX / BibLaTeX 流程零影响**（无 `.ccf` 不触发，用户无需额外配置）。
- **`build.lua`**：将 `*.csl` 纳入安装/源文件。
- `thusetup.tex` / `thuthesis-example.tex`：增加 CSL 用法示例（默认仍为 BibTeX）。
- `CHANGELOG.md`。

## 用法

```tex
% thusetup.tex：注释掉 natbib，启用
\usepackage{citation-style-language}
\cslsetup{style = thuthesis-arts}   % 美术学院
\addbibresource{ref/refs.bib}
% 正文用 \cite{...}；用 \printbibliography 输出参考文献表
```

中文文献在 `.bib` 条目中设 `language = {zh-CN}` 即按中文格式排版，英文文献按英文格式。`citeproc-lua` 已随 TeX Live 2023+ 发行，`latexmk` 编译时自动调用，无需另装。

## 测试（TeX Live 2026 / citeproc-lua 0.9.1）

- `thuthesis-arts`：正文带圈上标脚注引证 ①②③、再次引证自动简化、方括号悬挂参考文献表，中英双语切换均正常。
- 用一篇真实的美术学院硕士论文（80 页，中英文混合）完整编译通过：0 个未定义引用、`latexmk` 自动调用 `citeproc-lua`，脚注与参考文献表均符合《引证规范》。
- **回归**：默认 BibTeX 示例编译不受影响，不生成 `.ccf`、不调用 `citeproc`。
- `l3build check`：除一个与本改动无关的既有失败（`config-crossref/package-hyperref`，在 `master` 上同样失败，系 TeX Live 2026 hyperref 版本漂移）外全部通过。

## 致谢与署名

- `thuthesis-arts.csl` 原作者 @zepinglee（基于 `social-sciences-in-china` 模板）。
- `csl` 分支的整合与维护 @evie-mo（#948）。
- 中英文双语 locale 支持 @Dixiao-L。

Closes #844
