### PR TITLE
thuthesis.dtx: Scope graduate statement font settings locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   XECJK_PKGS: fontspec xecjk ulem xetex
-  # thuthesis loads xeCJKfntef, which requires l3draw from l3experimental;
-  # xecjk's TeX Live metadata does not declare this dependency.
-  CTEX_PKGS: cjk ctex everysel l3experimental zhnumber
+  # thuthesis loads xeCJKfntef, which requires l3draw and accsupp;
+  # xecjk's TeX Live metadata declares neither l3experimental nor accsupp.
+  CTEX_PKGS: accsupp cjk ctex everysel l3experimental zhnumber
   BIBLATEX_PKGS: biber biblatex biblatex-apa biblatex-gb7714-2015 biblatex-mla xstring
   HYPERREF_PKGS: pdflscape
   NOMENCL_PKGS: nomencl koma-script xkeyval

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,9 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   XECJK_PKGS: fontspec xecjk ulem xetex
-  CTEX_PKGS: cjk ctex everysel zhnumber
+  # thuthesis loads xeCJKfntef, which requires l3draw from l3experimental;
+  # xecjk's TeX Live metadata does not declare this dependency.
+  CTEX_PKGS: cjk ctex everysel l3experimental zhnumber
   BIBLATEX_PKGS: biber biblatex biblatex-apa biblatex-gb7714-2015 biblatex-mla xstring
   HYPERREF_PKGS: pdflscape
   NOMENCL_PKGS: nomencl koma-script xkeyval
@@ -53,7 +55,7 @@ jobs:
       run: |
         version=$(git describe --tags --always)
         echo "Current git revision: $version"
-        python3 utils/create_release.py --version $version
+        python3 utils/create_release.py --version "$version"
     - name: Build CTAN release zip with l3build
       run: l3build ctan --config utils/build-ctan
     - name: Upload release zip
@@ -89,6 +91,24 @@ jobs:
       if: failure()
       with:
         name: test-result-${{ matrix.os }}
+        path: |
+          build/test
+          build/test-testfiles
+
+  test-container:
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+    runs-on: ubuntu-latest
+    container:
+      image: texlive/texlive:latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Test with l3build
+      run: make test
+    - name: Upload test results if failed
+      uses: actions/upload-artifact@v7
+      if: failure()
+      with:
+        name: test-result-docker
         path: |
           build/test
           build/test-testfiles

--- a/testfiles/01-title-page-en/01-title-page-academic-doctor-1.tlg
+++ b/testfiles/01-title-page-en/01-title-page-academic-doctor-1.tlg
@@ -318,6 +318,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -364,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -408,6 +410,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -462,6 +465,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -485,6 +489,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-academic-doctor-2.tlg
+++ b/testfiles/01-title-page-en/01-title-page-academic-doctor-2.tlg
@@ -318,6 +318,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -364,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -408,6 +410,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -462,6 +465,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -485,6 +489,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -524,6 +530,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -547,6 +554,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-academic-doctor-3.tlg
+++ b/testfiles/01-title-page-en/01-title-page-academic-doctor-3.tlg
@@ -318,6 +318,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -364,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -408,6 +410,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -462,6 +465,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -485,6 +489,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -526,6 +532,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -549,6 +556,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-academic-master-1.tlg
+++ b/testfiles/01-title-page-en/01-title-page-academic-master-1.tlg
@@ -318,6 +318,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -364,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -408,6 +410,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -462,6 +465,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -485,6 +489,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-academic-master-2.tlg
+++ b/testfiles/01-title-page-en/01-title-page-academic-master-2.tlg
@@ -318,6 +318,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -364,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -408,6 +410,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -462,6 +465,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -485,6 +489,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -524,6 +530,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -547,6 +554,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-academic-master-3.tlg
+++ b/testfiles/01-title-page-en/01-title-page-academic-master-3.tlg
@@ -318,6 +318,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -364,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -408,6 +410,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -462,6 +465,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -485,6 +489,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -526,6 +532,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -549,6 +556,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-doctor-1.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-doctor-1.tlg
@@ -323,6 +323,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -371,6 +372,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -425,6 +427,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -448,6 +451,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-doctor-2.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-doctor-2.tlg
@@ -323,6 +323,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -371,6 +372,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -425,6 +427,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -448,6 +451,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -487,6 +492,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -510,6 +516,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-doctor-3.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-doctor-3.tlg
@@ -323,6 +323,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -371,6 +372,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -425,6 +427,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -448,6 +451,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -489,6 +494,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -512,6 +518,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-master-1.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-master-1.tlg
@@ -327,6 +327,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -375,6 +376,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -429,6 +431,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -452,6 +455,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-master-2.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-master-2.tlg
@@ -327,6 +327,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -375,6 +376,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -429,6 +431,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -452,6 +455,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -491,6 +496,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -514,6 +520,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-master-3.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-master-3.tlg
@@ -327,6 +327,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -375,6 +376,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -429,6 +431,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -452,6 +455,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -493,6 +498,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -516,6 +522,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-master-engineering-1.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-master-engineering-1.tlg
@@ -323,6 +323,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -373,6 +374,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -419,6 +421,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -473,6 +476,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -496,6 +500,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-master-engineering-2.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-master-engineering-2.tlg
@@ -323,6 +323,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -373,6 +374,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -419,6 +421,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -473,6 +476,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -496,6 +500,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -535,6 +541,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -558,6 +565,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page-en/01-title-page-professional-master-engineering-3.tlg
+++ b/testfiles/01-title-page-en/01-title-page-professional-master-engineering-3.tlg
@@ -323,6 +323,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -373,6 +374,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -419,6 +421,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(10.63171+0.17665)x85.35826, glue set 12.07649fil
@@ -473,6 +476,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -496,6 +500,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -537,6 +543,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -560,6 +567,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-bachelor-en.tlg
+++ b/testfiles/01-title-page/01-title-page-bachelor-en.tlg
@@ -297,6 +297,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -308,7 +310,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.83194+2.82654)x159.99774, glue set 47.57776fil
 .........\TU/FandolFang(0)/m/n/16.06 外
 .........\glue 0.0 plus 0.81671
@@ -326,6 +330,8 @@ Completed box being shipped out [1]
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -345,6 +351,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -356,7 +364,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.59103+2.87473)x159.99774, glue set 63.63776fil
 .........\TU/FandolFang(0)/m/n/16.06 英
 .........\glue 0.0 plus 0.81671
@@ -372,6 +382,8 @@ Completed box being shipped out [1]
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -391,6 +403,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -402,7 +416,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.67134+2.82654)x159.99774, glue set 95.75775fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -413,7 +429,11 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -437,6 +457,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -448,7 +470,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.73558+2.82654)x159.99774, glue set 23.48776fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -459,6 +483,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 24.09
 .........\hbox(12.73558+2.74625)x48.18
 ..........\special{color push gray 0}
@@ -471,6 +497,8 @@ Completed box being shipped out [1]
 ..........\kern 0.00017
 ..........\special{color pop}
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-bachelor-secret.tlg
+++ b/testfiles/01-title-page/01-title-page-bachelor-secret.tlg
@@ -100,8 +100,6 @@ Completed box being shipped out [1]
 ......\TU/FandolSong(0)/m/n/12.045 密
 ......\glue 0.0 plus 0.73799
 ......\TU/FandolSong(0)/m/n/12.045 ★
-......\kern -0.00018
-......\kern 0.00018
 ......\glue 3.01125 plus 1.50562 minus 1.00374
 ......\TU/texgyretermes(0)/m/n/12.045 10
 ......\glue 3.01125 plus 1.50562 minus 1.00374
@@ -263,6 +261,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -274,7 +274,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.63922+2.74625)x159.99774, glue set 47.57776fil
 .........\TU/FandolFang(0)/m/n/16.06 水
 .........\glue 0.0 plus 0.81671
@@ -292,6 +294,8 @@ Completed box being shipped out [1]
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -311,6 +315,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -322,7 +328,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.63922+2.74625)x159.99774, glue set 63.63776fil
 .........\TU/FandolFang(0)/m/n/16.06 水
 .........\glue 0.0 plus 0.81671
@@ -338,6 +346,8 @@ Completed box being shipped out [1]
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -357,6 +367,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -368,7 +380,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.67134+2.82654)x159.99774, glue set 95.75775fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -379,7 +393,11 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -403,6 +421,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -414,7 +434,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.73558+2.82654)x159.99774, glue set 31.51776fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -425,6 +447,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 24.09
 .........\hbox(12.73558+2.74625)x40.15, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 教
@@ -433,7 +457,11 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-bachelor.tlg
+++ b/testfiles/01-title-page/01-title-page-bachelor.tlg
@@ -210,13 +210,13 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\lineskip) 1.0
-...\hbox(65.1635+59.141)x421.10089, glue set 73.0592fil
+...\hbox(65.1635+59.141)x421.10089, glue set 71.0517fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\hbox(65.1635+59.141)x274.9825
-.....\vbox(65.1635+59.141)x274.9825
-......\hbox(21.7532+9.32292)x274.9825
+....\hbox(65.1635+59.141)x278.9975
+.....\vbox(65.1635+59.141)x278.9975
+......\hbox(21.7532+9.32292)x278.9975
 .......\glue(\tabskip) 0.0
-.......\hbox(21.7532+9.32292)x274.9825
+.......\hbox(21.7532+9.32292)x278.9975
 ........\rule(21.7532+9.32292)x0.0
 ........\glue 6.0
 ........\glue 0.00002
@@ -229,6 +229,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -240,19 +242,23 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 4.015 plus 2.00749 minus 1.33833
 ........\hbox(7.13065+0.0)x159.99774, glue set 123.76639fil
 .........\TU/texgyretermes(0)/m/n/16.06 ^^d7^^d7^^d7^^d7
 .........\kern -0.0002
 .........\kern 0.0002
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.0002
+........\kern 0.0002
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
 ......\glue(\lineskip) 0.0
-......\hbox(21.7532+9.32292)x274.9825
+......\hbox(21.7532+9.32292)x278.9975
 .......\glue(\tabskip) 0.0
-.......\hbox(21.7532+9.32292)x274.9825
+.......\hbox(21.7532+9.32292)x278.9975
 ........\rule(21.7532+9.32292)x0.0
 ........\glue 6.0
 ........\glue 0.00002
@@ -265,6 +271,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -276,19 +284,23 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 4.015 plus 2.00749 minus 1.33833
 ........\hbox(7.13065+0.0)x159.99774, glue set 87.53503fil
 .........\TU/texgyretermes(0)/m/n/16.06 ^^d7^^d7^^d7^^d7^^d7^^d7^^d7^^d7
 .........\kern -0.0002
 .........\kern 0.0002
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.0002
+........\kern 0.0002
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
 ......\glue(\lineskip) 0.0
-......\hbox(21.7532+9.32292)x274.9825
+......\hbox(21.7532+9.32292)x278.9975
 .......\glue(\tabskip) 0.0
-.......\hbox(21.7532+9.32292)x274.9825
+.......\hbox(21.7532+9.32292)x278.9975, glue set 4.015fil
 ........\rule(21.7532+9.32292)x0.0
 ........\glue 6.0
 ........\glue 0.00002
@@ -301,6 +313,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -312,7 +326,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.67134+2.82654)x159.99774, glue set 95.75775fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -323,14 +339,18 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
 ......\glue(\lineskip) 0.0
-......\hbox(21.7532+9.32292)x274.9825
+......\hbox(21.7532+9.32292)x278.9975
 .......\glue(\tabskip) 0.0
-.......\hbox(21.7532+9.32292)x274.9825
+.......\hbox(21.7532+9.32292)x278.9975, glue set 4.015fil
 ........\rule(21.7532+9.32292)x0.0
 ........\glue 6.0
 ........\glue 0.00002
@@ -347,6 +367,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -358,7 +380,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.73558+2.82654)x159.99774, glue set 31.51776fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -369,6 +393,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 24.09
 .........\hbox(12.73558+2.74625)x40.15, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 教
@@ -377,7 +403,11 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-1.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-1.tlg
@@ -252,6 +252,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 经
@@ -300,6 +301,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 应
@@ -348,6 +350,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.89618+2.6017)x85.35826, glue set 21.11827fil
@@ -403,6 +406,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.88011+2.9229)x85.35826, glue set 21.11827fil
@@ -426,6 +430,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-10.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-10.tlg
@@ -92,7 +92,7 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\vbox(12.5268+44.37871)x398.3386, glue set 41.58429fil
-.....\hbox(12.5268+2.79442)x398.3386, glue set 307.41861fil
+.....\hbox(12.5268+2.79442)x398.3386, glue set 298.48926fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -21.5
 ......\TU/FandolHei(0)/m/n/16.06 秘
@@ -100,14 +100,14 @@ Completed box being shipped out [1]
 ......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 ★
-......\kern -0.00017
-......\kern 0.00017
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\hbox(11.38654+0.24089)x48.18, glue set 15.16064fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\TU/texgyreheros(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
@@ -276,6 +276,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 能
@@ -330,6 +331,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -385,6 +387,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -408,6 +411,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -449,6 +454,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -472,6 +478,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-2.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-2.tlg
@@ -137,7 +137,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/26.09749 多
 ....\glue 0.0 plus 2.53644
 ....\TU/FandolHei(0)/m/n/26.09749 肽
-....\glue 7.2551 plus 3.62392 minus 2.42078
+....\glue 7.2551 plus 3.62755 minus 2.41837
 ....\TU/texgyreheros(0)/m/n/26.09749 C
 ....\glue 7.2551 plus 3.62392 minus 2.42078
 ....\TU/FandolHei(0)/m/n/26.09749 端
@@ -251,6 +251,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 化
@@ -293,6 +294,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 化
@@ -335,6 +337,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.6874+2.69806)x85.35826, glue set 21.11827fil
@@ -390,6 +393,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.65527+2.79442)x85.35826, glue set 21.11827fil
@@ -413,6 +417,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -452,6 +458,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -475,6 +482,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-3.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-3.tlg
@@ -225,6 +225,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 航
@@ -273,6 +274,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 力
@@ -315,6 +317,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.57498+2.81049)x85.35826, glue set 21.11827fil
@@ -368,6 +371,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.91223+2.77837)x85.35826, glue set 21.11827fil
@@ -391,6 +395,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-4.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-4.tlg
@@ -219,6 +219,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 精
@@ -273,6 +274,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 机
@@ -319,6 +321,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.06107+2.39293)x85.35826, glue set 21.11827fil
@@ -372,6 +375,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.70346+2.97108)x85.35826, glue set 21.11827fil
@@ -395,6 +399,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -434,6 +440,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.81049)x85.35826, glue set 21.11827fil

--- a/testfiles/01-title-page/01-title-page-doctor-1-5.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-5.tlg
@@ -92,7 +92,7 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\vbox(12.5268+44.37871)x398.3386, glue set 41.58429fil
-.....\hbox(12.5268+2.79442)x398.3386, glue set 307.41861fil
+.....\hbox(12.5268+2.79442)x398.3386, glue set 298.48926fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -21.5
 ......\TU/FandolHei(0)/m/n/16.06 秘
@@ -100,14 +100,14 @@ Completed box being shipped out [1]
 ......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 ★
-......\kern -0.00017
-......\kern 0.00017
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\hbox(11.38654+0.24089)x48.18, glue set 15.16064fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\TU/texgyreheros(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
@@ -267,6 +267,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 经
@@ -315,6 +316,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 应
@@ -363,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -418,6 +421,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -441,6 +445,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-6.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-6.tlg
@@ -219,6 +219,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 精
@@ -273,6 +274,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 机
@@ -319,6 +321,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.06107+2.39293)x85.35826, glue set 21.11827fil
@@ -372,6 +375,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.70346+2.97108)x85.35826, glue set 21.11827fil
@@ -395,6 +399,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -436,6 +442,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.73558+2.81049)x85.35826, glue set 21.11827fil

--- a/testfiles/01-title-page/01-title-page-doctor-1-7.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-7.tlg
@@ -253,6 +253,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 教
@@ -301,6 +302,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -356,6 +358,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -379,6 +382,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-8.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-8.tlg
@@ -92,7 +92,7 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\vbox(12.5268+44.37871)x398.3386, glue set 41.58429fil
-.....\hbox(12.5268+2.79442)x398.3386, glue set 307.41861fil
+.....\hbox(12.5268+2.79442)x398.3386, glue set 298.48926fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -21.5
 ......\TU/FandolHei(0)/m/n/16.06 秘
@@ -100,14 +100,14 @@ Completed box being shipped out [1]
 ......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 ★
-......\kern -0.00017
-......\kern 0.00017
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\hbox(11.38654+0.24089)x48.18, glue set 15.16064fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\TU/texgyreheros(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
@@ -268,6 +268,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 教
@@ -316,6 +317,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -371,6 +373,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -394,6 +397,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-doctor-1-9.tlg
+++ b/testfiles/01-title-page/01-title-page-doctor-1-9.tlg
@@ -261,6 +261,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 能
@@ -315,6 +316,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -370,6 +372,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -393,6 +396,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -434,6 +439,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -457,6 +463,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-1.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-1.tlg
@@ -250,6 +250,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 工
@@ -296,6 +297,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 管
@@ -348,6 +350,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -403,6 +406,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -426,6 +430,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -467,6 +473,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -490,6 +497,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-2.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-2.tlg
@@ -92,7 +92,7 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\vbox(12.5268+44.37871)x398.3386, glue set 41.58429fil
-.....\hbox(12.5268+2.79442)x398.3386, glue set 307.41861fil
+.....\hbox(12.5268+2.79442)x398.3386, glue set 298.48926fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -21.5
 ......\TU/FandolHei(0)/m/n/16.06 秘
@@ -100,14 +100,14 @@ Completed box being shipped out [1]
 ......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 ★
-......\kern -0.00017
-......\kern 0.00017
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\hbox(11.38654+0.24089)x48.18, glue set 15.16064fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\TU/texgyreheros(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
@@ -265,6 +265,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 工
@@ -311,6 +312,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 管
@@ -363,6 +365,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -418,6 +421,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -441,6 +445,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -482,6 +488,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -505,6 +512,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-3.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-3.tlg
@@ -257,6 +257,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 公
@@ -307,6 +308,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -362,6 +364,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -385,6 +388,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -426,6 +431,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -449,6 +455,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-4.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-4.tlg
@@ -92,7 +92,7 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\vbox(12.5268+44.37871)x398.3386, glue set 41.58429fil
-.....\hbox(12.5268+2.79442)x398.3386, glue set 307.41861fil
+.....\hbox(12.5268+2.79442)x398.3386, glue set 298.48926fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -21.5
 ......\TU/FandolHei(0)/m/n/16.06 秘
@@ -100,14 +100,14 @@ Completed box being shipped out [1]
 ......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 ★
-......\kern -0.00017
-......\kern 0.00017
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\hbox(11.38654+0.24089)x48.18, glue set 15.16064fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\TU/texgyreheros(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
@@ -272,6 +272,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 公
@@ -322,6 +323,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.71951+2.9229)x85.35826, glue set 21.11827fil
@@ -377,6 +379,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -400,6 +403,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -441,6 +446,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -464,6 +470,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-5.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-5.tlg
@@ -236,6 +236,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 环
@@ -284,6 +285,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 环
@@ -330,6 +332,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -385,6 +388,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -408,6 +412,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -449,6 +455,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -472,6 +479,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-6.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-6.tlg
@@ -92,7 +92,7 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
 ....\vbox(12.5268+44.37871)x398.3386, glue set 41.58429fil
-.....\hbox(12.5268+2.79442)x398.3386, glue set 307.41861fil
+.....\hbox(12.5268+2.79442)x398.3386, glue set 298.48926fil
 ......\hbox(0.0+0.0)x0.0
 ......\glue -21.5
 ......\TU/FandolHei(0)/m/n/16.06 秘
@@ -100,14 +100,14 @@ Completed box being shipped out [1]
 ......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 ★
-......\kern -0.00017
-......\kern 0.00017
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\hbox(11.38654+0.24089)x48.18, glue set 15.16064fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\TU/texgyreheros(0)/m/n/16.06 10
 .......\kern -0.0002
 .......\kern 0.0002
 .......\glue 0.0 plus 1.0fil minus 1.0fil
+......\glue 4.46468 plus 2.23233 minus 1.48822
 ......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
@@ -251,6 +251,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 环
@@ -299,6 +300,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 环
@@ -345,6 +347,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -400,6 +403,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -423,6 +427,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -464,6 +470,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -487,6 +494,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-7.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-7.tlg
@@ -230,6 +230,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 土
@@ -280,6 +281,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 建
@@ -332,6 +334,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -387,6 +390,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -410,6 +414,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -451,6 +457,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -474,6 +481,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-master-1-8.tlg
+++ b/testfiles/01-title-page/01-title-page-master-1-8.tlg
@@ -100,11 +100,10 @@ Completed box being shipped out [1]
 ......\TU/FandolHei(0)/m/n/16.06 密
 ......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 ★
-......\kern -0.00017
-......\kern 0.00017
 ......\hbox(0.0+0.0)x48.18, glue set 24.09fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 .......\glue 0.0 plus 1.0fil minus 1.0fil
+......\glue 0.0 plus 1.3163
 ......\TU/FandolHei(0)/m/n/16.06 年
 ......\kern -0.00017
 ......\kern 0.00017
@@ -242,6 +241,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 土
@@ -292,6 +292,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 建
@@ -344,6 +345,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -399,6 +401,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -422,6 +425,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -463,6 +468,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.67134+2.82654)x85.35826, glue set 21.11827fil
@@ -486,6 +492,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-postdoc-1.tlg
+++ b/testfiles/01-title-page/01-title-page-postdoc-1.tlg
@@ -72,6 +72,8 @@ Completed box being shipped out [1]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\glue 1.0
 ....\mathon
 ....\vbox(0.0+4.63684)x105.2751
@@ -117,6 +119,8 @@ Completed box being shipped out [1]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 1.0
 ....\mathon
 ....\vbox(0.0+4.63684)x105.2751
@@ -717,6 +721,7 @@ Completed box being shipped out [1]
 ......\TU/FandolSong(0)/m/n/12.045 —
 ......\rule(0.0+0.0)x0.0
 ......\glue 0.0
+......\penalty 0
 ......\TU/texgyretermes(0)/m/n/12.045 1994
 ......\glue 3.01125 plus 1.50562 minus 1.00374
 ......\TU/FandolSong(0)/m/n/12.045 年
@@ -727,6 +732,8 @@ Completed box being shipped out [1]
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.0002
+....\kern 0.0002
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -773,6 +780,8 @@ Completed box being shipped out [1]
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.0002
+....\kern 0.0002
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil

--- a/testfiles/01-title-page/01-title-page-postdoc-2.tlg
+++ b/testfiles/01-title-page/01-title-page-postdoc-2.tlg
@@ -256,6 +256,8 @@ Completed box being shipped out [1]
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 12.045
 .......\glue(\tabskip) 0.0

--- a/testfiles/01-title-page/01-title-page-proposal.tlg
+++ b/testfiles/01-title-page/01-title-page-proposal.tlg
@@ -250,6 +250,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 填
@@ -310,6 +311,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/FandolFang(0)/m/n/16.06 填
@@ -356,6 +358,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.75163+2.40898)x85.35826, glue set 21.11827fil
@@ -405,6 +408,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\TU/texgyretermes(0)/m/n/16.06 2000310000
@@ -447,6 +451,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.75163+2.40898)x85.35826, glue set 21.11827fil
@@ -468,6 +473,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0
@@ -507,6 +514,7 @@ Completed box being shipped out [1]
 ............\kern -0.99649
 ............\kern 0.99649
 ............\glue 11.19382 minus 8.03
+............\penalty 0
 ............\special{color pop}
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ..........\hbox(12.75163+2.40898)x85.35826, glue set 21.11827fil
@@ -528,6 +536,8 @@ Completed box being shipped out [1]
 ...........\kern -0.00017
 ...........\kern 0.00017
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\kern -0.00017
+..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil
 ..........\glue 6.0
 .........\glue(\tabskip) 0.0

--- a/testfiles/04-abstract.tlg
+++ b/testfiles/04-abstract.tlg
@@ -521,13 +521,13 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 章
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 …
-....\rule(0.0+0.0)x-2.04765
-....\glue 2.04765 minus 2.04765
+....\penalty 10000
+....\glue 0.0 minus 2.04765
 ....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
@@ -537,22 +537,22 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 章
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 …
-....\rule(0.0+0.0)x-2.04765
-....\glue 2.04765 minus 2.04765
+....\penalty 10000
+....\glue 0.0 minus 2.04765
 ....\TU/FandolSong(0)/m/n/12.045 ；
-....\rule(0.0+0.0)x-8.32309
-....\glue 8.32309 minus 8.07014
+....\penalty 10000
+....\glue 0.0 minus 8.07014
 ....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 …
-....\rule(0.0+0.0)x-2.04765
-....\glue 2.04765 minus 1.02382
+....\penalty 10000
+....\glue 0.0 minus 1.02382
 ....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225

--- a/testfiles/06-contents.tlg
+++ b/testfiles/06-contents.tlg
@@ -6518,7 +6518,7 @@ Completed box being shipped out [7]
 ......\TU/FandolHei(0)/m/n/12.045 附
 ......\glue 0.0 plus 0.52307
 ......\TU/FandolHei(0)/m/n/12.045 录
-......\glue 3.34851 plus 1.67258 minus 1.11728
+......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 A
 ......\kern -0.0002
 ......\kern 0.0002
@@ -6607,7 +6607,7 @@ Completed box being shipped out [7]
 ......\TU/FandolHei(0)/m/n/12.045 附
 ......\glue 0.0 plus 0.52307
 ......\TU/FandolHei(0)/m/n/12.045 录
-......\glue 3.34851 plus 1.67258 minus 1.11728
+......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 B
 ......\kern -0.0002
 ......\kern 0.0002

--- a/testfiles/07-1-figures-tables.tlg
+++ b/testfiles/07-1-figures-tables.tlg
@@ -1136,7 +1136,7 @@ Completed box being shipped out [3]
 ....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 型
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DU
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 的
@@ -1306,7 +1306,7 @@ Completed box being shipped out [3]
 ....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DU
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 个

--- a/testfiles/07-2-figures.tlg
+++ b/testfiles/07-2-figures.tlg
@@ -1559,7 +1559,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/12.045 线
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 及
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SurVolumemax
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 的
@@ -2215,7 +2215,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 统
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 NSGA-II
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 主
@@ -2381,7 +2381,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 统
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 NSGA-II
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 主
@@ -2889,7 +2889,7 @@ Completed box being shipped out [4]
 ....\TU/texgyretermes(0)/m/n/12.045 _Matrix
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 RD
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2963,7 +2963,7 @@ Completed box being shipped out [4]
 ....\TU/texgyretermes(0)/m/n/12.045 _Matrix
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 RD
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4107,7 +4107,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 矩
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 阵
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SM
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 示
@@ -4184,7 +4184,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 邻
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DU
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 之
@@ -4200,7 +4200,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 矩
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 阵
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DM
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 示
@@ -4476,7 +4476,7 @@ Completed box being shipped out [4]
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SO
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
@@ -4739,7 +4739,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 统
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SWMM
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 模
@@ -4827,7 +4827,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 同
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 WWTP
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 方
@@ -4911,7 +4911,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 统
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 LcC
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 差
@@ -4923,7 +4923,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 度
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 与
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 PeL
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 差
@@ -5009,7 +5009,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 案
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 NDSP
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 结
@@ -5046,7 +5046,7 @@ Completed box being shipped out [4]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x426.79135, glue set - 0.2373
+...\hbox(14.05243+6.02255)x426.79135, glue set - 0.23743
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
@@ -5079,7 +5079,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 案
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 NDSP
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 结
@@ -5284,7 +5284,7 @@ Completed box being shipped out [4]
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SLUC
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
@@ -5471,7 +5471,7 @@ Completed box being shipped out [5]
 ..\glue(\lineskip) 0.0
 ..\vbox(674.33032+0.0)x426.79135, glue set 158.3635fil
 ...\glue(\topskip) 0.0
-...\hbox(14.05243+6.02255)x426.79135, glue set - 0.09503
+...\hbox(14.05243+6.02255)x426.79135, glue set - 0.09506
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
@@ -5490,11 +5490,11 @@ Completed box being shipped out [5]
 ......\glue 12.045
 ......\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 在
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SCPC
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SLUC
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 情
@@ -5510,7 +5510,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 用
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 下
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Flooding
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 、
@@ -5519,7 +5519,7 @@ Completed box being shipped out [5]
 ....\TU/texgyretermes(0)/m/n/12.045 NumNode
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Flux
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 的
@@ -5977,7 +5977,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 案
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 NDSP
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 分
@@ -6065,7 +6065,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 案
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 NDSP
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 分
@@ -6356,7 +6356,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 案
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 LcC-DiV
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 性
@@ -6411,7 +6411,7 @@ Completed box being shipped out [5]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x426.79135, glue set - 0.08229
+...\hbox(14.05243+6.02255)x426.79135, glue set - 0.08232
 ....\glue(\leftskip) 42.15749
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
@@ -6432,7 +6432,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 相
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 同
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 LcC
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 条
@@ -6444,7 +6444,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 同
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SO
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 布
@@ -6456,7 +6456,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 案
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DiV
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 取
@@ -6475,7 +6475,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 没
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 有
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 LcC=200
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 的
@@ -6557,7 +6557,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 同
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SO
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 、
@@ -6654,7 +6654,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 同
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SO
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 、
@@ -6918,7 +6918,7 @@ Completed box being shipped out [5]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x426.79135, glue set 0.04353
+...\hbox(14.05243+6.02255)x426.79135, glue set 0.04352
 ....\glue(\leftskip) 42.15749
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
@@ -6969,7 +6969,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 下
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 LcC
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
@@ -6991,7 +6991,7 @@ Completed box being shipped out [5]
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 PwR
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654
@@ -7091,7 +7091,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 景
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 下
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 NDSP
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 分
@@ -7189,7 +7189,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 则
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 下
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DWF
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 变
@@ -7368,7 +7368,7 @@ Completed box being shipped out [5]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x426.79135, glue set 0.40443
+...\hbox(14.05243+6.02255)x426.79135, glue set 0.40437
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
@@ -7396,7 +7396,7 @@ Completed box being shipped out [5]
 ....\glue 7.63654 minus 6.0225
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 ES
 ....\glue 7.63654 minus 6.0225
 ....\rule(0.0+0.0)x-7.63654

--- a/testfiles/07-3-tables.tlg
+++ b/testfiles/07-3-tables.tlg
@@ -507,7 +507,7 @@ C.}
 ....\TU/texgyretermes(0)/m/n/12.045 SRES
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 和
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 RCPs
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 温
@@ -1580,7 +1580,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 型
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DU
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 的
@@ -1666,7 +1666,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 型
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DU
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 对
@@ -2323,7 +2323,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DU
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 个
@@ -2473,7 +2473,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/12.045 类
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 型
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 DU
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 的
@@ -4095,7 +4095,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 同
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 SO
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 数
@@ -4227,7 +4227,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 可
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 行
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 WWTP
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 组

--- a/testfiles/09-main-bachelor-en.tlg
+++ b/testfiles/09-main-bachelor-en.tlg
@@ -10725,9 +10725,9 @@ Completed box being shipped out [7]
 ....\TU/texgyretermes(0)/m/n/12.045 (Table
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 4.1
+....\hbox(0.0+0.0)x0.0
 ....\kern -0.0002
 ....\kern 0.0002
-....\hbox(0.0+0.0)x0.0
 ....\TU/texgyretermes(0)/m/n/12.045 –4.4)
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 below
@@ -15113,6 +15113,8 @@ C.}
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -15610,6 +15612,8 @@ Completed box being shipped out [15]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.0002
+....\kern 0.0002
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -15819,6 +15823,8 @@ Completed box being shipped out [16]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.0002
+....\kern 0.0002
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil

--- a/testfiles/09-main-bachelor.tlg
+++ b/testfiles/09-main-bachelor.tlg
@@ -230,6 +230,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -241,7 +243,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(13.10497+2.93896)x159.99774, glue set 15.45776fil
 .........\TU/FandolFang(0)/m/n/16.06 计
 .........\glue 0.0 plus 0.81671
@@ -263,6 +267,8 @@ Completed box being shipped out [1]
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -282,6 +288,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -293,7 +301,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(13.10497+2.93896)x159.99774, glue set 31.51776fil
 .........\TU/FandolFang(0)/m/n/16.06 计
 .........\glue 0.0 plus 0.81671
@@ -313,6 +323,8 @@ Completed box being shipped out [1]
 .........\kern -0.00017
 .........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -332,6 +344,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -343,7 +357,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.67134+2.82654)x159.99774, glue set 95.75775fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -354,7 +370,11 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -378,6 +398,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\hbox(8.47968+0.0)x23.33717, glue set 3.6386fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -389,7 +411,9 @@ Completed box being shipped out [1]
 .........\kern -0.99649
 .........\kern 0.99649
 .........\glue 11.19382 minus 8.03
+.........\penalty 0
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\glue 0.0 plus 0.81671
 ........\hbox(12.73558+2.82654)x159.99774, glue set 31.51776fil
 .........\hbox(12.67134+2.82654)x64.23999, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 某
@@ -400,6 +424,8 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 24.09
 .........\hbox(12.73558+2.74625)x40.15, glue set 4.015filll
 ..........\TU/FandolFang(0)/m/n/16.06 教
@@ -408,7 +434,11 @@ Completed box being shipped out [1]
 ..........\kern -0.00017
 ..........\kern 0.00017
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.00017
+.........\kern 0.00017
 .........\glue 0.0 plus 1.0fil minus 1.0fil
+........\kern -0.00017
+........\kern 0.00017
 ........\glue 0.0 plus 1.0fil
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -1456,13 +1486,13 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 1
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 章
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 …
-....\rule(0.0+0.0)x-2.04765
-....\glue 2.04765 minus 2.04765
+....\penalty 10000
+....\glue 0.0 minus 2.04765
 ....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue 8.32309 minus 6.02249
@@ -1472,22 +1502,22 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 2
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 章
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 …
-....\rule(0.0+0.0)x-2.04765
-....\glue 2.04765 minus 2.04765
+....\penalty 10000
+....\glue 0.0 minus 2.04765
 ....\TU/FandolSong(0)/m/n/12.045 ；
-....\rule(0.0+0.0)x-8.32309
-....\glue 8.32309 minus 8.07014
+....\penalty 10000
+....\glue 0.0 minus 8.07014
 ....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 …
-....\rule(0.0+0.0)x-2.04765
-....\glue 2.04765 minus 1.02382
+....\penalty 10000
+....\glue 0.0 minus 1.02382
 ....\TU/FandolSong(0)/m/n/12.045 ”
 ....\rule(0.0+0.0)x-7.04633
 ....\glue 7.04633 minus 6.0225
@@ -1612,12 +1642,10 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 取
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 3
-....\penalty 10000
-....\glue 3.34851 minus 1.67426
-....\rule(0.0+0.0)x-3.34851
+....\penalty 0
 ....\TU/FandolSong(0)/m/n/12.045 ～
 ....\rule(0.0+0.0)x-3.34851
-....\glue 3.34851 minus 1.67426
+....\glue 3.34851
 ....\TU/texgyretermes(0)/m/n/12.045 5
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 个
@@ -2425,6 +2453,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -2435,13 +2465,13 @@ Completed box being shipped out [3]
 ...\penalty 10000
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
-...\hbox(14.05243+6.02255)x426.79135, glue set 344.80505fill
-....\glue(\leftskip) 40.83255
+...\hbox(14.05243+6.02255)x426.79135, glue set 348.15356fill
+....\glue(\leftskip) 37.48404
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.41919+2.13194)x0.0, glue set - 40.83255fil
+....\hbox(9.41919+2.13194)x0.0, glue set - 37.48404fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.41919+2.13194)x40.83255
+.....\hbox(9.41919+2.13194)x37.48404
 ......\special{color push gray 0}
 ......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2450,7 +2480,6 @@ Completed box being shipped out [3]
 ......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00018
 ......\kern 0.00018
-......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\special{color pop}
 ....\hbox(9.21443+2.03558)x36.135, glue set 6.0225filll
 .....\TU/FandolHei(0)/m/n/12.045 引
@@ -2459,6 +2488,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
@@ -2659,13 +2690,13 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x426.79135, glue set 272.53506fill
-....\glue(\leftskip) 40.83255
+...\hbox(14.05243+6.02255)x426.79135, glue set 275.88358fill
+....\glue(\leftskip) 37.48404
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.41919+2.13194)x0.0, glue set - 40.83255fil
+....\hbox(9.41919+2.13194)x0.0, glue set - 37.48404fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.41919+2.13194)x40.83255
+.....\hbox(9.41919+2.13194)x37.48404
 ......\special{color push gray 0}
 ......\TU/FandolHei(0)/m/n/12.045 第
 ......\glue 3.34851 plus 1.67426 minus 1.11617
@@ -2674,7 +2705,6 @@ Completed box being shipped out [3]
 ......\TU/FandolHei(0)/m/n/12.045 章
 ......\kern -0.00018
 ......\kern 0.00018
-......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\special{color pop}
 ....\hbox(9.29874+2.16809)x108.40498
 .....\special{color push gray 0}
@@ -2953,7 +2983,7 @@ Completed box being shipped out [3]
 ......\TU/FandolHei(0)/m/n/12.045 附
 ......\glue 0.0 plus 0.52307
 ......\TU/FandolHei(0)/m/n/12.045 录
-......\glue 3.34851 plus 1.67258 minus 1.11728
+......\glue 3.34851 plus 1.67426 minus 1.11617
 ......\TU/texgyreheros(0)/m/n/12.045 A
 ......\glue 3.34851 plus 1.67258 minus 1.11728
 ......\special{color pop}
@@ -2964,6 +2994,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
@@ -3003,6 +3035,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
@@ -3042,6 +3076,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\penalty 10000
@@ -4660,6 +4696,8 @@ Completed box being shipped out [1]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -5773,17 +5811,15 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 5.02779
-...\hbox(12.72253+2.15604)x426.79135, glue set 373.82333fil
+...\hbox(12.72253+2.15604)x426.79135, glue set 376.83458fil
 ....\TU/FandolSong(0)/m/n/12.045 范
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 示
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 例
 ....\kern -0.00018
-....\kern 0.00018
-....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-....\penalty 10000
+....\kern 0.00018
 ....\penalty 10000
 ....\hbox(12.72253+0.0)x9.53375
 .....\hbox(7.90454+1.52669)x9.03375, shifted -4.818
@@ -5839,14 +5875,14 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/9.03374 “①
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/9.03374 ，
-....\rule(0.0+0.0)x-6.25134
-....\glue 6.25134 minus 6.0526
+....\penalty 10000
+....\glue 0.0 minus 6.0526
 ....\TU/FandolSong(0)/m/n/9.03374 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/9.03374 …
-....\rule(0.0+0.0)x-1.53574
-....\glue 1.53574 minus 1.53574
+....\penalty 10000
+....\glue 0.0 minus 1.53574
 ....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
@@ -7411,6 +7447,7 @@ Completed box being shipped out [3]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue 0.0 plus 1.0fil
@@ -7799,6 +7836,8 @@ C.}
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#52
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -8509,6 +8548,8 @@ C.}
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -8650,8 +8691,6 @@ Completed box being shipped out [5]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002
@@ -8664,6 +8703,8 @@ Completed box being shipped out [5]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -9605,6 +9646,8 @@ C.}
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -9776,7 +9819,7 @@ C.}
 ...\glue(\baselineskip) 13.81161
 ...\hbox(4.23984+0.0)x426.79135, glue set 380.65901fil
 ....\hbox(0.0+0.0)x24.09
-....\penalty 0
+....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue 0.0
@@ -10204,6 +10247,8 @@ C.}
 .....\kern -0.00017
 .....\kern 0.00017
 .....\glue 0.0 plus 1.0fil minus 1.0fil
+....\kern -0.00017
+....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil

--- a/testfiles/09-main-en.tlg
+++ b/testfiles/09-main-en.tlg
@@ -2617,9 +2617,9 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1.1
+....\hbox(0.0+0.0)x0.0
 ....\kern -0.0002
 ....\kern 0.0002
-....\hbox(0.0+0.0)x0.0
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 illustrates
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -2779,12 +2779,14 @@ Completed box being shipped out [1]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.14243+2.13194)x23.07822
 .....\TU/texgyretermes(0)/m/n/12.045 (1.1
+.....\hbox(0.0+0.0)x0.0
 .....\kern -0.0002
 .....\kern 0.0002
-.....\hbox(0.0+0.0)x0.0
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 is
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -3106,9 +3108,9 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 1.1
+....\hbox(0.0+0.0)x0.0
 ....\kern -0.0002
 ....\kern 0.0002
-....\hbox(0.0+0.0)x0.0
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 shows
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -4013,6 +4015,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#83
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#52
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4260,6 +4264,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#73
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4714,6 +4720,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#56
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4983,6 +4991,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#56
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -5449,6 +5459,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#52
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#57
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -5600,6 +5612,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#56
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -5863,6 +5877,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#51
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -6176,6 +6192,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#106
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#99
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -6378,9 +6396,9 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 A.1
+....\hbox(0.0+0.0)x0.0
 ....\kern -0.0002
 ....\kern 0.0002
-....\hbox(0.0+0.0)x0.0
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 illustrates
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -6539,12 +6557,14 @@ Completed box being shipped out [4]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.14243+2.13194)x25.75221
 .....\TU/texgyretermes(0)/m/n/12.045 (A.1
+.....\hbox(0.0+0.0)x0.0
 .....\kern -0.0002
 .....\kern 0.0002
-.....\hbox(0.0+0.0)x0.0
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 is
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -6907,9 +6927,9 @@ Completed box being shipped out [5]
 ....\penalty 10000
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 A.1
+....\hbox(0.0+0.0)x0.0
 ....\kern -0.0002
 ....\kern 0.0002
-....\hbox(0.0+0.0)x0.0
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 shows
 ....\glue 3.01125 plus 1.50562 minus 1.00374

--- a/testfiles/09-main.tlg
+++ b/testfiles/09-main.tlg
@@ -224,14 +224,14 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.1043
-...\hbox(9.45532+2.32468)x426.79135, glue set 0.21907
+...\hbox(9.45532+2.32468)x426.79135, glue set 0.21904
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 为
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -368,7 +368,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.33115
-...\hbox(9.45532+2.32468)x426.79135, glue set 0.29672
+...\hbox(9.45532+2.32468)x426.79135, glue set 0.2967
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 搜
@@ -394,7 +394,7 @@ Completed box being shipped out [1]
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 为
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -516,7 +516,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 系
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
-...\hbox(9.3951+2.32468)x426.79135, glue set 0.2068
+...\hbox(9.3951+2.32468)x426.79135, glue set 0.20679
 ....\TU/FandolSong(0)/m/n/12.045 统
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 参
@@ -582,7 +582,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 而
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 为
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
@@ -1230,7 +1230,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
-...\hbox(9.636+2.40898)x426.79135, glue set 0.21391
+...\hbox(9.636+2.40898)x426.79135, glue set 0.21388
 ....\TU/FandolSong(0)/m/n/12.045 带
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 宽
@@ -1293,7 +1293,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 化
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -1399,7 +1399,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 构
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 化
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
@@ -1445,7 +1445,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 般
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.17456
-...\hbox(9.49146+2.32468)x426.79135, glue set 0.21907
+...\hbox(9.49146+2.32468)x426.79135, glue set 0.21904
 ....\TU/FandolSong(0)/m/n/12.045 性
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 搜
@@ -1491,7 +1491,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 于
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 巨
@@ -1673,7 +1673,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 稍
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.24681
-...\hbox(9.50351+2.32468)x426.79135, glue set - 0.25717
+...\hbox(9.50351+2.32468)x426.79135, glue set - 0.25719
 ....\TU/FandolSong(0)/m/n/12.045 好
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 的
@@ -1699,7 +1699,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 认
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 为
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Gnutella
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 式
@@ -1741,7 +1741,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 结
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.34317
-...\hbox(9.40715+2.19217)x426.79135, glue set 0.2068
+...\hbox(9.40715+2.19217)x426.79135, glue set 0.20679
 ....\TU/FandolSong(0)/m/n/12.045 点
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 较
@@ -1805,7 +1805,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 此
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 类
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 搜
@@ -2175,14 +2175,14 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/9.03374 “①
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/9.03374 ，
-....\rule(0.0+0.0)x-6.25134
-....\glue 6.25134 minus 6.0526
+....\penalty 10000
+....\glue 0.0 minus 6.0526
 ....\TU/FandolSong(0)/m/n/9.03374 …
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/9.03374 …
-....\rule(0.0+0.0)x-1.53574
-....\glue 1.53574 minus 1.53574
+....\penalty 10000
+....\glue 0.0 minus 1.53574
 ....\TU/FandolSong(0)/m/n/9.03374 ，
 ....\rule(0.0+0.0)x-6.25134
 ....\glue 6.25134 minus 4.51686
@@ -2389,7 +2389,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/9.03374 文
 ....\glue 0.0 plus 0.36642
 ....\TU/FandolSong(0)/m/n/9.03374 用
-....\glue 2.25844 plus 1.12807 minus 0.75356
+....\glue 2.25844 plus 1.12921 minus 0.7528
 ....\TU/texgyretermes(0)/m/n/9.03374 Times
 ....\glue 2.25844 plus 1.12921 minus 0.7528
 ....\TU/texgyretermes(0)/m/n/9.03374 New
@@ -2939,7 +2939,7 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\penalty 150
 ...\glue(\baselineskip) 8.24681
-...\hbox(9.50351+2.32468)x426.79135, glue set 0.21907
+...\hbox(9.50351+2.32468)x426.79135, glue set 0.21904
 ....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 索
@@ -3007,7 +3007,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 由
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 于
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -3552,9 +3552,9 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 为
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.11432
-...\hbox(9.636+2.40898)x426.79135, glue set 0.20673
+...\hbox(9.636+2.40898)x426.79135, glue set 0.2067
 ....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 无
@@ -3791,7 +3791,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 规
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 模
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
@@ -5332,7 +5332,7 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.40341
-...\hbox(9.45532+2.32468)x426.79135, glue set - 0.58185
+...\hbox(9.45532+2.32468)x426.79135, glue set - 0.5819
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 本
 ....\glue 0.0 plus 0.52307
@@ -5341,7 +5341,7 @@ Completed box being shipped out [3]
 ....\TU/FandolSong(0)/m/n/12.045 针
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 对
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -5551,12 +5551,12 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.37833
-...\hbox(9.49146+2.32468)x426.79135, glue set 0.21907
+...\hbox(9.49146+2.32468)x426.79135, glue set 0.21904
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 如
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 果
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -6954,7 +6954,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 8.11432
-...\hbox(9.636+2.40898)x426.79135, glue set - 0.40732
+...\hbox(9.636+2.40898)x426.79135, glue set - 0.40733
 ....\TU/FandolSong(0)/m/n/12.045 显
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 著
@@ -6994,7 +6994,7 @@ Completed box being shipped out [3]
 ....\TU/FandolSong(0)/m/n/12.045 按
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 照
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -7587,7 +7587,7 @@ Completed box being shipped out [4]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.23378
-...\hbox(9.636+2.40898)x426.79135, glue set 0.22575
+...\hbox(9.636+2.40898)x426.79135, glue set 0.22574
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 我
 ....\glue 0.0 plus 0.52307
@@ -7596,7 +7596,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 设
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
@@ -7819,7 +7819,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 变
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 8.27092
-...\hbox(9.3951+2.32468)x426.79135, glue set 0.21907
+...\hbox(9.3951+2.32468)x426.79135, glue set 0.21904
 ....\TU/FandolSong(0)/m/n/12.045 化
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 总
@@ -7881,7 +7881,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 描
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 述
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
@@ -8003,7 +8003,7 @@ Completed box being shipped out [4]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.34921
-...\hbox(9.45532+2.32468)x426.79135, glue set 0.42592
+...\hbox(9.45532+2.32468)x426.79135, glue set 0.42587
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 综
 ....\glue 0.0 plus 0.52307
@@ -8070,7 +8070,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 设
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
@@ -8320,7 +8320,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 针
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 对
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
@@ -8397,7 +8397,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 多
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 宽
@@ -8697,9 +8697,9 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 3.1
+....\hbox(0.0+0.0)x0.0
 ....\kern -0.0002
 ....\kern 0.0002
-....\hbox(0.0+0.0)x0.0
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
@@ -11789,6 +11789,7 @@ Completed box being shipped out [5]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -12878,6 +12879,7 @@ Completed box being shipped out [6]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -12993,7 +12995,7 @@ Completed box being shipped out [6]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.34016
-...\hbox(9.50351+2.32468)x426.79135, glue set 0.16719
+...\hbox(9.50351+2.32468)x426.79135, glue set 0.16718
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 首
 ....\glue 0.0 plus 0.52307
@@ -13024,7 +13026,7 @@ Completed box being shipped out [6]
 ....\TU/FandolSong(0)/m/n/12.045 考
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 虑
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 系
@@ -13156,7 +13158,7 @@ Completed box being shipped out [6]
 ....\TU/FandolSong(0)/m/n/12.045 不
 ....\glue(\rightskip) 0.0
 ...\glue(\baselineskip) 7.53584
-...\hbox(9.52759+2.32468)x426.79135, glue set - 0.07417
+...\hbox(9.52759+2.32468)x426.79135, glue set - 0.07419
 ....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 结
@@ -13178,7 +13180,7 @@ Completed box being shipped out [6]
 ....\TU/FandolSong(0)/m/n/12.045 况
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 在
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 中
@@ -13196,7 +13198,7 @@ Completed box being shipped out [6]
 ....\TU/FandolSong(0)/m/n/12.045 譬
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 如
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 P2P
 ....\glue 3.01125 plus 1.5041 minus 1.00473
 ....\TU/FandolSong(0)/m/n/12.045 文
@@ -13969,6 +13971,7 @@ Completed box being shipped out [6]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayskip) 6.02249
 ...\glue 0.0 plus 1.0fil

--- a/testfiles/09-schwarzman.tlg
+++ b/testfiles/09-schwarzman.tlg
@@ -251,6 +251,7 @@ Completed box being shipped out [1]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -301,6 +302,7 @@ Completed box being shipped out [1]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -351,6 +353,7 @@ Completed box being shipped out [1]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\penalty 0
@@ -1186,6 +1189,7 @@ Completed box being shipped out [3]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -1236,6 +1240,7 @@ Completed box being shipped out [3]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -1286,6 +1291,7 @@ Completed box being shipped out [3]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\penalty 0
@@ -1934,7 +1940,7 @@ Completed box being shipped out [5]
 ..........\TU/FandolSong(0)/m/n/10.53937 附
 ..........\glue 0.0 plus 0.41463
 ..........\TU/FandolSong(0)/m/n/10.53937 录
-..........\glue 2.63484 plus 1.31609 minus 0.87915
+..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 A
 ..........\kern -0.0002
 ..........\kern 0.0002
@@ -1984,8 +1990,6 @@ Completed box being shipped out [5]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002
@@ -2126,6 +2130,7 @@ Completed box being shipped out [5]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -2176,6 +2181,7 @@ Completed box being shipped out [5]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
@@ -2226,6 +2232,7 @@ Completed box being shipped out [5]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\penalty 0
@@ -2597,7 +2604,7 @@ Completed box being shipped out [6]
 ..........\TU/FandolSong(0)/m/n/10.53937 附
 ..........\glue 0.0 plus 0.41463
 ..........\TU/FandolSong(0)/m/n/10.53937 录
-..........\glue 2.63484 plus 1.31609 minus 0.87915
+..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 A
 ..........\kern -0.0002
 ..........\kern 0.0002

--- a/testfiles/10-biblatex/10-biblatex-author-year.tlg
+++ b/testfiles/10-biblatex/10-biblatex-author-year.tlg
@@ -333,9 +333,9 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (see
+....\write1{\abx@aux@page{10}{\the \c@page }}
 ....\kern -0.0002
 ....\kern 0.0002
-....\write1{\abx@aux@page{10}{\the \c@page }}
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Baker
 ....\kern -0.0002
@@ -378,9 +378,9 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (see
+....\write1{\abx@aux@page{11}{\the \c@page }}
 ....\kern -0.0002
 ....\kern 0.0002
-....\write1{\abx@aux@page{11}{\the \c@page }}
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Baker
 ....\kern -0.0002
@@ -509,9 +509,8 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 用
-....\kern -0.00017
-....\kern 0.00017
 ....\write1{\abx@aux@page{16}{\the \c@page }}
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
@@ -561,9 +560,8 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 用
-....\kern -0.00017
-....\kern 0.00017
 ....\write1{\abx@aux@page{18}{\the \c@page }}
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
@@ -716,7 +714,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.03001
-...\hbox(9.636+2.40898)x426.79135, glue set 268.30934fil
+...\hbox(9.636+2.40898)x426.79135, glue set 271.32059fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
@@ -728,10 +726,8 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 见
-....\kern -0.00017
-....\kern 0.00017
 ....\write1{\abx@aux@page{21}{\the \c@page }}
-....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
@@ -767,7 +763,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.74121
-...\hbox(10.9248+2.40898)x426.79135, glue set 259.27559fil
+...\hbox(10.9248+2.40898)x426.79135, glue set 262.28683fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
@@ -779,10 +775,8 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue 0.0
 ....\TU/FandolSong(0)/m/n/12.045 见
-....\kern -0.00017
-....\kern 0.00017
 ....\write1{\abx@aux@page{22}{\the \c@page }}
-....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
@@ -826,9 +820,8 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 用
-....\kern -0.00017
-....\kern 0.00017
 ....\write1{\abx@aux@page{24}{\the \c@page }}
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
@@ -1828,8 +1821,6 @@ Completed box being shipped out [3]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002
@@ -1904,9 +1895,9 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/12.045 ,
 ....\glue 3.01125 plus 1.88202 minus 0.80298
 ....\TU/texgyretermes(0)/m/n/12.045 1995
+....\write1{\abx@aux@page{34}{\the \c@page }}
 ....\kern -0.0002
 ....\kern 0.0002
-....\write1{\abx@aux@page{34}{\the \c@page }}
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309

--- a/testfiles/10-biblatex/10-biblatex-bachelor.tlg
+++ b/testfiles/10-biblatex/10-biblatex-bachelor.tlg
@@ -770,7 +770,7 @@ C.}
 ...\glue 27.10124 plus -1.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\hbox(8.19963+1.90761)x398.33861, glue set 147.44241fil, shifted 28.45274
+...\hbox(8.19963+1.90761)x398.33861, glue set 146.6896fil, shifted 28.45274
 ....\hbox(7.12462+1.64412)x0.0
 .....\glue 0.0
 .....\glue -28.45274
@@ -811,9 +811,9 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\glue 2.63484 plus 1.32399 minus 0.8739
 ....\TU/FandolSong(0)/m/n/10.53937 第
-....\glue 2.63484 plus 1.31741 minus 0.87828
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/10.53937 1
-....\glue 2.63484 plus 1.31741 minus 0.87828
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/10.53937 卷
 ....\kern -0.00017
 ....\kern 0.00017
@@ -2054,7 +2054,7 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\penalty 200
 ...\glue(\baselineskip) 6.82753
-...\hbox(7.25108+2.28705)x398.33861, glue set 0.59467, shifted 28.45274
+...\hbox(7.25108+2.28705)x398.33861, glue set 0.59468, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 33
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2281,6 +2281,7 @@ C.}
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\glue 2.63484 plus 1.32532 minus 0.87303
 ....\TU/texgyretermes(0)/m/n/10.53937 DOI
@@ -2290,7 +2291,7 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\penalty 200
 ...\glue(\baselineskip) 6.52187
-...\hbox(7.25108+2.63512)x398.33861, glue set 232.42323fil, shifted 28.45274
+...\hbox(7.25108+2.63512)x398.33861, glue set 232.42343fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#83
 ....\glue 0.0
 ....\penalty 100
@@ -2410,6 +2411,7 @@ C.}
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2697,7 +2699,7 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\penalty 200
 ...\glue(\baselineskip) 6.52187
-...\hbox(7.25108+2.29758)x398.33861, glue set 100.91763fil, shifted 28.45274
+...\hbox(7.25108+2.29758)x398.33861, glue set 100.91803fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#103
 ....\penalty 200
 ....\glue(\medmuskip) 0.0 plus 1.75671
@@ -2821,6 +2823,7 @@ C.}
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\glue 2.63484 plus 1.32532 minus 0.87303
 ....\TU/texgyretermes(0)/m/n/10.53937 DOI
@@ -2889,6 +2892,7 @@ C.}
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3279,7 +3283,7 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\penalty 200
 ...\glue(\baselineskip) 6.6378
-...\hbox(7.12462+0.14755)x398.33861, glue set 385.1644fil, shifted 28.45274
+...\hbox(7.12462+0.14755)x398.33861, glue set 385.1646fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#122
 ....\glue 0.0
 ....\penalty 100
@@ -3287,6 +3291,7 @@ C.}
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -3805,7 +3810,7 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\penalty 200
 ...\glue(\baselineskip) 6.52187
-...\hbox(7.25108+2.63512)x398.33861, glue set 255.3476fil, shifted 28.45274
+...\hbox(7.25108+2.63512)x398.33861, glue set 255.3478fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#122
 ....\glue 0.0
 ....\penalty 100
@@ -3893,6 +3898,7 @@ C.}
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4167,7 +4173,7 @@ C.}
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.86969
-...\hbox(7.25108+2.28705)x398.33861, glue set 66.39069fil, shifted 28.45274
+...\hbox(7.25108+2.28705)x398.33861, glue set 66.39088fil, shifted 28.45274
 ....\hbox(6.97707+1.64412)x3.50961
 .....\TU/texgyretermes(0)/m/n/10.53937 [
 ....\TU/texgyretermes(0)/m/n/10.53937 2013
@@ -4377,6 +4383,7 @@ C.}
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5043,7 +5050,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 200
 ...\glue(\baselineskip) 6.5535
-...\hbox(7.20892+0.14755)x398.33861, glue set 352.88232fil, shifted 28.45274
+...\hbox(7.20892+0.14755)x398.33861, glue set 352.88252fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#44
 ....\glue 0.0
 ....\penalty 100
@@ -5070,6 +5077,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5440,7 +5448,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 200
 ...\glue(\baselineskip) 6.56403
-...\hbox(7.1984+2.29758)x398.33861, glue set 300.47006fil, shifted 28.45274
+...\hbox(7.1984+2.29758)x398.33861, glue set 300.47026fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#60
 ....\glue 0.0
 ....\penalty 100
@@ -5502,6 +5510,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5877,7 +5886,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.91183
-...\hbox(7.1984+2.63512)x398.33861, glue set 5.64297fil, shifted 28.45274
+...\hbox(7.1984+2.63512)x398.33861, glue set 5.64317fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#64
 ....\glue 0.0
 ....\penalty 100
@@ -6143,6 +6152,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6356,7 +6366,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.52187
-...\hbox(7.25108+0.23187)x398.33861, glue set 221.54073fil, shifted 28.45274
+...\hbox(7.25108+0.23187)x398.33861, glue set 221.54092fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\glue 0.0
 ....\penalty 100
@@ -6469,6 +6479,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6560,7 +6571,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 400
 ...\glue(\baselineskip) 6.56404
-...\hbox(7.1984+2.29758)x398.33861, glue set 163.85875fil, shifted 28.45274
+...\hbox(7.1984+2.29758)x398.33861, glue set 163.85895fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 03
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6723,6 +6734,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -6800,8 +6812,6 @@ Completed box being shipped out [4]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002
@@ -7060,7 +7070,7 @@ C.}
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.71283
-...\hbox(8.19963+1.90761)x398.33861, glue set 147.44241fil, shifted 28.45274
+...\hbox(8.19963+1.90761)x398.33861, glue set 146.6896fil, shifted 28.45274
 ....\hbox(7.12462+1.64412)x0.0
 .....\glue 0.0
 .....\glue -28.45274
@@ -7101,9 +7111,9 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 :
 ....\glue 2.63484 plus 1.32399 minus 0.8739
 ....\TU/FandolSong(0)/m/n/10.53937 第
-....\glue 2.63484 plus 1.31741 minus 0.87828
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/10.53937 1
-....\glue 2.63484 plus 1.31741 minus 0.87828
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/10.53937 卷
 ....\kern -0.00017
 ....\kern 0.00017

--- a/testfiles/10-biblatex/10-biblatex-inline.tlg
+++ b/testfiles/10-biblatex/10-biblatex-inline.tlg
@@ -3147,7 +3147,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.57455
-...\hbox(7.1984+0.14755)x398.33861, glue set 240.55374fil, shifted 28.45274
+...\hbox(7.1984+0.14755)x398.33861, glue set 240.55394fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#115
 ....\glue 0.0
 ....\penalty 100
@@ -3262,6 +3262,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -4761,7 +4762,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.82753
-...\hbox(7.25108+2.29758)x398.33861, glue set 83.60146fil, shifted 28.45274
+...\hbox(7.25108+2.29758)x398.33861, glue set 83.60165fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#64
 ....\glue 0.0
 ....\penalty 100
@@ -4958,6 +4959,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5171,7 +5173,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.57455
-...\hbox(7.1984+0.23187)x398.33861, glue set 232.62813fil, shifted 28.45274
+...\hbox(7.1984+0.23187)x398.33861, glue set 232.62833fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\glue 0.0
 ....\penalty 100
@@ -5273,6 +5275,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5364,7 +5367,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 400
 ...\glue(\baselineskip) 6.56404
-...\hbox(7.1984+2.29758)x398.33861, glue set 166.7887fil, shifted 28.45274
+...\hbox(7.1984+2.29758)x398.33861, glue set 166.7889fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 01
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5524,6 +5527,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5683,8 +5687,6 @@ Completed box being shipped out [4]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002

--- a/testfiles/10-biblatex/10-biblatex-numeric.tlg
+++ b/testfiles/10-biblatex/10-biblatex-numeric.tlg
@@ -3398,7 +3398,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.57455
-...\hbox(7.1984+0.14755)x398.33861, glue set 240.55374fil, shifted 28.45274
+...\hbox(7.1984+0.14755)x398.33861, glue set 240.55394fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#115
 ....\glue 0.0
 ....\penalty 100
@@ -3513,6 +3513,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5012,7 +5013,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.82753
-...\hbox(7.25108+2.29758)x398.33861, glue set 83.60146fil, shifted 28.45274
+...\hbox(7.25108+2.29758)x398.33861, glue set 83.60165fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#64
 ....\glue 0.0
 ....\penalty 100
@@ -5209,6 +5210,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5422,7 +5424,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 300
 ...\glue(\baselineskip) 6.57455
-...\hbox(7.1984+0.23187)x398.33861, glue set 232.62813fil, shifted 28.45274
+...\hbox(7.1984+0.23187)x398.33861, glue set 232.62833fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\glue 0.0
 ....\penalty 100
@@ -5524,6 +5526,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5615,7 +5618,7 @@ Completed box being shipped out [3]
 ....\glue(\rightskip) 0.0
 ...\penalty 400
 ...\glue(\baselineskip) 6.56404
-...\hbox(7.1984+2.29758)x398.33861, glue set 166.7887fil, shifted 28.45274
+...\hbox(7.1984+2.29758)x398.33861, glue set 166.7889fil, shifted 28.45274
 ....\TU/texgyretermes(0)/m/n/10.53937 01
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5775,6 +5778,7 @@ Completed box being shipped out [3]
 ....\glue 0.0
 ....\penalty 100
 ....\mathoff
+....\kern -0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -5934,8 +5938,6 @@ Completed box being shipped out [4]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002

--- a/testfiles/10-bibtex/10-bibtex-author-year.tlg
+++ b/testfiles/10-bibtex/10-bibtex-author-year.tlg
@@ -426,8 +426,6 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
-....\kern -0.00017
-....\kern 0.00017
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (1997
 ....\kern -0.0002
@@ -454,8 +452,6 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
-....\kern -0.00017
-....\kern 0.00017
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (1997
 ....\kern -0.0002
@@ -557,7 +553,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.69249
-...\hbox(9.23851+2.144)x426.79135, glue set 271.21817fil
+...\hbox(9.23851+2.144)x426.79135, glue set 274.22942fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
@@ -565,9 +561,7 @@ Completed box being shipped out [1]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (
 ....\TU/FandolSong(0)/m/n/12.045 见
-....\kern -0.00017
-....\kern 0.00017
-....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
@@ -593,7 +587,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.0062
-...\hbox(10.9248+2.144)x426.79135, glue set 264.69566fil
+...\hbox(10.9248+2.144)x426.79135, glue set 267.70691fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
@@ -601,9 +595,7 @@ Completed box being shipped out [1]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (
 ....\TU/FandolSong(0)/m/n/12.045 见
-....\kern -0.00017
-....\kern 0.00017
-....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
@@ -648,8 +640,6 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 汪
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 冰
-....\kern -0.00017
-....\kern 0.00017
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 (1997
 ....\kern -0.0002
@@ -904,6 +894,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 3
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Test
 ....\kern -0.0002
@@ -1692,8 +1684,6 @@ Completed box being shipped out [3]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002

--- a/testfiles/10-bibtex/10-bibtex-bachelor.tlg
+++ b/testfiles/10-bibtex/10-bibtex-bachelor.tlg
@@ -1817,6 +1817,8 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#67
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#73
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
@@ -1916,6 +1918,8 @@ C.}
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#108
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -2171,6 +2175,8 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#48
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#56
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\glue 1.15933 plus 3.478 minus 0.73782
@@ -2224,6 +2230,8 @@ C.}
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#52
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -2454,6 +2462,8 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#122
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#83
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -2930,6 +2940,8 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#43
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#77
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -3316,6 +3328,8 @@ C.}
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#73
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -3865,6 +3879,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#52
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4148,6 +4164,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#122
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#101
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4581,6 +4599,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4790,6 +4810,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#73
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4799,7 +4821,7 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.6192
-...\hbox(7.20892+2.29756)x398.33861, glue set 0.24536, shifted 28.45274
+...\hbox(7.20892+2.29756)x398.33861, glue set 0.19019, shifted 28.45274
 ....\hbox(7.20892+1.64412)x0.0
 .....\glue 0.0
 .....\glue -28.45274
@@ -4835,7 +4857,7 @@ Completed box being shipped out [3]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 :
-....\glue 2.63484 plus 1.31741 minus 0.87828
+....\glue 3.51312 plus 2.63483 minus 0.43913
 ....\TU/texgyretermes(0)/m/n/10.53937 History
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 of
@@ -4967,6 +4989,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#73
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -5040,8 +5064,6 @@ Completed box being shipped out [4]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002

--- a/testfiles/10-bibtex/10-bibtex-inline.tlg
+++ b/testfiles/10-bibtex/10-bibtex-inline.tlg
@@ -39,7 +39,7 @@ Completed box being shipped out [1]
 ...\write-{}
 ...\special{color push gray 0}
 ...\glue(\topskip) 2.58081
-...\hbox(9.41919+2.144)x426.79135, glue set 301.33064fil
+...\hbox(9.41919+2.144)x426.79135, glue set 298.3194fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
@@ -50,8 +50,6 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 昆
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 等
-....\kern -0.00017
-....\kern 0.00017
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(7.97379+1.879)x4.01099
 .....\TU/texgyretermes(0)/m/n/12.045 [
@@ -63,6 +61,7 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 ]
 .....\kern -0.0002
 .....\kern 0.0002
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 测
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 试
@@ -85,8 +84,6 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 昆
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 等
-....\kern -0.00017
-....\kern 0.00017
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(7.97379+1.879)x4.01099
 .....\TU/texgyretermes(0)/m/n/12.045 [
@@ -98,6 +95,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 ]
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\hbox(6.10681+0.0)x9.03375, shifted -4.818
 .....\special{color push gray 0}
 .....\TU/texgyretermes(0)/m/n/9.03375 42
@@ -129,6 +128,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 1
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 测
@@ -153,6 +154,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 1
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\kern -0.0002
 ....\kern 0.0002
@@ -184,13 +187,13 @@ Completed box being shipped out [1]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [
 ....\TU/FandolSong(0)/m/n/12.045 见
-....\kern -0.00017
-....\kern 0.00017
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.14243+0.0)x6.0225
 .....\TU/texgyretermes(0)/m/n/12.045 2
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 测
@@ -212,13 +215,13 @@ Completed box being shipped out [1]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [
 ....\TU/FandolSong(0)/m/n/12.045 见
-....\kern -0.00017
-....\kern 0.00017
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.14243+0.0)x6.0225
 .....\TU/texgyretermes(0)/m/n/12.045 2
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\kern -0.0002
 ....\kern 0.0002
@@ -247,8 +250,6 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Dupont
-....\kern -0.0002
-....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(7.97379+1.879)x4.01099
 .....\TU/texgyretermes(0)/m/n/12.045 [
@@ -260,6 +261,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 ]
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 test
 ....\kern -0.0002
@@ -275,8 +278,6 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Dupont
-....\kern -0.0002
-....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(7.97379+1.879)x4.01099
 .....\TU/texgyretermes(0)/m/n/12.045 [
@@ -288,6 +289,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 ]
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\hbox(6.10681+0.0)x9.03375, shifted -4.818
 .....\special{color push gray 0}
 .....\TU/texgyretermes(0)/m/n/9.03375 42
@@ -316,6 +319,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 3
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\kern -0.0002
 ....\kern 0.0002
@@ -338,6 +343,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 3
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\kern -0.0002
 ....\kern 0.0002
@@ -365,13 +372,13 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [see
-....\kern -0.0002
-....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.14243+0.0)x6.0225
 .....\TU/texgyretermes(0)/m/n/12.045 4
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\kern -0.0002
 ....\kern 0.0002
@@ -390,13 +397,13 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 [see
-....\kern -0.0002
-....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.14243+0.0)x6.0225
 .....\TU/texgyretermes(0)/m/n/12.045 4
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\kern -0.0002
 ....\kern 0.0002
@@ -430,6 +437,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 1
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 测
@@ -454,6 +463,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 2
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 -
 ....\discretionary
 ....\kern -0.00023
@@ -463,6 +474,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 3
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 测
@@ -487,6 +500,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 4
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 -
 ....\discretionary
 ....\kern -0.00023
@@ -496,6 +511,8 @@ Completed box being shipped out [1]
 .....\TU/texgyretermes(0)/m/n/12.045 6
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 测
@@ -1473,7 +1490,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/10.53937 利
 ....\glue 0.0 plus 0.41463
 ....\TU/FandolSong(0)/m/n/10.53937 用
-....\glue 2.63484 plus 1.31609 minus 0.87915
+....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 REMPI
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1485,7 +1502,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/10.53937 测
 ....\glue 0.0 plus 0.41463
 ....\TU/FandolSong(0)/m/n/10.53937 量
-....\glue 2.63484 plus 1.31609 minus 0.87915
+....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 BaF
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2568,6 +2585,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#106
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -3777,6 +3796,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -3976,6 +3997,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#106
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -3985,7 +4008,7 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.62973
-...\hbox(7.1984+2.29756)x398.33861, glue set 0.24536, shifted 28.45274
+...\hbox(7.1984+2.29756)x398.33861, glue set 0.19019, shifted 28.45274
 ....\hbox(7.12462+1.64412)x0.0
 .....\glue 0.0
 .....\glue -28.45274
@@ -4021,7 +4044,7 @@ Completed box being shipped out [3]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 :
-....\glue 2.63484 plus 1.31741 minus 0.87828
+....\glue 3.51312 plus 2.63483 minus 0.43913
 ....\TU/texgyretermes(0)/m/n/10.53937 History
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 of
@@ -4152,6 +4175,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4277,8 +4302,6 @@ Completed box being shipped out [4]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002
@@ -4338,6 +4361,8 @@ Completed box being shipped out [4]
 .....\TU/texgyretermes(0)/m/n/12.045 1
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 -
 ....\discretionary
 ....\kern -0.00023
@@ -4350,6 +4375,8 @@ Completed box being shipped out [4]
 .....\TU/texgyretermes(0)/m/n/12.045 2
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 ]
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/10-bibtex/10-bibtex-numeric.tlg
+++ b/testfiles/10-bibtex/10-bibtex-numeric.tlg
@@ -1609,7 +1609,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/10.53937 利
 ....\glue 0.0 plus 0.41463
 ....\TU/FandolSong(0)/m/n/10.53937 用
-....\glue 2.63484 plus 1.31609 minus 0.87915
+....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 REMPI
 ....\kern -0.0002
 ....\kern 0.0002
@@ -1621,7 +1621,7 @@ C.}
 ....\TU/FandolSong(0)/m/n/10.53937 测
 ....\glue 0.0 plus 0.41463
 ....\TU/FandolSong(0)/m/n/10.53937 量
-....\glue 2.63484 plus 1.31609 minus 0.87915
+....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 BaF
 ....\kern -0.0002
 ....\kern 0.0002
@@ -2704,6 +2704,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#106
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -3913,6 +3915,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4112,6 +4116,8 @@ Completed box being shipped out [3]
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#106
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4121,7 +4127,7 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.62973
-...\hbox(7.1984+2.29756)x398.33861, glue set 0.24536, shifted 28.45274
+...\hbox(7.1984+2.29756)x398.33861, glue set 0.19019, shifted 28.45274
 ....\hbox(7.12462+1.64412)x0.0
 .....\glue 0.0
 .....\glue -28.45274
@@ -4157,7 +4163,7 @@ Completed box being shipped out [3]
 ....\kern -0.0002
 ....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 :
-....\glue 2.63484 plus 1.31741 minus 0.87828
+....\glue 3.51312 plus 2.63483 minus 0.43913
 ....\TU/texgyretermes(0)/m/n/10.53937 History
 ....\glue 2.63484 plus 1.31741 minus 0.87828
 ....\TU/texgyretermes(0)/m/n/10.53937 of
@@ -4288,6 +4294,8 @@ Completed box being shipped out [3]
 ....\glue(\medmuskip) 0.0 plus 0.05855
 ....\TU/texgyretermes(0)/m/n/10.53937 glyph#76
 ....\mathoff
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/10.53937 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -4413,8 +4421,6 @@ Completed box being shipped out [4]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002

--- a/testfiles/11-appendix.tlg
+++ b/testfiles/11-appendix.tlg
@@ -143,7 +143,7 @@ Completed box being shipped out [115]
 ..........\TU/FandolSong(0)/m/n/10.53937 附
 ..........\glue 0.0 plus 0.41463
 ..........\TU/FandolSong(0)/m/n/10.53937 录
-..........\glue 2.63484 plus 1.31609 minus 0.87915
+..........\glue 2.63484 plus 1.31741 minus 0.87828
 ..........\TU/texgyretermes(0)/m/n/10.53937 A
 ..........\kern -0.0002
 ..........\kern 0.0002
@@ -212,8 +212,6 @@ Completed box being shipped out [115]
 ....\TU/FandolHei(0)/m/n/16.06 附
 ....\glue 0.0 plus 1.0538
 ....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 4.46468 plus 2.23233 minus 1.48822
 ....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002

--- a/testfiles/12-acknowledgements.tlg
+++ b/testfiles/12-acknowledgements.tlg
@@ -208,7 +208,7 @@ Completed box being shipped out [115]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.63226
-...\hbox(9.3951+2.32468)x426.79135, glue set - 0.09322
+...\hbox(9.3951+2.32468)x426.79135, glue set - 0.09323
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 在
 ....\glue 0.0 plus 0.52307
@@ -265,7 +265,7 @@ Completed box being shipped out [115]
 ....\TU/FandolSong(0)/m/n/12.045 承
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 蒙
-....\glue 3.01125 plus 1.5041 minus 1.00473
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Robert
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 Field

--- a/testfiles/13-1-statement.tex
+++ b/testfiles/13-1-statement.tex
@@ -9,6 +9,11 @@
 \setcounter{page}{116}
 \statement
 
+\makeatletter
+\TYPE{Font size after statement: \f@size}
+\TYPE{Baseline skip after statement: \the\baselineskip}
+\makeatother
+
 \clearpage
 \OMIT
 \end{document}

--- a/testfiles/13-1-statement.tlg
+++ b/testfiles/13-1-statement.tlg
@@ -21,6 +21,8 @@ LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
 (Font)              scaled to size 9.13309pt on input line ....
 LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
 (Font)              scaled to size 6.52367pt on input line ....
+Font size after statement: 12.045
+Baseline skip after statement: 20.075pt
 Completed box being shipped out [116]
 \vbox(710.18088+4.1104)x439.87962
 .\hbox(0.0+0.0)x0.0

--- a/testfiles/option-eqn-paren-style.tlg
+++ b/testfiles/option-eqn-paren-style.tlg
@@ -131,18 +131,16 @@ Completed box being shipped out [1]
 ......\kern -0.99623
 ......\kern 0.99623
 ......\glue 7.63654 minus 6.0225
+......\penalty 0
 .....\write1{\newlabel{eq:einstein}{{1.1}{\thepage }{}{equation.1.1}{}}}
 ...\penalty 0
 ...\glue(\belowdisplayshortskip) 6.02249
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.03001
-...\hbox(9.636+2.40898)x426.79135, glue set 314.09834fil
+...\hbox(9.636+2.40898)x426.79135, glue set 311.0871fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\kern 0.0
-....\kern -0.00017
-....\kern 0.00017
 ....\hbox(9.636+2.40898)x36.135
 .....\kern 0.0
 .....\glue 7.63654 minus 6.0225
@@ -158,6 +156,8 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\TU/FandolSong(0)/m/n/12.045 ）
 .....\rule(0.0+0.0)x-7.63654
@@ -166,6 +166,8 @@ Completed box being shipped out [1]
 .....\kern -0.99623
 .....\kern 0.99623
 .....\glue 7.63654 minus 6.0225
+.....\penalty 0
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 空
@@ -184,7 +186,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.03001
-...\hbox(9.636+2.40898)x426.79135, glue set 253.87335fil
+...\hbox(9.636+2.40898)x426.79135, glue set 250.8621fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
@@ -205,6 +207,8 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\TU/FandolSong(0)/m/n/12.045 ）
 .....\rule(0.0+0.0)x-7.63654
@@ -213,6 +217,10 @@ Completed box being shipped out [1]
 .....\kern -0.99623
 .....\kern 0.99623
 .....\glue 7.63654 minus 6.0225
+.....\penalty 0
+....\kern -0.0002
+....\kern 0.0002
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 用
@@ -241,12 +249,9 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.03001
-...\hbox(9.636+2.40898)x426.79135, glue set 277.96335fil
+...\hbox(9.636+2.40898)x426.79135, glue set 274.9521fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\kern 0.0
-....\kern -0.00018
-....\kern 0.00018
 ....\hbox(9.636+2.40898)x36.135
 .....\kern 0.0
 .....\glue 7.63654 minus 6.0225
@@ -262,6 +267,8 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\TU/FandolSong(0)/m/n/12.045 ）
 .....\rule(0.0+0.0)x-7.63654
@@ -270,6 +277,10 @@ Completed box being shipped out [1]
 .....\kern -0.99623
 .....\kern 0.99623
 .....\glue 7.63654 minus 6.0225
+.....\penalty 0
+....\kern -0.0002
+....\kern 0.0002
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 用
@@ -294,21 +305,23 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.31909
-...\hbox(9.34692+2.13194)x426.79135, glue set 330.16637fil
+...\hbox(9.34692+2.13194)x426.79135, glue set 324.14388fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern 0.0
-....\kern -0.00017
-....\kern 0.00017
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.29901+2.13194)x20.06697
 .....\TU/texgyretermes(0)/m/n/12.045 (
 .....\hbox(8.29901+0.15657)x12.045
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 空
@@ -340,9 +353,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
@@ -375,8 +392,7 @@ Completed box being shipped out [1]
 ...\hbox(9.50351+2.28853)x426.79135, glue set 288.00888fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\hbox(8.29901+2.13194)x20.06697
 .....\TU/texgyretermes(0)/m/n/12.045 (
@@ -384,9 +400,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
@@ -437,9 +457,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -472,9 +496,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -497,18 +525,19 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 in
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 equation
-....\kern 0.0
-....\kern -0.0002
-....\kern 0.0002
 ....\hbox(8.29901+2.13194)x20.06697
 .....\TU/texgyretermes(0)/m/n/12.045 (
 .....\hbox(8.29901+0.15657)x12.045
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/package-amsthm.tlg
+++ b/testfiles/package-amsthm.tlg
@@ -84,8 +84,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 理
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -99,6 +98,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -516,8 +516,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 假
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 设
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -531,6 +530,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -731,8 +731,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 公
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 理
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -746,6 +745,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -946,8 +946,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 猜
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 想
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -961,6 +960,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -1161,8 +1161,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 推
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 论
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -1176,6 +1175,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -1376,8 +1376,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 定
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 义
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -1391,6 +1390,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -1589,8 +1589,7 @@ Completed box being shipped out [1]
 ...\hbox(9.45532+2.32468)x426.79135, glue set 0.20212
 ....\special{color push gray 0}
 ....\TU/FandolHei(0)/m/n/12.045 例
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -1604,6 +1603,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -1804,8 +1804,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 练
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 习
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -1819,6 +1818,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -2019,8 +2019,7 @@ Completed box being shipped out [1]
 ....\TU/FandolHei(0)/m/n/12.045 引
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 理
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -2034,6 +2033,7 @@ Completed box being shipped out [1]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -2272,8 +2272,7 @@ Completed box being shipped out [2]
 ....\TU/FandolHei(0)/m/n/12.045 问
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 题
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -2287,6 +2286,7 @@ Completed box being shipped out [2]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -2487,8 +2487,7 @@ Completed box being shipped out [2]
 ....\TU/FandolHei(0)/m/n/12.045 命
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 题
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -2502,6 +2501,7 @@ Completed box being shipped out [2]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳
@@ -2702,8 +2702,7 @@ Completed box being shipped out [2]
 ....\TU/FandolHei(0)/m/n/12.045 注
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolHei(0)/m/n/12.045 释
-....\kern -0.00018
-....\kern 0.00018
+....\kern 0.0
 ....\glue 3.34851 plus 1.67426 minus 1.11617
 ....\TU/texgyreheros(0)/m/n/12.045 1.1
 ....\kern 0.0
@@ -2717,6 +2716,7 @@ Completed box being shipped out [2]
 ....\kern -0.99649
 ....\kern 0.99649
 ....\glue 8.52786 minus 6.0225
+....\penalty 0
 ....\glue 6.02249
 ....\special{color pop}
 ....\TU/FandolSong(0)/m/n/12.045 劳

--- a/testfiles/package-hyperref.tlg
+++ b/testfiles/package-hyperref.tlg
@@ -859,6 +859,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{pdf:eann}
+.....\kern -0.00017
+.....\kern 0.00017
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -880,6 +882,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -898,6 +902,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -919,6 +925,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -941,6 +949,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -962,6 +972,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -988,6 +1000,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1009,6 +1023,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1035,6 +1051,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1056,6 +1074,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1088,6 +1108,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{pdf:eann}
+.....\kern -0.00017
+.....\kern 0.00017
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1109,6 +1131,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1135,6 +1159,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1156,6 +1182,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1182,6 +1210,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1203,6 +1233,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1229,6 +1261,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1250,6 +1284,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1276,6 +1312,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1297,6 +1335,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1315,6 +1355,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1336,6 +1378,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1366,6 +1410,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1387,6 +1433,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1405,6 +1453,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1426,6 +1476,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1448,6 +1500,8 @@ Completed box being shipped out [3]
 .....\kern -0.00017
 .....\kern 0.00017
 .....\special{pdf:eann}
+.....\kern -0.00017
+.....\kern 0.00017
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1469,6 +1523,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1487,6 +1543,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1508,6 +1566,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1532,6 +1592,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1553,6 +1615,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1579,6 +1643,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1600,6 +1666,8 @@ Completed box being shipped out [3]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1812,6 +1880,8 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1833,6 +1903,8 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -1868,6 +1940,8 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\rule(14.05243+6.02255)x0.0
 .....\kern 0.0
 .....\penalty 10000
@@ -1889,6 +1963,8 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
@@ -2419,14 +2495,14 @@ Completed box being shipped out [1]
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 8.18861
-....\hbox(9.45532+2.32468)x426.79135, glue set 0.39096
+....\hbox(9.45532+2.32468)x426.79135, glue set 0.39093
 .....\hbox(0.0+0.0)x21.05519
 .....\TU/FandolSong(0)/m/n/12.045 本
 .....\glue 0.0 plus 0.52307
 .....\TU/FandolSong(0)/m/n/12.045 章
 .....\glue 0.0 plus 0.52307
 .....\TU/FandolSong(0)/m/n/12.045 为
-.....\glue 3.01125 plus 1.5041 minus 1.00473
+.....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 P2P
 .....\glue 3.01125 plus 1.5041 minus 1.00473
 .....\TU/FandolSong(0)/m/n/12.045 中
@@ -2563,7 +2639,7 @@ Completed box being shipped out [1]
 .....\TU/FandolSong(0)/m/n/12.045 的
 .....\glue(\rightskip) 0.0
 ....\glue(\baselineskip) 8.33115
-....\hbox(9.45532+2.32468)x426.79135, glue set 0.29672
+....\hbox(9.45532+2.32468)x426.79135, glue set 0.2967
 .....\TU/texgyretermes(0)/m/n/12.045 P2P
 .....\glue 3.01125 plus 1.5041 minus 1.00473
 .....\TU/FandolSong(0)/m/n/12.045 搜
@@ -2589,7 +2665,7 @@ Completed box being shipped out [1]
 .....\glue 8.33514 minus 6.0225
 .....\glue 0.0 plus 0.52307
 .....\TU/FandolSong(0)/m/n/12.045 为
-.....\glue 3.01125 plus 1.5041 minus 1.00473
+.....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 P2P
 .....\glue 3.01125 plus 1.5041 minus 1.00473
 .....\TU/FandolSong(0)/m/n/12.045 中
@@ -2711,7 +2787,7 @@ Completed box being shipped out [1]
 .....\TU/FandolSong(0)/m/n/12.045 系
 .....\glue(\rightskip) 0.0
 ....\glue(\baselineskip) 8.27092
-....\hbox(9.3951+2.32468)x426.79135, glue set 0.2068
+....\hbox(9.3951+2.32468)x426.79135, glue set 0.20679
 .....\TU/FandolSong(0)/m/n/12.045 统
 .....\glue 0.0 plus 0.52307
 .....\TU/FandolSong(0)/m/n/12.045 参
@@ -2777,7 +2853,7 @@ Completed box being shipped out [1]
 .....\TU/FandolSong(0)/m/n/12.045 而
 .....\glue 0.0 plus 0.52307
 .....\TU/FandolSong(0)/m/n/12.045 为
-.....\glue 3.01125 plus 1.5041 minus 1.00473
+.....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 P2P
 .....\glue 3.01125 plus 1.5041 minus 1.00473
 .....\TU/FandolSong(0)/m/n/12.045 系
@@ -3006,6 +3082,8 @@ Completed box being shipped out [1]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 illustrates
 .....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -3145,9 +3223,13 @@ Completed box being shipped out [1]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\special{pdf:eann}
+......\kern -0.0002
+......\kern 0.0002
 ......\TU/texgyretermes(0)/m/n/12.045 )
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 is
 .....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -3520,7 +3602,7 @@ Completed box being shipped out [1]
 .....\TU/FandolSong(0)/m/n/9.03374 文
 .....\glue 0.0 plus 0.36642
 .....\TU/FandolSong(0)/m/n/9.03374 用
-.....\glue 2.25844 plus 1.12807 minus 0.75356
+.....\glue 2.25844 plus 1.12921 minus 0.7528
 .....\TU/texgyretermes(0)/m/n/9.03374 Times
 .....\glue 2.25844 plus 1.12921 minus 0.7528
 .....\TU/texgyretermes(0)/m/n/9.03374 New
@@ -3719,6 +3801,8 @@ Completed box being shipped out [2]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 shows
 .....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -4593,8 +4677,8 @@ Completed box being shipped out [4]
 ...\vbox(674.33032+0.0)x426.79135, glue set 7.58475fil
 ....\write-{}
 ....\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-....\special{pdf:dest (chapter.A) [@thispage /XYZ @xpos @ypos null]}
-....\write4{\protect \BOOKMARK [0][]{chapter.A}{\376\377\000A\000p\000p\000e\000n\ETC.}
+....\special{pdf:dest (appendix.A) [@thispage /XYZ @xpos @ypos null]}
+....\write4{\protect \BOOKMARK [0][]{appendix.A}{\376\377\000A\000p\000p\000e\000\ETC.}
 ....\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
 ....\marks1{\__mark_value:nn {22}{Appendix A Title}}
 ....\marks2{\__mark_value:nn {23}{}}
@@ -4621,7 +4705,7 @@ Completed box being shipped out [4]
 .....\glue(\rightskip) 0.0 plus 1.0fil
 ....\penalty 10000
 ....\glue 27.10124 plus -1.0
-....\special{pdf:dest (section.A.1) [@thispage /XYZ @xpos @ypos null]}
+....\special{pdf:dest (appendix.A.1) [@thispage /XYZ @xpos @ypos null]}
 ....\penalty 10000
 ....\glue -27.10124 plus 1.0
 ....\glue 27.10124 plus -1.0
@@ -4639,7 +4723,7 @@ Completed box being shipped out [4]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\write4{\protect \BOOKMARK [1][-]{section.A.1}{\376\377\000A\000.\0001\000\04\ETC.}
+....\write4{\protect \BOOKMARK [1][-]{appendix.A.1}{\376\377\000A\000.\0001\000\0\ETC.}
 ....\penalty 10000
 ....\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
 ....\penalty 10000
@@ -4666,6 +4750,8 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 illustrates
 .....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -4804,9 +4890,13 @@ Completed box being shipped out [4]
 ......\kern -0.0002
 ......\kern 0.0002
 ......\special{pdf:eann}
+......\kern -0.0002
+......\kern 0.0002
 ......\TU/texgyretermes(0)/m/n/12.045 )
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 is
 .....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -5034,6 +5124,8 @@ Completed box being shipped out [4]
 .....\kern -0.0002
 .....\kern 0.0002
 .....\special{pdf:eann}
+.....\kern -0.0002
+.....\kern 0.0002
 .....\glue 3.01125 plus 1.50562 minus 1.00374
 .....\TU/texgyretermes(0)/m/n/12.045 shows
 .....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -5045,7 +5137,7 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\penalty -300
 ....\glue 24.09
-....\special{pdf:dest (section.A.2) [@thispage /XYZ @xpos @ypos null]}
+....\special{pdf:dest (appendix.A.2) [@thispage /XYZ @xpos @ypos null]}
 ....\penalty 10000
 ....\glue -24.09
 ....\glue 24.09
@@ -5064,7 +5156,7 @@ Completed box being shipped out [4]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\write4{\protect \BOOKMARK [1][-]{section.A.2}{\376\377\000A\000.\0002\000\04\ETC.}
+....\write4{\protect \BOOKMARK [1][-]{appendix.A.2}{\376\377\000A\000.\0002\000\0\ETC.}
 ....\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
 ....\penalty 10000
 ....\glue 6.02249

--- a/testfiles/package-mathtools.tlg
+++ b/testfiles/package-mathtools.tlg
@@ -116,11 +116,9 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 10.3065
-...\hbox(9.636+2.40898)x426.79135, glue set 314.09834fil
+...\hbox(9.636+2.40898)x426.79135, glue set 311.0871fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\kern -0.00017
-....\kern 0.00017
 ....\write1{\MT@newlabel{eq:einstein}}
 ....\hbox(9.636+2.40898)x36.135
 .....\kern 0.0
@@ -137,6 +135,8 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\TU/FandolSong(0)/m/n/12.045 ）
 .....\rule(0.0+0.0)x-7.63654
@@ -145,6 +145,8 @@ Completed box being shipped out [1]
 .....\kern -0.99623
 .....\kern 0.99623
 .....\glue 7.63654 minus 6.0225
+.....\penalty 0
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 空
@@ -163,7 +165,7 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.03001
-...\hbox(9.636+2.40898)x426.79135, glue set 253.87335fil
+...\hbox(9.636+2.40898)x426.79135, glue set 250.8621fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
@@ -185,6 +187,8 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\TU/FandolSong(0)/m/n/12.045 ）
 .....\rule(0.0+0.0)x-7.63654
@@ -193,6 +197,10 @@ Completed box being shipped out [1]
 .....\kern -0.99623
 .....\kern 0.99623
 .....\glue 7.63654 minus 6.0225
+.....\penalty 0
+....\kern -0.0002
+....\kern 0.0002
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 用
@@ -221,11 +229,9 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.03001
-...\hbox(9.636+2.40898)x426.79135, glue set 277.96335fil
+...\hbox(9.636+2.40898)x426.79135, glue set 274.9521fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\kern -0.00018
-....\kern 0.00018
 ....\write1{\MT@newlabel{eq:einstein}}
 ....\hbox(9.636+2.40898)x36.135
 .....\kern 0.0
@@ -242,6 +248,8 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\penalty 10000
 .....\TU/FandolSong(0)/m/n/12.045 ）
 .....\rule(0.0+0.0)x-7.63654
@@ -250,6 +258,10 @@ Completed box being shipped out [1]
 .....\kern -0.99623
 .....\kern 0.99623
 .....\glue 7.63654 minus 6.0225
+.....\penalty 0
+....\kern -0.0002
+....\kern 0.0002
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 用
@@ -274,11 +286,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 8.31909
-...\hbox(9.34692+2.13194)x426.79135, glue set 330.16637fil
+...\hbox(9.34692+2.13194)x426.79135, glue set 324.14388fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\kern -0.00017
-....\kern 0.00017
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\write1{\MT@newlabel{eq:einstein}}
 ....\hbox(8.29901+2.13194)x20.06697
 .....\TU/texgyretermes(0)/m/n/12.045 (
@@ -286,9 +297,12 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 无
 ....\glue 0.0 plus 0.52307
 ....\TU/FandolSong(0)/m/n/12.045 空
@@ -321,9 +335,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
@@ -356,8 +374,6 @@ Completed box being shipped out [1]
 ...\hbox(9.50351+2.28853)x426.79135, glue set 288.00888fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 式
-....\kern -0.00018
-....\kern 0.00018
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\write1{\MT@newlabel{eq:einstein}}
 ....\hbox(8.29901+2.13194)x20.06697
@@ -366,9 +382,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/FandolSong(0)/m/n/12.045 使
 ....\glue 0.0 plus 0.52307
@@ -420,9 +440,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -455,9 +479,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.0002
 ....\kern 0.0002
@@ -480,8 +508,6 @@ Completed box being shipped out [1]
 ....\TU/texgyretermes(0)/m/n/12.045 in
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 equation
-....\kern -0.0002
-....\kern 0.0002
 ....\write1{\MT@newlabel{eq:einstein}}
 ....\hbox(8.29901+2.13194)x20.06697
 .....\TU/texgyretermes(0)/m/n/12.045 (
@@ -489,9 +515,13 @@ Completed box being shipped out [1]
 ......\TU/texgyretermes(0)/b/n/12.045 ??
 ......\kern -0.0002
 ......\kern 0.0002
+.....\kern -0.0002
+.....\kern 0.0002
 .....\TU/texgyretermes(0)/m/n/12.045 )
 .....\kern -0.0002
 .....\kern 0.0002
+....\kern -0.0002
+....\kern 0.0002
 ....\TU/texgyretermes(0)/m/n/12.045 .
 ....\kern -0.0002
 ....\kern 0.0002

--- a/testfiles/package-ntheorem.tlg
+++ b/testfiles/package-ntheorem.tlg
@@ -109,6 +109,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -549,6 +550,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -774,6 +776,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -999,6 +1002,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -1224,6 +1228,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -1449,6 +1454,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -1672,6 +1678,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -1897,6 +1904,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -2122,6 +2130,7 @@ Completed box being shipped out [1]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -2388,6 +2397,7 @@ Completed box being shipped out [2]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -2613,6 +2623,7 @@ Completed box being shipped out [2]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0
@@ -2838,6 +2849,7 @@ Completed box being shipped out [2]
 ......\kern -0.99649
 ......\kern 0.99649
 ......\glue 8.52786 minus 6.0225
+......\penalty 0
 ......\special{color pop}
 .....\glue 6.0
 ....\penalty 0

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -5443,8 +5443,8 @@
     \thispagestyle{\thu@statement@page@style}%
     \ifthu@degree@graduate
       \vspace{13bp}%
-      \fontsize{12bp}{21bp}\selectfont
       \begingroup
+        \fontsize{12bp}{21bp}\selectfont
         \renewcommand\CJKglue{\hspace{.15bp plus .1bp}}%
         \thu@statement@text@graduate\par
       \endgroup


### PR DESCRIPTION
Commit 98f70dc split the bachelor and graduate statement paths and
accidentally moved the 12bp/21bp font selection out of the group that
had scoped the statement body. Since a macro invocation does not form
a TeX group, the setting leaked beyond \statement and changed the
leading of subsequent content.

Move the font selection into the group containing the graduate
statement text and CJK glue. This restores the pre-98f70dc scope while
preserving the statement format established in 0577583.